### PR TITLE
Add support for prefix searching

### DIFF
--- a/db.go
+++ b/db.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"runtime"
 	"slices"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -251,6 +252,9 @@ func (h Handle) WriteTxn(table TableMeta, tables ...TableMeta) WriteTxn {
 			table.sortableMutex().AcquireDuration(),
 		)
 	}
+
+	// Sort the table names so they always appear ordered in metrics.
+	sort.Strings(tableNames)
 
 	db.metrics.WriteTxnTotalAcquisition(
 		h.name,

--- a/db_test.go
+++ b/db_test.go
@@ -24,6 +24,9 @@ import (
 	"github.com/cilium/stream"
 )
 
+// Amount of time to wait for the watch channel to close in tests
+const watchCloseTimeout = 30 * time.Second
+
 func TestMain(m *testing.M) {
 	// Catch any leaks of goroutines from these tests.
 	goleak.VerifyTestMain(m)
@@ -191,7 +194,7 @@ func TestDB_LowerBound_ByRevision(t *testing.T) {
 
 	select {
 	case <-watch:
-	case <-time.After(time.Second):
+	case <-time.After(watchCloseTimeout):
 		t.Fatalf("expected LowerBound watch to close after changes")
 	}
 
@@ -248,7 +251,7 @@ func TestDB_Prefix(t *testing.T) {
 
 	select {
 	case <-watch:
-	case <-time.After(time.Second):
+	case <-time.After(watchCloseTimeout):
 		t.Fatalf("expected Prefix watch to close after relevant changes")
 	}
 
@@ -497,7 +500,7 @@ func TestDB_All(t *testing.T) {
 
 	select {
 	case <-watch:
-	case <-time.After(time.Second):
+	case <-time.After(watchCloseTimeout):
 		t.Fatalf("expected All() watch channel to close after delete")
 	}
 }
@@ -621,17 +624,17 @@ func TestDB_GetFirstLast(t *testing.T) {
 
 	select {
 	case <-firstWatch:
-	case <-time.After(time.Second):
+	case <-time.After(watchCloseTimeout):
 		t.Fatalf("FirstWatch channel not closed after change")
 	}
 	select {
 	case <-lastWatch:
-	case <-time.After(time.Second):
+	case <-time.After(watchCloseTimeout):
 		t.Fatalf("LastWatch channel not closed after change")
 	}
 	select {
 	case <-getWatch:
-	case <-time.After(time.Second):
+	case <-time.After(watchCloseTimeout):
 		t.Fatalf("Get channel not closed after change")
 	}
 

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -269,6 +269,12 @@ func lowerboundAction(ctx actionContext) {
 	ctx.log.log("%s: LowerBound(%d) => %d found", ctx.table.Name(), id, len(statedb.Collect(iter)))
 }
 
+func prefixAction(ctx actionContext) {
+	id := mkID()
+	iter, _ := ctx.table.Prefix(ctx.txn, idIndex.Query(id))
+	ctx.log.log("%s: Prefix(%d) => %d found", ctx.table.Name(), id, len(statedb.Collect(iter)))
+}
+
 var actions = []action{
 	insertAction, insertAction, insertAction, insertAction, insertAction,
 	insertAction, insertAction, insertAction, insertAction, insertAction,
@@ -282,6 +288,7 @@ var actions = []action{
 	allAction, lowerboundAction,
 	getAction, getAction, getAction,
 	lastAction, lastAction,
+	prefixAction,
 }
 
 func randomAction() action {

--- a/index/keyset.go
+++ b/index/keyset.go
@@ -8,13 +8,6 @@ import (
 )
 
 // Key is a byte slice describing a key used in an index by statedb.
-// If a key is variable-sized, then it must be either terminated with
-// e.g. zero byte or it must be length-encoded. If it is not, then
-// a Get() may return results that don't match the query (e.g. objects
-// indexed with a key that has the same prefix but are longer).
-// The reason is that Get() is implemented as a prefix seek to avoid
-// full key comparison on iteration and also to support the
-// non-unique indexes which key on "secondary + primary" keys.
 type Key []byte
 
 func (k Key) Equal(k2 Key) bool {

--- a/index/string.go
+++ b/index/string.go
@@ -6,7 +6,7 @@ package index
 import "fmt"
 
 func String(s string) Key {
-	return append([]byte(s), 0 /* termination */)
+	return []byte(s)
 }
 
 func Stringer[T fmt.Stringer](s T) Key {

--- a/table.go
+++ b/table.go
@@ -294,6 +294,14 @@ func (t *genTable[Obj]) LowerBound(txn ReadTxn, q Query[Obj]) (Iterator[Obj], <-
 	return &iterator[Obj]{iter}, watch
 }
 
+func (t *genTable[Obj]) Prefix(txn ReadTxn, q Query[Obj]) (Iterator[Obj], <-chan struct{}) {
+	indexTxn := txn.getTxn().mustIndexReadTxn(t, t.indexPos(q.index))
+	root := indexTxn.Root()
+	iter := root.Iterator()
+	watch := iter.SeekPrefixWatch(q.key)
+	return &iterator[Obj]{iter}, watch
+}
+
 func (t *genTable[Obj]) All(txn ReadTxn) (Iterator[Obj], <-chan struct{}) {
 	indexTxn := txn.getTxn().mustIndexReadTxn(t, PrimaryIndexPos)
 	root := indexTxn.Root()

--- a/types.go
+++ b/types.go
@@ -68,6 +68,9 @@ type Table[Obj any] interface {
 	// are not possible with a lower bound search.
 	LowerBound(ReadTxn, Query[Obj]) (iter Iterator[Obj], watch <-chan struct{})
 
+	// Prefix searches the table by key prefix.
+	Prefix(ReadTxn, Query[Obj]) (iter Iterator[Obj], watch <-chan struct{})
+
 	// DeleteTracker creates a new delete tracker for the table.
 	//
 	// It starts tracking deletions performed against the table from the


### PR DESCRIPTION
Add the Prefix() method for doing a prefix search on a table:

```
  var tbl Table[Foo]
  var index Index[Foo, string]
  tbl.Insert(wtxn, Foo{"foo"})
  tbl.Insert(wtxn, Foo{"foobar"})
  wtxn.Commit()

  iter, watch := tbl.Prefix(db.ReadTxn(), index.Query("fo"))
  // returns "foo" and "foobar", the watch channel will be the channel
  // of the parent of "foo" since that's the most specific one.
```