### PR TITLE
Use github.com/alecthomas/assert/v2 for tests

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -10,9 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alecthomas/assert/v2"
 	iradix "github.com/hashicorp/go-immutable-radix/v2"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/hive"
 	"github.com/cilium/hive/cell"
@@ -187,13 +186,13 @@ func BenchmarkDB_SequentialInsert(b *testing.B) {
 		txn := db.WriteTxn(table)
 		for id := uint64(0); id < uint64(numObjectsToInsert); id++ {
 			_, _, err := table.Insert(txn, testObject{ID: id, Tags: nil})
-			require.NoError(b, err)
+			assert.NoError(b, err)
 		}
 		txn.Commit()
 	}
 	b.StopTimer()
 
-	require.EqualValues(b, table.NumObjects(db.ReadTxn()), numObjectsToInsert)
+	assert.Equal(b, table.NumObjects(db.ReadTxn()), numObjectsToInsert)
 	b.ReportMetric(float64(numObjectsToInsert*b.N)/b.Elapsed().Seconds(), "objects/sec")
 }
 
@@ -205,7 +204,7 @@ func BenchmarkDB_Baseline_SingleRadix_Insert(b *testing.B) {
 			txn.Insert(index.Uint64(j), j)
 		}
 		tree = txn.Commit()
-		require.Equal(b, tree.Len(), numObjectsToInsert)
+		assert.Equal(b, tree.Len(), numObjectsToInsert)
 	}
 	b.ReportMetric(float64(numObjectsToInsert*b.N)/b.Elapsed().Seconds(), "objects/sec")
 }
@@ -219,7 +218,7 @@ func BenchmarkDB_Baseline_SingleRadix_TrackMutate_Insert(b *testing.B) {
 			txn.Insert(index.Uint64(j), j)
 		}
 		tree = txn.Commit() // Commit and notify
-		require.Equal(b, tree.Len(), numObjectsToInsert)
+		assert.Equal(b, tree.Len(), numObjectsToInsert)
 	}
 	b.ReportMetric(float64(numObjectsToInsert*b.N)/b.Elapsed().Seconds(), "objects/sec")
 }
