### PR TITLE
Add support for table initializers to gate keep pruning

### DIFF
--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -152,7 +152,7 @@ func (r *reconciler[Obj]) loop(ctx context.Context, health cell.Health) error {
 			errs = append(errs, err)
 		}
 
-		if fullReconciliation {
+		if fullReconciliation && r.Table.Initialized(txn) {
 			// Time to perform a full reconciliation. An incremental reconciliation
 			// has been performed prior to this, so the assumption is that everything
 			// is up to date (provided incremental reconciliation did not fail). We


### PR DESCRIPTION
It's often important to avoid pruning data before the table has been fully populated by writers. Add support for this in the form of table initializers that can be registered before the application starts. Make the reconciler pruning conditional on the table being fully initialized.

The initializers are stored in the table entry, which means that the initializer count is coupled to the snapshot and thus a reader won't think the table is initialized before it gets a snapshot that indeed is initialized.

Example:
```
  // Adding an initializer (called before start)
  txn := db.WriteTxn(myTable)
  done := myTable.RegisterInitializer(txn)
  txn.Commit()

  rtxn1 := db.ReadTxn()
  myTable.Initialized(rtxn1) == false

  txn = db.WriteTxn(myTable)
  done(txn)
  txn.Commit()

  rtxn2 := db.ReadTxn()
  myTable.Initialized(rtxn1) == false
  myTable.Initialized(rtxn2) == true
```