### PR TITLE
Remove unused type tableIndex

### DIFF
--- a/txn.go
+++ b/txn.go
@@ -30,11 +30,6 @@ type txn struct {
 	tableNames     []string
 }
 
-type tableIndex struct {
-	tablePos int
-	index    IndexName
-}
-
 // rooter is implemented by both iradix.Txn and iradix.Tree.
 type rooter interface {
 	Root() *iradix.Node[object]


### PR DESCRIPTION
It's unused since commit 965dc5bb488b ("Use arrays for index tree lookup").