@@ -298,7 +297,7 @@ func BenchmarkDB_DeleteTracker(b *testing.B) {
 		// Create objects
 		txn := db.WriteTxn(table)
 		dt, err := table.DeleteTracker(txn, "test")
-		require.NoError(b, err)
+		assert.NoError(b, err)
 		defer dt.Close()
 		for i := 0; i < numObjectsToInsert; i++ {
 			_, _, err := table.Insert(txn, testObject{ID: uint64(i), Tags: nil})
@@ -320,7 +319,7 @@ func BenchmarkDB_DeleteTracker(b *testing.B) {
 			func(obj testObject, deleted bool, _ Revision) {
 				nDeleted++
 			})
-		require.EqualValues(b, nDeleted, numObjectsToInsert)
+		assert.Equal(b, nDeleted, numObjectsToInsert)
 		dt.Close()
 	}
 	b.StopTimer()
@@ -336,7 +335,7 @@ func BenchmarkDB_RandomLookup(b *testing.B) {
 	for i := 0; i < numObjectsToInsert; i++ {
 		queries = append(queries, idIndex.Query(uint64(i)))
 		_, _, err := table.Insert(wtxn, testObject{ID: uint64(i), Tags: nil})
-		require.NoError(b, err)
+		assert.NoError(b, err)
 	}
 	wtxn.Commit()
 	rand.Shuffle(numObjectsToInsert, func(i, j int) {
@@ -363,7 +362,7 @@ func BenchmarkDB_SequentialLookup(b *testing.B) {
 	for i := 0; i < numObjectsToInsert; i++ {
 		ids = append(ids, uint64(i))
 		_, _, err := table.Insert(wtxn, testObject{ID: uint64(i), Tags: nil})
-		require.NoError(b, err)
+		assert.NoError(b, err)
 	}
 	wtxn.Commit()
 	b.ResetTimer()
@@ -388,7 +387,7 @@ func BenchmarkDB_FullIteration_All(b *testing.B) {
 	wtxn := db.WriteTxn(table)
 	for i := 0; i < numObjectsToInsert; i++ {
 		_, _, err := table.Insert(wtxn, testObject{ID: uint64(i), Tags: nil})
-		require.NoError(b, err)
+		assert.NoError(b, err)
 	}
 	wtxn.Commit()
 	b.ResetTimer()
@@ -403,7 +402,7 @@ func BenchmarkDB_FullIteration_All(b *testing.B) {
 			}
 			i++
 		}
-		require.EqualValues(b, i, numObjectsToInsert)
+		assert.Equal(b, i, numObjectsToInsert)
 	}
 	b.ReportMetric(float64(numObjectsToInsert*b.N)/b.Elapsed().Seconds(), "objects/sec")
 }
@@ -413,7 +412,7 @@ func BenchmarkDB_FullIteration_Get(b *testing.B) {
 	wtxn := db.WriteTxn(table)
 	for i := 0; i < numObjectsToInsert; i++ {
 		_, _, err := table.Insert(wtxn, testObject{ID: uint64(i), Tags: []string{"foo"}})
-		require.NoError(b, err)
+		assert.NoError(b, err)
 	}
 	wtxn.Commit()
 	b.ResetTimer()
@@ -428,7 +427,7 @@ func BenchmarkDB_FullIteration_Get(b *testing.B) {
 			}
 			i++
 		}
-		require.EqualValues(b, i, numObjectsToInsert)
+		assert.Equal(b, i, numObjectsToInsert)
 	}
 	b.ReportMetric(float64(numObjectsToInsert*b.N)/b.Elapsed().Seconds(), "objects/sec")
 }
@@ -467,7 +466,7 @@ func BenchmarkDB_PropagationDelay(b *testing.B) {
 		}),
 	)
 
-	require.NoError(b, h.Start(context.TODO()))
+	assert.NoError(b, h.Start(context.TODO()))
 	b.Cleanup(func() {
 		assert.NoError(b, h.Stop(context.TODO()))
 	})

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -15,7 +15,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/alecthomas/assert/v2"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/statedb"
@@ -141,7 +141,7 @@ func (a *realActionLog) validate(db *statedb.DB, t *testing.T) {
 		for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
 			actual.Insert(obj.id)
 		}
