### PR TITLE
Various optimizations

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -424,7 +424,7 @@ func TestDB_All(t *testing.T) {
 
 	select {
 	case <-watch:
-		t.Fatalf("expected All() watch channel to not close before changes")
+		t.Fatalf("expected All() watch channel to not close before delete")
 	default:
 	}
 
@@ -434,10 +434,15 @@ func TestDB_All(t *testing.T) {
 		txn.Commit()
 	}
 
+	// Prior read transaction not affected by delete.
+	iter, _ = table.All(txn)
+	objs = Collect(iter)
+	require.Len(t, objs, 3)
+
 	select {
 	case <-watch:
 	case <-time.After(time.Second):
-		t.Fatalf("expceted All() watch channel to close after changes")
+		t.Fatalf("expected All() watch channel to close after delete")
 	}
 }
 

--- a/deletetracker.go
+++ b/deletetracker.go
@@ -36,7 +36,7 @@ func (dt *DeleteTracker[Obj]) getRevision() uint64 {
 // 'minRevision'. The deleted objects are not garbage-collected unless 'Mark' is
 // called!
 func (dt *DeleteTracker[Obj]) Deleted(txn ReadTxn, minRevision Revision) Iterator[Obj] {
-	indexTxn := txn.getTxn().mustIndexReadTxn(dt.table, GraveyardRevisionIndex)
+	indexTxn := txn.getTxn().mustIndexReadTxn(dt.table, GraveyardRevisionIndexPos)
 	iter := indexTxn.Root().Iterator()
 	iter.SeekLowerBound(index.Uint64(minRevision))
 	return &iterator[Obj]{iter}

--- a/deletetracker.go
+++ b/deletetracker.go
@@ -36,7 +36,7 @@ func (dt *DeleteTracker[Obj]) getRevision() uint64 {
 // 'minRevision'. The deleted objects are not garbage-collected unless 'Mark' is
 // called!
 func (dt *DeleteTracker[Obj]) Deleted(txn ReadTxn, minRevision Revision) Iterator[Obj] {
-	indexTxn := txn.getTxn().mustIndexReadTxn(dt.table.Name(), GraveyardRevisionIndex)
+	indexTxn := txn.getTxn().mustIndexReadTxn(dt.table, GraveyardRevisionIndex)
 	iter := indexTxn.Root().Iterator()
 	iter.SeekLowerBound(index.Uint64(minRevision))
 	return &iterator[Obj]{iter}
@@ -57,7 +57,7 @@ func (dt *DeleteTracker[Obj]) Close() {
 	// Remove the delete tracker from the table.
 	txn := dt.db.WriteTxn(dt.table).getTxn()
 	db := txn.db
-	table := txn.modifiedTables[dt.table.Name()]
+	table := txn.modifiedTables[dt.table.tablePos()]
 	if table == nil {
 		panic("BUG: Table missing from write transaction")
 	}

--- a/metrics.go
+++ b/metrics.go
@@ -10,7 +10,7 @@ import (
 type Metrics interface {
 	WriteTxnTableAcquisition(tableName string, acquire time.Duration)
 	WriteTxnTotalAcquisition(goPackage string, tables []string, acquire time.Duration)
-	WriteTxnDuration(goPackage string, s []string, acquire time.Duration)
+	WriteTxnDuration(goPackage string, acquire time.Duration)
 
 	GraveyardLowWatermark(tableName string, lowWatermark Revision)
 	GraveyardCleaningDuration(tableName string, duration time.Duration)
@@ -121,7 +121,7 @@ func (m *ExpVarMetrics) ObjectCount(name string, numObjects int) {
 	m.ObjectCountVar.Set(name, &intVar)
 }
 
-func (m *ExpVarMetrics) WriteTxnDuration(goPackage string, s []string, acquire time.Duration) {
+func (m *ExpVarMetrics) WriteTxnDuration(goPackage string, acquire time.Duration) {
 	m.WriteTxnDurationVar.AddFloat(goPackage, acquire.Seconds())
 }
 
@@ -162,7 +162,7 @@ func (*NopMetrics) Revision(tableName string, revision uint64) {
 }
 
 // WriteTxnDuration implements Metrics.
-func (*NopMetrics) WriteTxnDuration(goPackage string, s []string, acquire time.Duration) {
+func (*NopMetrics) WriteTxnDuration(goPackage string, acquire time.Duration) {
 }
 
 // WriteTxnTableAcquisition implements Metrics.

--- a/metrics.go
+++ b/metrics.go
@@ -8,9 +8,9 @@ import (
 )
 
 type Metrics interface {
-	WriteTxnTableAcquisition(tableName string, acquire time.Duration)
-	WriteTxnTotalAcquisition(goPackage string, tables []string, acquire time.Duration)
-	WriteTxnDuration(goPackage string, acquire time.Duration)
+	WriteTxnTableAcquisition(handle string, tableName string, acquire time.Duration)
+	WriteTxnTotalAcquisition(handle string, tables []string, acquire time.Duration)
+	WriteTxnDuration(handle string, tables []string, acquire time.Duration)
 
 	GraveyardLowWatermark(tableName string, lowWatermark Revision)
 	GraveyardCleaningDuration(tableName string, duration time.Duration)
@@ -121,16 +121,16 @@ func (m *ExpVarMetrics) ObjectCount(name string, numObjects int) {
 	m.ObjectCountVar.Set(name, &intVar)
 }
 
-func (m *ExpVarMetrics) WriteTxnDuration(goPackage string, acquire time.Duration) {
-	m.WriteTxnDurationVar.AddFloat(goPackage, acquire.Seconds())
+func (m *ExpVarMetrics) WriteTxnDuration(handle string, tables []string, acquire time.Duration) {
+	m.WriteTxnDurationVar.AddFloat(handle+"/"+strings.Join(tables, "+"), acquire.Seconds())
 }
 
-func (m *ExpVarMetrics) WriteTxnTotalAcquisition(goPackage string, tables []string, acquire time.Duration) {
-	m.WriteTxnAcquisitionVar.AddFloat(goPackage, acquire.Seconds())
+func (m *ExpVarMetrics) WriteTxnTotalAcquisition(handle string, tables []string, acquire time.Duration) {
+	m.WriteTxnAcquisitionVar.AddFloat(handle+"/"+strings.Join(tables, "+"), acquire.Seconds())
 }
 
-func (m *ExpVarMetrics) WriteTxnTableAcquisition(name string, acquire time.Duration) {
-	m.LockContentionVar.AddFloat(name, acquire.Seconds())
+func (m *ExpVarMetrics) WriteTxnTableAcquisition(handle string, tableName string, acquire time.Duration) {
+	m.LockContentionVar.AddFloat(handle+"/"+tableName, acquire.Seconds())
 }
 
 var _ Metrics = &ExpVarMetrics{}
@@ -162,15 +162,15 @@ func (*NopMetrics) Revision(tableName string, revision uint64) {
 }
 
 // WriteTxnDuration implements Metrics.
-func (*NopMetrics) WriteTxnDuration(goPackage string, acquire time.Duration) {
+func (*NopMetrics) WriteTxnDuration(handle string, tables []string, acquire time.Duration) {
 }
 
 // WriteTxnTableAcquisition implements Metrics.
-func (*NopMetrics) WriteTxnTableAcquisition(tableName string, acquire time.Duration) {
+func (*NopMetrics) WriteTxnTableAcquisition(handle string, tableName string, acquire time.Duration) {
 }
 
 // WriteTxnTotalAcquisition implements Metrics.
-func (*NopMetrics) WriteTxnTotalAcquisition(goPackage string, tables []string, acquire time.Duration) {
+func (*NopMetrics) WriteTxnTotalAcquisition(handle string, tables []string, acquire time.Duration) {
 }
 
 var _ Metrics = &NopMetrics{}

--- a/metrics.go
+++ b/metrics.go
@@ -134,3 +134,43 @@ func (m *ExpVarMetrics) WriteTxnTableAcquisition(name string, acquire time.Durat
 }
 
 var _ Metrics = &ExpVarMetrics{}
+
+type NopMetrics struct{}
+
+// DeleteTrackerCount implements Metrics.
+func (*NopMetrics) DeleteTrackerCount(tableName string, numTrackers int) {
+}
+
+// GraveyardCleaningDuration implements Metrics.
+func (*NopMetrics) GraveyardCleaningDuration(tableName string, duration time.Duration) {
+}
+
+// GraveyardLowWatermark implements Metrics.
+func (*NopMetrics) GraveyardLowWatermark(tableName string, lowWatermark uint64) {
+}
+
+// GraveyardObjectCount implements Metrics.
+func (*NopMetrics) GraveyardObjectCount(tableName string, numDeletedObjects int) {
+}
+
+// ObjectCount implements Metrics.
+func (*NopMetrics) ObjectCount(tableName string, numObjects int) {
+}
+
+// Revision implements Metrics.
+func (*NopMetrics) Revision(tableName string, revision uint64) {
+}
+
+// WriteTxnDuration implements Metrics.
+func (*NopMetrics) WriteTxnDuration(goPackage string, s []string, acquire time.Duration) {
+}
+
+// WriteTxnTableAcquisition implements Metrics.
+func (*NopMetrics) WriteTxnTableAcquisition(tableName string, acquire time.Duration) {
+}
+
+// WriteTxnTotalAcquisition implements Metrics.
+func (*NopMetrics) WriteTxnTotalAcquisition(goPackage string, tables []string, acquire time.Duration) {
+}
+
+var _ Metrics = &NopMetrics{}

--- a/table.go
+++ b/table.go
@@ -59,10 +59,11 @@ func NewTable[Obj any](
 
 	indexPos := SecondaryIndexStartPos
 	for _, indexer := range secondaryIndexers {
+		name := indexer.indexName()
 		anyIndexer := toAnyIndexer(indexer)
 		anyIndexer.pos = indexPos
-		table.secondaryAnyIndexers[indexer.indexName()] = anyIndexer
-		table.indexPositions[indexer.indexName()] = indexPos
+		table.secondaryAnyIndexers[name] = anyIndexer
+		table.indexPositions[name] = indexPos
 		indexPos++
 	}
 

--- a/types.go
+++ b/types.go
@@ -149,7 +149,9 @@ type RWTable[Obj any] interface {
 // TableMeta provides information about the table that is independent of
 // the object type (the 'Obj' constraint).
 type TableMeta interface {
-	Name() TableName                       // The name of the table
+	Name() TableName // The name of the table
+	tablePos() int
+	setTablePos(int)
 	tableKey() []byte                      // The radix key for the table in the root tree
 	primary() anyIndexer                   // The untyped primary indexer for the table
 	secondary() map[string]anyIndexer      // Secondary indexers (if any)


### PR DESCRIPTION
Various optimizations:
- Switch storing of tables and indexes from iradix to simple arrays.
- Drop callerPackage as it was very costly and use a named handle instead (we can easily inject the module name as part of cell.Module using a module provider).
- Rework the benchmarks to use constant data set size to avoid using too much memory.

Before:
```
 goos: linux
 goarch: amd64
 pkg: github.com/cilium/statedb
 cpu: Intel(R) Core(TM) i5-10210U CPU @ 1.60GHz
 BenchmarkDB_WriteTxn_1-8                                          132523              9268 ns/op            107899 objects/sec
 BenchmarkDB_WriteTxn_10-8                                         367114              3044 ns/op            328531 objects/sec
 BenchmarkDB_WriteTxn_100-8                                        430207              2459 ns/op            406751 objects/sec
 BenchmarkDB_WriteTxn_100_SecondaryIndex-8                         503071              2358 ns/op            424111 objects/sec
 BenchmarkDB_RandomInsert-8                                           945           1288636 ns/op            776014 objects/sec
 BenchmarkDB_RandomReplace-8                                          226           5256999 ns/op            190223 objects/sec
 BenchmarkDB_SequentialInsert-8                                       370           3580799 ns/op            279267 objects/sec
 ...
 BenchmarkDB_DeleteTracker_Baseline-8                                 356           3314962 ns/op            301663 objects/sec
 BenchmarkDB_DeleteTracker-8                                          181           6609844 ns/op            151290 objects/sec
 BenchmarkDB_RandomLookup-8                                          3289            354713 ns/op           2819181 objects/sec
 BenchmarkDB_SequentialLookup-8                                      3519            334955 ns/op           2985479 objects/sec
 BenchmarkDB_FullIteration_All-8                                    88718             12817 ns/op          78022832 objects/sec
 BenchmarkDB_FullIteration_Get-8                                    71965             15974 ns/op          62599999 objects/sec
 BenchmarkDB_PropagationDelay-8                                    188659              6398 ns/op
 55.00 50th_µs           74.00 90th_µs          277.0 99th_µs
 PASS
 ok      github.com/cilium/statedb       33.132s 
```

After:
```
 goos: linux
 goarch: amd64
 pkg: github.com/cilium/statedb
 cpu: Intel(R) Core(TM) i5-10210U CPU @ 1.60GHz
 BenchmarkDB_WriteTxn_1-8                                          310290              3885 ns/op            257388 objects/sec
 BenchmarkDB_WriteTxn_10-8                                         523450              2441 ns/op            409679 objects/sec
 BenchmarkDB_WriteTxn_100-8                                        538578              2219 ns/op            450628 objects/sec
 BenchmarkDB_WriteTxn_100_SecondaryIndex-8                         515170              2156 ns/op            463816 objects/sec
 BenchmarkDB_RandomInsert-8                                          1110           1081693 ns/op            924477 objects/sec
 BenchmarkDB_RandomReplace-8                                          237           5034048 ns/op            198647 objects/sec
 BenchmarkDB_SequentialInsert-8                                       380           3048134 ns/op            328070 objects/sec
 ...
 BenchmarkDB_DeleteTracker_Baseline-8                                 396           3066078 ns/op            326150 objects/sec
 BenchmarkDB_DeleteTracker-8                                          169           7019558 ns/op            142459 objects/sec
 BenchmarkDB_RandomLookup-8                                          8839            137467 ns/op           7274474 objects/sec
 BenchmarkDB_SequentialLookup-8                                      8958            124483 ns/op           8033258 objects/sec
 BenchmarkDB_FullIteration_All-8                                    97218             11356 ns/op          88057271 objects/sec
 BenchmarkDB_FullIteration_Get-8                                    78102             14373 ns/op          69577187 objects/sec
 BenchmarkDB_PropagationDelay-8                                    245020              4727 ns/op
 42.00 50th_µs           48.00 90th_µs          210.0 99th_µs
 PASS
 ok      github.com/cilium/statedb       31.520s
```

Result highlights:
* One insert per one WriteTxn went from 100k/s to 260k/s
* Random insert of a new object went from 776k/s to 924k/s