-		require.True(t, expected.Equal(actual), "validate failed, mismatching ids: %v",
+		assert.True(t, expected.Equal(actual), "validate failed, mismatching ids: %v",
 			actual.SymmetricDifference(expected))
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,8 @@ require (
 )
 
 require (
+	github.com/alecthomas/assert/v2 v2.7.0 // indirect
+	github.com/alecthomas/repr v0.4.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
@@ -30,6 +32,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/alecthomas/assert/v2 v2.7.0 h1:QtqSACNS3tF7oasA8CU6A6sXZSBDqnm7RfpLl9bZqbE=
+github.com/alecthomas/assert/v2 v2.7.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
+github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=
+github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/cilium/hive v0.0.0-20240209163124-bd6ebb4ec11d h1:No/H/K3aGoD835vF4dWeMC/ahZFMMGzZLYjE0uPFVrQ=
 github.com/cilium/hive v0.0.0-20240209163124-bd6ebb4ec11d/go.mod h1:6tW1eCwSq8Wz8IVtpZE0MemoCWSrEOUa8aLKotmBRCo=
 github.com/cilium/stream v0.0.0-20240209152734-a0792b51812d h1:p6MgATaKEB9o7iAsk9rlzXNDMNCeKPAkx4Y8f+Zq8X8=
@@ -46,6 +50,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=

--- a/regression_test.go
+++ b/regression_test.go
@@ -6,8 +6,7 @@ package statedb
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/alecthomas/assert/v2"
 
 	"github.com/cilium/statedb/index"
 )
@@ -39,8 +38,8 @@ func Test_Regression_29324(t *testing.T) {
 
 	db, _, _ := newTestDB(t)
 	table, err := NewTable[object]("objects", idIndex, tagIndex)
-	require.NoError(t, err)
-	require.NoError(t, db.RegisterTable(table))
+	assert.NoError(t, err)
+	assert.NoError(t, db.RegisterTable(table))
 
 	wtxn := db.WriteTxn(table)
 	table.Insert(wtxn, object{"foo", "aa"})
@@ -52,25 +51,23 @@ func Test_Regression_29324(t *testing.T) {
 	txn := db.ReadTxn()
 	iter, _ := table.Get(txn, idIndex.Query("foo"))
 	items := Collect(iter)
-	if assert.Len(t, items, 1, "Get(\"foo\") should return one match") {
-		assert.EqualValues(t, "foo", items[0].ID)
-	}
+	assert.Equal(t, 1, len(items), "Get(\"foo\") should return one match")
+	assert.Equal(t, "foo", items[0].ID)
 
 	// Partial match on prefix should not return anything
 	iter, _ = table.Get(txn, idIndex.Query("foob"))
 	items = Collect(iter)
-	assert.Len(t, items, 0, "Get(\"foob\") should return nothing")
+	assert.Zero(t, len(items), "Get(\"foob\") should return nothing")
 
 	// Query on non-unique index should only return exact match
 	iter, _ = table.Get(txn, tagIndex.Query("aa"))
 	items = Collect(iter)
-	if assert.Len(t, items, 1, "Get(\"aa\") on tags should return one match") {
-		assert.EqualValues(t, "foo", items[0].ID)
-	}
+	assert.Equal(t, 1, len(items), "Get(\"aa\") on tags should return one match")
+	assert.Equal(t, "foo", items[0].ID)
 
 	// Partial match on prefix should not return anything on non-unique index
 	iter, _ = table.Get(txn, idIndex.Query("a"))
 	items = Collect(iter)
-	assert.Len(t, items, 0, "Get(\"a\") should return nothing")
+	assert.Zero(t, len(items), "Get(\"a\") should return nothing")
 
 }

--- a/statedb_test.go
+++ b/statedb_test.go
@@ -1,0 +1,44 @@
+package statedb
+
+import (
+	"cmp"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/assert/v2"
+)
+
+func assertEventually(t testing.TB, condition func() bool, waitFor time.Duration, tick time.Duration, msgAndArgs ...interface{}) bool {
+	t.Helper()
+
+	ch := make(chan bool, 1)
+
+	timer := time.NewTimer(waitFor)
+	defer timer.Stop()
+
+	ticker := time.NewTicker(tick)
+	defer ticker.Stop()
+
+	for tick := ticker.C; ; {
+		select {
+		case <-timer.C:
+			// FIXME fix use of msgAndArgs
+			// see https://github.com/stretchr/testify/blob/v1.9.0/assert/assertions.go#L342
+			assert.Zero(t, "Condition never satisfied", msgAndArgs...)
+		case <-tick:
+			tick = nil
+			go func() { ch <- condition() }()
+		case v := <-ch:
+			if v {
+				return true
+			}
+			tick = ticker.C
+		}
+	}
+}
+
+func sorted[T cmp.Ordered](s []T) []T {
+	slices.Sort(s)
+	return s
+}


### PR DESCRIPTION
Another draft PR...

github.com/alecthomas/assert/v2 is a modern testing assertion library that uses Go generics. It has a smaller API than github.com/stretchr/testify but -- more importantly -- better type safety. Specifically, stretchr/testify performs many silent type conversions that may conceal type errors, whereas alecthomas/assert uses Go generics to ensure type safety at compile time.

This draft PR switches to the core statedb tests to use alecthomas/assert so you can see what the changes look like. I would be happy to port the remaining tests if you are interested.