### PR TITLE
Switch to persistent adaptive radix trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 # :memo: StateDB [![GoDoc](https://pkg.go.dev/badge/github.com/cilium/statedb)](https://pkg.go.dev/github.com/cilium/statedb) 
 
-StateDB is an in-memory database for Go. It stores immutable objects in
-[immutable radix trees](https://github.com/hashicorp/go-immutable-radix), and thus
-supports multi-version concurrency control (MVCC) and transactional write transactions.
-Changes to the database can be watched at fine-granularity which allows reacting to changes in the database. 
+StateDB is an in-memory database for Go. It supports unique and non-unique indexes and objects
+can have multiple keys.
 
-The library is inspired by [go-memdb](https://github.com/hashicorp/go-memdb). The main differences
-to it are type-safety via generics, builtin object revision numbers and per-table locking rather
-than single database lock.
+The database is built on top of Persistent Adative Radix Trees (implemented in part/). It supports
+multi-version concurrency control and transactional cross-table write transaction. Changes to the database
+can be watched at fine-granularity which allows reacting to changes in the database.
 

--- a/deletetracker.go
+++ b/deletetracker.go
@@ -37,8 +37,7 @@ func (dt *DeleteTracker[Obj]) getRevision() uint64 {
 // called!
 func (dt *DeleteTracker[Obj]) Deleted(txn ReadTxn, minRevision Revision) Iterator[Obj] {
 	indexTxn := txn.getTxn().mustIndexReadTxn(dt.table, GraveyardRevisionIndexPos)
-	iter := indexTxn.Root().Iterator()
-	iter.SeekLowerBound(index.Uint64(minRevision))
+	iter := indexTxn.LowerBound(index.Uint64(minRevision))
 	return &iterator[Obj]{iter}
 }
 
@@ -61,7 +60,7 @@ func (dt *DeleteTracker[Obj]) Close() {
 	if table == nil {
 		panic("BUG: Table missing from write transaction")
 	}
-	table.deleteTrackers, _, _ = table.deleteTrackers.Delete([]byte(dt.trackerName))
+	_, _, table.deleteTrackers = table.deleteTrackers.Delete([]byte(dt.trackerName))
 	txn.Commit()
 
 	db.metrics.DeleteTrackerCount(dt.table.Name(), table.deleteTrackers.Len())

--- a/doc.go
+++ b/doc.go
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-// The statedb package provides a transactional in-memory database with per-table locking
-// built on top of the go-immutable-radix library.
+// The statedb package provides a transactional in-memory database with per-table locking.
+// The database indexes objects using Persistive Adaptive Radix Trees.
+// (https://db.in.tum.de/~leis/papers/ART.pdf)
 //
 // As this is built around an immutable data structure and objects may have lockless readers
 // the stored objects MUST NOT be mutated, but instead a copy must be made prior to mutation
 // and insertion.
 //
-// See pkg/statedb/example for an example how to construct an application that uses this library.
+// See 'example/' for an example how to construct an application that uses this library.
 package statedb

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -15,10 +15,9 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/cilium/statedb"
 	"github.com/cilium/statedb/index"
+	"golang.org/x/exp/maps"
 )
 
 // Run test with "--debug" for log output.
@@ -44,9 +43,10 @@ func newDebugLogger(worker int) *debugLogger {
 }
 
 const (
-	numUniqueIDs  = 20
-	numWorkers    = 50
-	numIterations = 1000
+	numUniqueIDs    = 2000
+	numUniqueValues = 3000
+	numWorkers      = 20
+	numIterations   = 1000
 )
 
 type fuzzObj struct {
@@ -56,6 +56,10 @@ type fuzzObj struct {
 
 func mkID() uint64 {
 	return uint64(rand.Int63n(numUniqueIDs))
+}
+
+func mkValue() uint64 {
+	return uint64(rand.Int63n(numUniqueValues))
 }
 
 var idIndex = statedb.Index[fuzzObj, uint64]{
@@ -77,13 +81,13 @@ var valueIndex = statedb.Index[fuzzObj, uint64]{
 }
 
 var (
-	tableFuzz1  = statedb.MustNewTable[fuzzObj]("fuzz1", idIndex)
-	tableFuzz2  = statedb.MustNewTable[fuzzObj]("fuzz2", idIndex)
+	tableFuzz1  = statedb.MustNewTable[fuzzObj]("fuzz1", idIndex, valueIndex)
+	tableFuzz2  = statedb.MustNewTable[fuzzObj]("fuzz2", idIndex, valueIndex)
 	tableFuzz3  = statedb.MustNewTable[fuzzObj]("fuzz3", idIndex, valueIndex)
 	tableFuzz4  = statedb.MustNewTable[fuzzObj]("fuzz4", idIndex, valueIndex)
 	fuzzTables  = []statedb.TableMeta{tableFuzz1, tableFuzz2, tableFuzz3, tableFuzz4}
 	fuzzMetrics = statedb.NewExpVarMetrics(false)
-	fuzzDB, _   = statedb.NewDB(fuzzTables, fuzzMetrics)
+	fuzzDB      *statedb.DB
 )
 
 func randomSubset[T any](xs []T) []T {
@@ -98,51 +102,50 @@ func randomSubset[T any](xs []T) []T {
 
 type actionLog interface {
 	append(actionLogEntry)
+	validateTable(txn statedb.ReadTxn, table statedb.Table[fuzzObj]) error
 }
 
 type realActionLog struct {
 	sync.Mutex
-	log []actionLogEntry
+	log map[string][]actionLogEntry
 }
 
 func (a *realActionLog) append(e actionLogEntry) {
 	a.Lock()
-	a.log = append(a.log, e)
+	a.log[e.table.Name()] = append(a.log[e.table.Name()], e)
 	a.Unlock()
 }
 
-func (a *realActionLog) validate(db *statedb.DB, t *testing.T) {
+func (a *realActionLog) validateTable(txn statedb.ReadTxn, table statedb.Table[fuzzObj]) error {
 	a.Lock()
 	defer a.Unlock()
 
 	// Collapse the log down to objects that are alive at the end.
-	alive := map[statedb.Table[fuzzObj]]map[uint64]struct{}{}
-	for _, e := range a.log {
-		aliveThis, ok := alive[e.table]
-		if !ok {
-			aliveThis = map[uint64]struct{}{}
-			alive[e.table] = aliveThis
-		}
+	alive := map[uint64]struct{}{}
+	for _, e := range a.log[table.Name()] {
 		switch e.act {
 		case actInsert:
-			aliveThis[e.id] = struct{}{}
+			alive[e.id] = struct{}{}
 		case actDelete:
-			delete(aliveThis, e.id)
+			delete(alive, e.id)
 		case actDeleteAll:
-			clear(aliveThis)
+			clear(alive)
 		}
 	}
 
-	for table, expected := range alive {
-		txn := db.ReadTxn()
-		iter, _ := table.All(txn)
-		actual := map[uint64]struct{}{}
-		for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
-			actual[obj.id] = struct{}{}
-		}
-		require.Equal(t, expected, actual, "validate failed, mismatching ids: %v",
-			setSymmetricDifference(actual, expected))
+	// Since everything was deleted we can clear the log entries for this table now
+	a.log[table.Name()] = nil
+
+	iter, _ := table.All(txn)
+	actual := map[uint64]struct{}{}
+	for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
+		actual[obj.id] = struct{}{}
 	}
+	diff := setSymmetricDifference(actual, alive)
+	if len(diff) != 0 {
+		return fmt.Errorf("validate failed, mismatching ids: %v", maps.Keys(diff))
+	}
+	return nil
 }
 
 func setSymmetricDifference[T comparable, M map[T]struct{}](s1, s2 M) M {
@@ -167,6 +170,10 @@ type nopActionLog struct {
 
 func (nopActionLog) append(e actionLogEntry) {}
 
+func (nopActionLog) validateTable(txn statedb.ReadTxn, table statedb.Table[fuzzObj]) error {
+	return nil
+}
+
 const (
 	actInsert = iota
 	actDelete
@@ -190,6 +197,7 @@ type txnActionLog struct {
 }
 
 type actionContext struct {
+	t      *testing.T
 	log    *debugLogger
 	actLog actionLog
 	txnLog *txnActionLog
@@ -201,7 +209,7 @@ type action func(ctx actionContext)
 
 func insertAction(ctx actionContext) {
 	id := mkID()
-	value := rand.Uint64()
+	value := mkValue()
 	ctx.log.log("%s: Insert %d", ctx.table.Name(), id)
 	ctx.table.Insert(ctx.txn, fuzzObj{id, value})
 	e := actionLogEntry{ctx.table, actInsert, id, value}
@@ -220,9 +228,38 @@ func deleteAction(ctx actionContext) {
 
 func deleteAllAction(ctx actionContext) {
 	ctx.log.log("%s: DeleteAll", ctx.table.Name())
+
+	// Validate the log before objects are wiped.
+	if err := ctx.actLog.validateTable(ctx.txn, ctx.table); err != nil {
+		panic(err)
+	}
 	ctx.table.DeleteAll(ctx.txn)
 	ctx.actLog.append(actionLogEntry{ctx.table, actDeleteAll, 0, 0})
 	clear(ctx.txnLog.latest)
+}
+
+func deleteManyAction(ctx actionContext) {
+	// Delete third of the objects using iteration to test that
+	// nothing bad happens when the iterator is used while deleting.
+	toDelete := ctx.table.NumObjects(ctx.txn) / 3
+
+	iter, _ := ctx.table.All(ctx.txn)
+	n := 0
+	for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
+		ctx.log.log("%s: DeleteMany %d (%d/%d)", ctx.table.Name(), obj.id, n+1, toDelete)
+		_, hadOld, _ := ctx.table.Delete(ctx.txn, obj)
+		if !hadOld {
+			panic("expected Delete of a known object to return the old object")
+		}
+		e := actionLogEntry{ctx.table, actDelete, obj.id, 0}
+		ctx.actLog.append(e)
+		ctx.txnLog.latest[tableAndID{ctx.table.Name(), obj.id}] = e
+
+		n++
+		if n >= toDelete {
+			break
+		}
+	}
 }
 
 func allAction(ctx actionContext) {
@@ -231,9 +268,28 @@ func allAction(ctx actionContext) {
 }
 
 func getAction(ctx actionContext) {
-	id := mkID()
-	iter, _ := ctx.table.Get(ctx.txn, idIndex.Query(mkID()))
-	ctx.log.log("%s: Get(%d) => %d found", ctx.table.Name(), id, len(statedb.Collect(iter)))
+	value := mkValue()
+	iter, _ := ctx.table.Get(ctx.txn, valueIndex.Query(value))
+	ctx.log.log("%s: Get(%d)", ctx.table.Name(), value)
+	for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
+		if e, ok2 := ctx.txnLog.latest[tableAndID{ctx.table.Name(), obj.id}]; ok2 {
+			if e.act == actInsert {
+				if !ok {
+					panic("Get() returned not found, expected last inserted value")
+				}
+				if e.value != obj.value {
+					panic("Get() did not return the last write")
+				}
+				if obj.value != value {
+					panic(fmt.Sprintf("Get() returned object with wrong value, expected %d, got %d", value, obj.value))
+				}
+			} else if e.act == actDelete {
+				if ok {
+					panic("Get() returned value even though it was deleted")
+				}
+			}
+		}
+	}
 }
 
 func firstAction(ctx actionContext) {
@@ -270,22 +326,68 @@ func prefixAction(ctx actionContext) {
 }
 
 var actions = []action{
+	// Make inserts much more likely than deletions to build up larger tables.
+	insertAction, insertAction, insertAction, insertAction, insertAction,
+	insertAction, insertAction, insertAction, insertAction, insertAction,
+	insertAction, insertAction, insertAction, insertAction, insertAction,
+	insertAction, insertAction, insertAction, insertAction, insertAction,
+	insertAction, insertAction, insertAction, insertAction, insertAction,
+	insertAction, insertAction, insertAction, insertAction, insertAction,
+	insertAction, insertAction, insertAction, insertAction, insertAction,
+	insertAction, insertAction, insertAction, insertAction, insertAction,
+	insertAction, insertAction, insertAction, insertAction, insertAction,
+	insertAction, insertAction, insertAction, insertAction, insertAction,
+	insertAction, insertAction, insertAction, insertAction, insertAction,
+	insertAction, insertAction, insertAction, insertAction, insertAction,
+	insertAction, insertAction, insertAction, insertAction, insertAction,
+	insertAction, insertAction, insertAction, insertAction, insertAction,
+	insertAction, insertAction, insertAction, insertAction, insertAction,
+	insertAction, insertAction, insertAction, insertAction, insertAction,
+	insertAction, insertAction, insertAction, insertAction, insertAction,
+	insertAction, insertAction, insertAction, insertAction, insertAction,
+	insertAction, insertAction, insertAction, insertAction, insertAction,
+	insertAction, insertAction, insertAction, insertAction, insertAction,
 	insertAction, insertAction, insertAction, insertAction, insertAction,
 	insertAction, insertAction, insertAction, insertAction, insertAction,
 	insertAction, insertAction, insertAction, insertAction, insertAction,
 
 	deleteAction, deleteAction, deleteAction,
-
-	deleteAllAction,
+	deleteManyAction, deleteAllAction,
 
 	firstAction, firstAction, firstAction, firstAction, firstAction,
-	allAction, lowerboundAction,
-	getAction, getAction, getAction,
-	prefixAction,
+	firstAction, firstAction, firstAction, firstAction, firstAction,
+	firstAction, firstAction, firstAction, firstAction, firstAction,
+	getAction, getAction, getAction, getAction, getAction,
+	allAction, allAction,
+	lowerboundAction, lowerboundAction, lowerboundAction,
+	prefixAction, prefixAction, prefixAction,
 }
 
 func randomAction() action {
 	return actions[rand.Intn(len(actions))]
+}
+
+func trackerWorker(stop <-chan struct{}) {
+	txn := fuzzDB.WriteTxn(tableFuzz1)
+	dt, err := tableFuzz1.DeleteTracker(txn, "tracker")
+	if err != nil {
+		panic(err)
+	}
+	txn.Commit()
+	defer dt.Close()
+
+	for {
+		watch := dt.Iterate(
+			fuzzDB.ReadTxn(),
+			func(obj fuzzObj, deleted bool, rev uint64) {
+			},
+		)
+		select {
+		case <-watch:
+		case <-stop:
+			return
+		}
+	}
 }
 
 func fuzzWorker(realActionLog *realActionLog, worker int, iterations int) {
@@ -337,21 +439,40 @@ func fuzzWorker(realActionLog *realActionLog, worker int, iterations int) {
 func TestDB_Fuzz(t *testing.T) {
 	t.Parallel()
 
+	fuzzDB, _ = statedb.NewDB(fuzzTables, fuzzMetrics)
+
 	fuzzDB.Start(context.TODO())
 	defer fuzzDB.Stop(context.TODO())
 
-	var actionLog realActionLog
+	actionLog := &realActionLog{
+		log: map[string][]actionLogEntry{},
+	}
+
 	var wg sync.WaitGroup
 	wg.Add(numWorkers)
 	for i := 0; i < numWorkers; i++ {
 		i := i
 		go func() {
-			fuzzWorker(&actionLog, i, numIterations)
+			fuzzWorker(actionLog, i, numIterations)
 			wg.Done()
 		}()
 	}
+	stop := make(chan struct{})
+	var wg2 sync.WaitGroup
+	wg2.Add(1)
+	go func() {
+		trackerWorker(stop)
+		wg2.Done()
+	}()
 	wg.Wait()
-	actionLog.validate(fuzzDB, t)
+	close(stop)
+	wg2.Wait()
+
+	for _, table := range []statedb.Table[fuzzObj]{tableFuzz1, tableFuzz2, tableFuzz3, tableFuzz4} {
+		if err := actionLog.validateTable(fuzzDB.ReadTxn(), table); err != nil {
+			t.Fatal(err)
+		}
+	}
 
 	t.Logf("metrics:\n%s\n", fuzzMetrics.String())
 }

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -257,12 +257,6 @@ func firstAction(ctx actionContext) {
 	ctx.log.log("%s: First(%d) => rev=%d, ok=%v", ctx.table.Name(), id, rev, ok)
 }
 
-func lastAction(ctx actionContext) {
-	id := mkID()
-	_, rev, ok := ctx.table.Last(ctx.txn, idIndex.Query(id))
-	ctx.log.log("%s: Last(%d) => rev=%d, ok=%v", ctx.table.Name(), id, rev, ok)
-}
-
 func lowerboundAction(ctx actionContext) {
 	id := mkID()
 	iter, _ := ctx.table.LowerBound(ctx.txn, idIndex.Query(id))
@@ -287,7 +281,6 @@ var actions = []action{
 	firstAction, firstAction, firstAction, firstAction, firstAction,
 	allAction, lowerboundAction,
 	getAction, getAction, getAction,
-	lastAction, lastAction,
 	prefixAction,
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.21.3
 require (
 	github.com/cilium/hive v0.0.0-20240209163124-bd6ebb4ec11d
 	github.com/cilium/stream v0.0.0-20240209152734-a0792b51812d
-	github.com/hashicorp/go-immutable-radix/v2 v2.1.0
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
@@ -17,7 +16,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
-	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,12 +13,6 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/hashicorp/go-immutable-radix/v2 v2.1.0 h1:CUW5RYIcysz+D3B+l1mDeXrQ7fUvGGCwJfdASSzbrfo=
-github.com/hashicorp/go-immutable-radix/v2 v2.1.0/go.mod h1:hgdqLXA4f6NIjRVisM1TJ9aOJVNRqKZj+xDGF6m7PBw=
-github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
-github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
-github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/graveyard.go
+++ b/graveyard.go
@@ -45,7 +45,7 @@ func graveyardWorker(db *DB, ctx context.Context, gcRateLimitInterval time.Durat
 
 			// Find the low watermark
 			lowWatermark := table.revision
-			dtIter := table.deleteTrackers.Root().Iterator()
+			dtIter := table.deleteTrackers.Iterator()
 			for _, dt, ok := dtIter.Next(); ok; _, dt, ok = dtIter.Next() {
 				rev := dt.getRevision()
 				// If the revision is higher than zero than the tracker has been observed
@@ -65,7 +65,7 @@ func graveyardWorker(db *DB, ctx context.Context, gcRateLimitInterval time.Durat
 			// to the low watermark.
 			indexTree := txn.mustIndexReadTxn(table.meta, GraveyardRevisionIndexPos)
 
-			objIter := indexTree.Root().Iterator()
+			objIter := indexTree.Iterator()
 			for key, obj, ok := objIter.Next(); ok; key, obj, ok = objIter.Next() {
 				if obj.revision > lowWatermark {
 					break

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -51,5 +51,5 @@ func TestFilter(t *testing.T) {
 		),
 	)
 	assert.Len(t, filtered, 2)
-	assert.Equal(t, filtered, []int{2, 4})
+	assert.Equal(t, []int{2, 4}, filtered)
 }

--- a/part/iterator.go
+++ b/part/iterator.go
@@ -51,7 +51,7 @@ func lowerbound[T any](start *header[T], key []byte) *Iterator[T] {
 
 	var traverseToMin func(n *header[T])
 	traverseToMin = func(n *header[T]) {
-		if n.leaf != nil {
+		if leaf := n.getLeaf(); leaf != nil {
 			edges = append(edges, []*header[T]{n})
 			return
 		}
@@ -163,9 +163,9 @@ func (it *Iterator[T]) Next() (key []byte, value T, ok bool) {
 		if node.size() > 0 {
 			it.next = append(it.next, node.children())
 		}
-		if node.leaf != nil {
-			key = node.leaf.key
-			value = node.leaf.value
+		if leaf := node.getLeaf(); leaf != nil {
+			key = leaf.key
+			value = leaf.value
 			ok = true
 			return
 		}

--- a/part/iterator.go
+++ b/part/iterator.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package part
+
+import (
+	"bytes"
+	"sort"
+)
+
+func prefixSearch[T any](root *header[T], key []byte) (*Iterator[T], <-chan struct{}) {
+	this := root
+
+	for {
+		switch {
+		case bytes.Equal(key, this.prefix[:min(len(key), len(this.prefix))]):
+			return newIterator(this), this.watch
+
+		case bytes.HasPrefix(key, this.prefix):
+			key = key[len(this.prefix):]
+			if len(key) == 0 {
+				return newIterator(this), this.watch
+			}
+
+		default:
+			return newIterator[T](nil), root.watch
+		}
+
+		this = this.find(key[0])
+		if this == nil {
+			return newIterator[T](nil), root.watch
+		}
+	}
+}
+
+type Iterator[T any] struct {
+	next [][]*header[T] // sets of edges to explore
+}
+
+func newIterator[T any](start *header[T]) *Iterator[T] {
+	if start == nil {
+		return &Iterator[T]{nil}
+	}
+	return &Iterator[T]{[][]*header[T]{{start}}}
+}
+
+func lowerbound[T any](start *header[T], key []byte) *Iterator[T] {
+	// The starting edges to explore. This contains all larger nodes encountered
+	// on the path to the node larger or equal to the key.
+	edges := [][]*header[T]{}
+
+	var traverseToMin func(n *header[T])
+	traverseToMin = func(n *header[T]) {
+		if n.leaf != nil {
+			edges = append(edges, []*header[T]{n})
+			return
+		}
+		children := n.children()
+
+		// Find the first non-nil child
+		for len(children) > 0 && children[0] == nil {
+			children = children[1:]
+		}
+
+		if len(children) > 0 {
+			// Add the larger children.
+			if len(children) > 1 {
+				edges = append(edges, children[1:])
+			}
+			// Recurse into the smallest child
+			traverseToMin(children[0])
+		}
+	}
+
+	this := start
+loop:
+	for {
+		switch bytes.Compare(this.prefix, key[:min(len(key), len(this.prefix))]) {
+		case -1:
+			// Prefix is smaller, which means there is no node smaller than
+			// the given lowerbound.
+			return &Iterator[T]{nil}
+
+		case 0:
+			if len(this.prefix) == len(key) {
+				// Exact match.
+				edges = append(edges, []*header[T]{this})
+				break loop
+			} else if len(key) == 0 {
+				// Search key exhausted, find the minimum node.
+				traverseToMin(this)
+				break loop
+			}
+
+			// Prefix matches, keep going.
+			key = key[len(this.prefix):]
+
+			if this.kind() == nodeKind256 {
+				children := this.node256().children[:]
+				idx := int(key[0])
+				this = children[idx]
+
+				// Add all larger children and recurse further.
+				children = children[idx+1:]
+				for len(children) > 0 && children[0] == nil {
+					children = children[1:]
+				}
+				edges = append(edges, children)
+
+				if this == nil {
+					break loop
+				}
+			} else {
+				children := this.children()
+
+				// Find the smallest child that is equal or larger than the lower bound
+				idx := sort.Search(len(children), func(i int) bool {
+					return children[i].prefix[0] >= key[0]
+				})
+				if idx >= this.size() {
+					break loop
+				}
+				// Add all larger children and recurse further.
+				if len(children) > idx+1 {
+					edges = append(edges, children[idx+1:])
+				}
+				this = children[idx]
+			}
+
+		case 1:
+			// Prefix bigger than lowerbound, go to smallest node and stop.
+			traverseToMin(this)
+			break loop
+		}
+	}
+
+	if len(edges) > 0 {
+		return &Iterator[T]{edges}
+	}
+	return &Iterator[T]{nil}
+}
+
+func (it *Iterator[T]) Next() (key []byte, value T, ok bool) {
+	for len(it.next) > 0 {
+		// Pop the next set of edges to explore
+		edges := it.next[len(it.next)-1]
+		for len(edges) > 0 && edges[0] == nil {
+			// Node256 may have nil children, so jump over them.
+			edges = edges[1:]
+		}
+		it.next = it.next[:len(it.next)-1]
+
+		if len(edges) == 0 {
+			continue
+		} else if len(edges) > 1 {
+			// More edges remain to be explored, add them back.
+			it.next = append(it.next, edges[1:])
+		}
+
+		// Follow the smallest edge and add its children to the queue.
+		node := edges[0]
+
+		if node.size() > 0 {
+			it.next = append(it.next, node.children())
+		}
+		if node.leaf != nil {
+			key = node.leaf.key
+			value = node.leaf.value
+			ok = true
+			return
+		}
+	}
+	return
+}

--- a/part/node.go
+++ b/part/node.go
@@ -22,6 +22,7 @@ const (
 	nodeKind256
 )
 
+// header is the common header shared by all node kinds.
 type header[T any] struct {
 	flags  uint16        // kind(4b) | unused(3b) | size(9b)
 	prefix []byte        // the compressed prefix, [0] is the key

--- a/part/node.go
+++ b/part/node.go
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package part
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+	"unsafe"
+)
+
+type nodeKind uint8
+
+const (
+	nodeKindUnknown = iota
+	nodeKind4
+	nodeKind16
+	nodeKind48
+	nodeKind256
+)
+
+type leaf[T any] struct {
+	key   []byte
+	value T
+}
+
+type header[T any] struct {
+	flags  uint16        // kind(4b) | unused(3b) | size(9b)
+	prefix []byte        // the compressed prefix, [0] is the key
+	leaf   *leaf[T]      // non-nil if this node contains a value
+	watch  chan struct{} // watch channel that is closed when this node mutates
+}
+
+const kindMask = uint16(0b1111_000_00000000_0)
+
+func (n *header[T]) kind() nodeKind {
+	return nodeKind(n.flags >> 12)
+}
+
+func (n *header[T]) setKind(k nodeKind) {
+	n.flags = (n.flags & ^kindMask) | (uint16(k&0b1111) << 12)
+}
+
+const sizeMask = uint16(0b0000_000_1111_1111_1)
+
+func (n *header[T]) cap() int {
+	switch n.kind() {
+	case nodeKind4:
+		return 4
+	case nodeKind16:
+		return 16
+	case nodeKind48:
+		return 48
+	case nodeKind256:
+		return 256
+	default:
+		panic("unknown node kind")
+	}
+}
+
+func (n *header[T]) size() int {
+	return int(n.flags & sizeMask)
+}
+
+func (n *header[T]) setSize(size int) {
+	n.flags = (n.flags & ^sizeMask) | uint16(size)&sizeMask
+}
+
+func (n *header[T]) self() *header[T] {
+	return n
+}
+
+func (n *header[T]) node4() *node4[T] {
+	return (*node4[T])(unsafe.Pointer(n))
+}
+
+func (n *header[T]) node16() *node16[T] {
+	return (*node16[T])(unsafe.Pointer(n))
+}
+
+func (n *header[T]) node48() *node48[T] {
+	return (*node48[T])(unsafe.Pointer(n))
+}
+
+func (n *header[T]) node256() *node256[T] {
+	return (*node256[T])(unsafe.Pointer(n))
+}
+
+// clone returns a shallow clone of the node.
+// We are working on the assumption here that only
+// value-types are mutated in the returned clone.
+func (n *header[T]) clone(watch bool) *header[T] {
+	var nCopy *header[T]
+	switch n.kind() {
+	case nodeKind4:
+		n4 := *n.node4()
+		nCopy = (&n4).self()
+	case nodeKind16:
+		n16 := *n.node16()
+		nCopy = (&n16).self()
+	case nodeKind48:
+		n48 := *n.node48()
+		nCopy = (&n48).self()
+	case nodeKind256:
+		nCopy256 := *n.node256()
+		nCopy = (&nCopy256).self()
+	default:
+		panic("unknown node kind")
+	}
+	if watch {
+		nCopy.watch = make(chan struct{})
+	} else {
+		nCopy.watch = nil
+	}
+	if n.leaf != nil {
+		nCopy.leaf = &leaf[T]{
+			key:   n.leaf.key,
+			value: n.leaf.value,
+		}
+	}
+	return nCopy
+}
+
+func (n *header[T]) promote(watch bool) *header[T] {
+	switch n.kind() {
+	case nodeKind4:
+		node4 := n.node4()
+		node16 := &node16[T]{header: *n}
+		node16.setKind(nodeKind16)
+		copy(node16.children[:], node4.children[:node4.size()])
+		if watch {
+			node16.watch = make(chan struct{})
+		}
+		return node16.self()
+	case nodeKind16:
+		node16 := n.node16()
+		node48 := &node48[T]{header: *n}
+		node48.setKind(nodeKind48)
+		copy(node48.children[:], node16.children[:node16.size()])
+		if watch {
+			node48.watch = make(chan struct{})
+		}
+		return node48.self()
+	case nodeKind48:
+		node48 := n.node48()
+		node256 := &node256[T]{header: *n}
+		node256.setKind(nodeKind256)
+
+		// Since Node256 has children indexed directly, iterate over the children
+		// to assign them to the right index.
+		for _, child := range node48.children[:node48.size()] {
+			node256.children[child.prefix[0]] = child
+		}
+		if watch {
+			node256.watch = make(chan struct{})
+		}
+		return node256.self()
+	case nodeKind256:
+		panic("BUG: should not need to promote node256")
+	default:
+		panic("unknown node kind")
+	}
+}
+
+func (n *header[T]) printTree(level int) {
+	fmt.Print(strings.Repeat(" ", level))
+
+	var children []*header[T]
+	switch n.kind() {
+	case nodeKind4:
+		fmt.Printf("node4[%v]:", n.prefix)
+		children = n.node4().children[:n.size()]
+	case nodeKind16:
+		fmt.Printf("node16[%v]:", n.prefix)
+		children = n.node16().children[:n.size()]
+	case nodeKind48:
+		fmt.Printf("node48[%v]:", n.prefix)
+		children = n.node48().children[:n.size()]
+	case nodeKind256:
+		fmt.Printf("node256[%v]:", n.prefix)
+		children = n.node256().children[:]
+	default:
+		panic("unknown node kind")
+	}
+	if n.leaf != nil {
+		fmt.Printf(" %v -> %v", n.leaf.key, n.leaf.value)
+	}
+	fmt.Printf("(%p)\n", n)
+
+	for _, child := range children {
+		if child != nil {
+			child.printTree(level + 1)
+		}
+	}
+}
+
+func (n *header[T]) children() []*header[T] {
+	switch n.kind() {
+	case nodeKind4:
+		return n.node4().children[0:n.size():4]
+	case nodeKind16:
+		return n.node16().children[0:n.size():16]
+	case nodeKind48:
+		return n.node48().children[0:n.size():48]
+	case nodeKind256:
+		return n.node256().children[:]
+	default:
+		panic("unexpected node kind")
+	}
+}
+
+func (n *header[T]) findIndex(key byte) (*header[T], int) {
+	if n.kind() == nodeKind256 {
+		return n.node256().children[key], int(key)
+	}
+
+	children := n.children()
+	idx := sort.Search(len(children), func(i int) bool {
+		return children[i].prefix[0] >= key
+	})
+	if idx >= n.size() || children[idx].prefix[0] != key {
+		// No node found, return nil and the index into
+		// which it should go.
+		return nil, idx
+	}
+	return children[idx], idx
+}
+
+func (n *header[T]) find(key byte) *header[T] {
+	child, _ := n.findIndex(key)
+	return child
+}
+
+func (n *header[T]) insert(idx int, child *header[T]) {
+	n.setSize(n.size() + 1)
+	switch n.kind() {
+	case nodeKind256:
+		n.node256().children[child.prefix[0]] = child
+	default:
+		children := n.children()
+		// Shift to make room
+		copy(children[idx+1:], children[idx:])
+		children[idx] = child
+	}
+}
+
+func (n *header[T]) remove(idx int) {
+	if n.kind() == nodeKind256 {
+		n.node256().children[idx] = nil
+	} else {
+		children := n.children()
+		copy(children[idx:], children[idx+1:])
+		children[n.size()-1] = nil
+	}
+	n.setSize(n.size() - 1)
+}
+
+type node4[T any] struct {
+	header[T]
+	children [4]*header[T]
+}
+
+type node16[T any] struct {
+	header[T]
+	children [16]*header[T]
+}
+
+type node48[T any] struct {
+	header[T]
+	children [48]*header[T]
+}
+
+type node256[T any] struct {
+	header[T]
+	children [256]*header[T]
+}
+
+func newRoot[T any]() *header[T] {
+	n := &node4[T]{header: header[T]{watch: make(chan struct{})}}
+	n.setKind(nodeKind4)
+	return n.self()
+}
+
+func search[T any](root *header[T], key []byte) (value T, watch <-chan struct{}, ok bool) {
+	this := root
+	for {
+		// Consume the prefix
+		if !bytes.HasPrefix(key, this.prefix) {
+			return
+		}
+		key = key[len(this.prefix):]
+
+		if len(key) == 0 {
+			if this.leaf != nil {
+				value = this.leaf.value
+				watch = this.watch
+				ok = true
+			}
+			return
+		}
+
+		if this.kind() == nodeKind256 {
+			n256 := this.node256()
+			this = n256.children[key[0]]
+			if this == nil {
+				return
+			}
+		} else {
+			children := this.children()
+			idx := sort.Search(len(children), func(i int) bool {
+				return children[i].prefix[0] >= key[0]
+			})
+			if idx < len(children) && children[idx].prefix[0] == key[0] {
+				this = children[idx]
+			} else {
+				return
+			}
+		}
+	}
+}
+
+func commonPrefix(a, b []byte) []byte {
+	n := min(len(a), len(b))
+	for i := 0; i < n; i++ {
+		if a[i] != b[i] {
+			return a[:i]
+		}
+	}
+	return a[:n]
+}

--- a/part/ops.go
+++ b/part/ops.go
@@ -6,12 +6,33 @@ package part
 // Ops is the common operations that can be performed with a Tree
 // or Txn.
 type Ops[T any] interface {
+	// Len returns the number of objects in the tree.
 	Len() int
+
+	// Get fetches the value associated with the given key.
+	// Returns the value, a watch channel (which is closed on
+	// modification to the key) and boolean which is true if
+	// value was found.
 	Get(key []byte) (T, <-chan struct{}, bool)
+
+	// Prefix returns an iterator for all objects that starts with the
+	// given prefix, and a channel that closes when any objects matching
+	// the given prefix are upserted or deleted.
 	Prefix(key []byte) (*Iterator[T], <-chan struct{})
+
+	// LowerBound returns an iterator for all objects that have a
+	// key equal or higher than the given 'key'.
 	LowerBound(key []byte) *Iterator[T]
+
+	// RootWatch returns a watch channel for the root of the tree.
+	// Since this is the channel associated with the root, this closes
+	// when there are any changes to the tree.
 	RootWatch() <-chan struct{}
+
+	// Iterator returns an iterator for all objects.
 	Iterator() *Iterator[T]
+
+	// PrintTree to the standard output. For debugging.
 	PrintTree()
 }
 

--- a/part/ops.go
+++ b/part/ops.go
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package part
+
+// Ops is the common operations that can be performed with a Tree
+// or Txn.
+type Ops[T any] interface {
+	Len() int
+	Get(key []byte) (T, <-chan struct{}, bool)
+	Prefix(key []byte) (*Iterator[T], <-chan struct{})
+	LowerBound(key []byte) *Iterator[T]
+	RootWatch() <-chan struct{}
+	Iterator() *Iterator[T]
+	PrintTree()
+}
+
+var (
+	_ Ops[int] = &Tree[int]{}
+	_ Ops[int] = &Txn[int]{}
+)

--- a/part/part_test.go
+++ b/part/part_test.go
@@ -1,0 +1,547 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package part
+
+import (
+	"encoding/binary"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_commonPrefix(t *testing.T) {
+	check := func(a, b, common string) {
+		actual := string(commonPrefix([]byte(a), []byte(b)))
+		if actual != common {
+			t.Fatalf("expected commonPrefix(%q, %q) to equal %q, but got %q",
+				a, b, common, actual)
+		}
+	}
+
+	check("", "", "")
+	check("", "a", "")
+	check("a", "", "")
+	check("a", "a", "a")
+	check("a", "b", "")
+	check("abc", "d", "")
+	check("d", "abc", "")
+	check("ab", "abc", "ab")
+	check("abc", "ab", "ab")
+}
+
+func Test_search(t *testing.T) {
+	tree := New[[]byte](RootOnlyWatch)
+	_, _, tree = tree.Insert([]byte("a"), []byte("a"))
+	_, _, tree = tree.Insert([]byte("ba"), []byte("ba"))
+	_, _, tree = tree.Insert([]byte("bb"), []byte("bb"))
+	_, _, tree = tree.Insert([]byte("c"), []byte("c"))
+	_, _, tree = tree.Insert([]byte("ca"), []byte("ca"))
+
+	v, _, ok := tree.Get([]byte("nope"))
+	if ok {
+		t.Fatalf("found unexpected value: %v", v)
+	}
+
+	for _, key := range []string{"a", "ba", "bb"} {
+		v, _, ok = tree.Get([]byte(key))
+		if !ok || string(v) != key {
+			t.Fatalf("%q not found (%v) or mismatch %q", key, ok, v)
+		}
+	}
+}
+
+func intKey(n uint64) []byte {
+	return binary.BigEndian.AppendUint64(nil, n)
+}
+
+func Test_simple_delete(t *testing.T) {
+	tree := New[uint64]()
+	txn := tree.Txn()
+
+	_, hadOld := txn.Insert(intKey(1), 1)
+	require.False(t, hadOld)
+
+	_, hadOld = txn.Insert(intKey(2), 2)
+	require.False(t, hadOld)
+
+	_, hadOld = txn.Delete(intKey(1))
+	require.True(t, hadOld)
+
+	_, _, ok := txn.Get(intKey(1))
+	require.False(t, ok)
+}
+
+func Test_delete(t *testing.T) {
+	tree := New[uint64]()
+
+	// Do multiple rounds with the same tree.
+	for round := 0; round < 10; round++ {
+		// Use a random amount of keys in random order to exercise different
+		// tree structures each time.
+		numKeys := 10 + rand.Intn(5000)
+		t.Logf("numKeys=%d", numKeys)
+
+		keys := []uint64{}
+		for i := uint64(1); i < uint64(numKeys); i++ {
+			keys = append(keys, i)
+		}
+		hadOld := false
+
+		// Insert the keys in random order.
+		rand.Shuffle(len(keys), func(i, j int) {
+			keys[i], keys[j] = keys[j], keys[i]
+		})
+
+		txn := tree.Txn()
+		for _, i := range keys {
+			_, hadOld = txn.Insert(intKey(i), i)
+			assert.False(t, hadOld)
+			v, _, ok := txn.Get(intKey(i))
+			assert.True(t, ok)
+			assert.EqualValues(t, v, i)
+		}
+		tree = txn.Commit()
+		assert.Equal(t, len(keys), tree.Len())
+
+		// Delete the keys in random order.
+		rand.Shuffle(len(keys), func(i, j int) {
+			keys[i], keys[j] = keys[j], keys[i]
+		})
+
+		txn = tree.Txn()
+		for _, i := range keys {
+			_, _, ok := txn.Get(intKey(i))
+			assert.True(t, ok)
+			_, hadOld = txn.Delete(intKey(i))
+			assert.True(t, hadOld)
+			_, _, ok = txn.Get(intKey(i))
+			assert.False(t, ok)
+		}
+		tree = txn.Commit()
+		assert.Equal(t, 0, tree.Len())
+		for _, i := range keys {
+			_, _, ok := tree.Get(intKey(i))
+			assert.False(t, ok)
+		}
+
+		// And finally insert the keys back one more time
+		// in random order.
+		rand.Shuffle(len(keys), func(i, j int) {
+			keys[i], keys[j] = keys[j], keys[i]
+		})
+
+		txn = tree.Txn()
+		for _, i := range keys {
+			_, hadOld = txn.Insert(intKey(i), i)
+			assert.False(t, hadOld)
+			v, _, ok := txn.Get(intKey(i))
+			assert.True(t, ok)
+			assert.EqualValues(t, v, i)
+		}
+		tree = txn.Commit()
+		assert.Equal(t, len(keys), tree.Len())
+
+		// Do few rounds of lookups and deletions.
+		for step := 0; step < 2; step++ {
+			// Lookup with a Txn
+			txn = tree.Txn()
+			for _, i := range keys {
+				v, _, ok := txn.Get(intKey(i))
+				assert.True(t, ok)
+				assert.EqualValues(t, v, i)
+			}
+			txn = nil
+
+			// Test that full iteration is ordered
+			iter := tree.Iterator()
+			prev := uint64(0)
+			num := 0
+			for {
+				_, v, ok := iter.Next()
+				if !ok {
+					break
+				}
+				num++
+				require.Greater(t, v, prev)
+				prev = v
+			}
+			assert.Equal(t, num, len(keys))
+
+			// Test that lowerbound iteration is ordered and correct
+			prev = keys[len(keys)/2]
+			iter = tree.LowerBound(intKey(prev + 1))
+			for {
+				_, v, ok := iter.Next()
+				if !ok {
+					break
+				}
+				require.Greater(t, v, prev)
+				prev = v
+			}
+
+			// Test that prefix iteration is ordered and correct
+			prev = 0
+			iter, _ = tree.Prefix([]byte{})
+			for {
+				_, v, ok := iter.Next()
+				if !ok {
+					break
+				}
+				require.Greater(t, v, prev)
+				prev = v
+			}
+
+			// Remove half the keys
+			for _, k := range keys[:len(keys)/2] {
+				_, _, tree = tree.Delete(intKey(k))
+			}
+			keys = keys[len(keys)/2:]
+		}
+
+		// Remove everything remaining with iteration
+		txn = tree.Txn()
+		iter := txn.Iterator()
+		for k, _, ok := iter.Next(); ok; k, _, ok = iter.Next() {
+			_, hadOld = txn.Delete(k)
+			assert.True(t, hadOld)
+
+			_, _, ok := txn.Get(k)
+			assert.False(t, ok)
+		}
+
+		// Check that we can iterate with the transaction and
+		// everything is gone.
+		iter = txn.Iterator()
+		_, _, ok := iter.Next()
+		assert.False(t, ok)
+
+		tree = txn.Commit()
+
+		// Check that everything is gone after commit.
+		for _, i := range keys {
+			_, _, ok := tree.Get(intKey(i))
+			assert.False(t, ok)
+		}
+
+		assert.Equal(t, 0, tree.Len())
+	}
+}
+
+func Test_watch(t *testing.T) {
+	tree := New[[]byte]()
+	_, _, tree = tree.Insert([]byte("a"), []byte("a"))
+
+	_, watch, ok := tree.Get([]byte("a"))
+	if !ok {
+		t.Fatal("expected to find 'a'")
+	}
+	select {
+	case <-watch:
+		t.Fatal("did not expect watch to be closed")
+	default:
+	}
+
+	_, _, tree = tree.Insert([]byte("a"), []byte("b"))
+
+	select {
+	case <-watch:
+	case <-time.After(10 * time.Second):
+		t.Fatal("expected watch channel to close")
+	}
+
+	v, _, ok := tree.Get([]byte("a"))
+	if !ok {
+		t.Fatal("expected to find 'a'")
+	}
+	if string(v) != "b" {
+		t.Fatal("expected value 'b'")
+	}
+}
+
+func Test_insert(t *testing.T) {
+	tree := New[int]()
+	for i := 0; i < 10000; i++ {
+		key := binary.NativeEndian.AppendUint32(nil, uint32(i))
+		_, _, tree = tree.Insert(key, i)
+	}
+	for i := 0; i < 10000; i++ {
+		key := binary.NativeEndian.AppendUint32(nil, uint32(i))
+		_, _, ok := tree.Get(key)
+		if !ok {
+			t.Fatalf("%d not found", i)
+		}
+	}
+}
+
+func Test_prefix(t *testing.T) {
+	tree := New[[]byte]()
+	ins := func(s string) { _, _, tree = tree.Insert([]byte(s), []byte(s)) }
+	ins("a")
+	ins("ab")
+	ins("abc")
+	ins("abcd")
+
+	iter, _ := tree.Prefix([]byte("ab"))
+	k, v, ok := iter.Next()
+	assert.True(t, ok)
+	assert.Equal(t, []byte("ab"), k)
+	assert.Equal(t, []byte("ab"), v)
+
+	k, v, ok = iter.Next()
+	assert.True(t, ok)
+	assert.Equal(t, []byte("abc"), k)
+	assert.Equal(t, []byte("abc"), v)
+
+	k, v, ok = iter.Next()
+	assert.True(t, ok)
+	assert.Equal(t, []byte("abcd"), k)
+	assert.Equal(t, []byte("abcd"), v)
+
+	_, _, ok = iter.Next()
+	assert.False(t, ok)
+}
+
+func Test_txn(t *testing.T) {
+	tree := New[uint64]()
+	ins := func(n uint64) { _, _, tree = tree.Insert(intKey(n), n) }
+
+	var iter *Iterator[uint64]
+	next := func(exOK bool, exVal int) {
+		t.Helper()
+		_, v, ok := iter.Next()
+		if assert.Equal(t, exOK, ok) {
+			assert.EqualValues(t, exVal, v)
+		}
+	}
+
+	for i := 1; i <= 3; i++ {
+		ins(1)
+		ins(2)
+		ins(3)
+	}
+
+	txn := tree.Txn()
+	txn.Delete(intKey(2))
+	txn.Delete(intKey(3))
+	txn.Insert(intKey(4), 4)
+
+	iter = txn.Iterator()
+	next(true, 1)
+	next(true, 4)
+	next(false, 0)
+
+	_ = txn.Commit() // Ignore the new tree
+
+	// Original tree should be untouched.
+	for i := 1; i <= 3; i++ {
+		_, _, ok := tree.Get(intKey(uint64(i)))
+		assert.True(t, ok, "Get(%d)", i)
+	}
+
+	iter = tree.Iterator()
+	next(true, 1)
+	next(true, 2)
+	next(true, 3)
+	next(false, 0)
+}
+
+func Test_lowerbound(t *testing.T) {
+	tree := New[uint64]()
+	ins := func(n int) { _, _, tree = tree.Insert(intKey(uint64(n)), uint64(n)) }
+
+	// Insert 1..3
+	for i := 1; i <= 3; i++ {
+		ins(i)
+	}
+
+	var iter *Iterator[uint64]
+	next := func(exOK bool, exVal int) {
+		t.Helper()
+		_, v, ok := iter.Next()
+		require.Equal(t, exOK, ok)
+		require.EqualValues(t, exVal, v)
+	}
+
+	iter = tree.LowerBound([]byte{})
+	next(true, 1)
+	next(true, 2)
+	next(true, 3)
+	next(false, 0)
+
+	iter = tree.LowerBound(intKey(0))
+	next(true, 1)
+	next(true, 2)
+	next(true, 3)
+	next(false, 0)
+
+	iter = tree.LowerBound(intKey(3))
+	next(true, 3)
+	next(false, 0)
+
+	iter = tree.LowerBound(intKey(4))
+	next(false, 0)
+}
+
+func Test_iterate(t *testing.T) {
+	sizes := []int{0, 1, 10, 100, 1000, rand.Intn(1000)}
+	for _, size := range sizes {
+		tree := New[uint64]()
+		for i := 0; i < size; i++ {
+			_, _, tree = tree.Insert(intKey(uint64(i)), uint64(i))
+		}
+
+		iter := tree.LowerBound([]byte{})
+		i := uint64(0)
+		for _, obj, ok := iter.Next(); ok; _, obj, ok = iter.Next() {
+			if obj != uint64(i) {
+				t.Fatalf("expected %d,  got %d", i, obj)
+			}
+			i++
+		}
+		require.EqualValues(t, i, size)
+	}
+
+}
+
+func Benchmark_Insert_RootOnlyWatch(b *testing.B) {
+	benchmark_Insert(b, RootOnlyWatch)
+}
+
+func Benchmark_Insert(b *testing.B) {
+	benchmark_Insert(b)
+}
+
+func benchmark_Insert(b *testing.B, opts ...Option) {
+	numObjs := 1000
+	for n := 0; n < b.N; n++ {
+		tree := New[int](opts...)
+		txn := tree.Txn()
+		for i := 0; i < numObjs; i++ {
+			key := binary.BigEndian.AppendUint32(nil, uint32(numObjs+i))
+			txn.Insert(key, numObjs+i)
+		}
+		txn.Commit()
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(b.N*numObjs)/b.Elapsed().Seconds(), "objects/sec")
+}
+
+func Benchmark_Replace(b *testing.B) {
+	benchmark_Replace(b, true)
+}
+
+func Benchmark_Replace_RootOnlyWatch(b *testing.B) {
+	benchmark_Replace(b, false)
+}
+
+func benchmark_Replace(b *testing.B, watching bool) {
+	numObjs := 1000
+
+	tree := New[int](RootOnlyWatch)
+	txn := tree.Txn()
+	for i := 0; i < numObjs; i++ {
+		key := binary.BigEndian.AppendUint32(nil, uint32(numObjs+i))
+		txn.Insert(key, numObjs+i)
+	}
+
+	b.ResetTimer()
+	key := binary.BigEndian.AppendUint32(nil, uint32(0))
+	for n := 0; n < b.N; n++ {
+		txn.Insert(key, 0)
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "objects/sec")
+}
+
+func Benchmark_txn_1(b *testing.B) {
+	benchmark_txn_batch(b, 1)
+}
+
+func Benchmark_txn_10(b *testing.B) {
+	benchmark_txn_batch(b, 10)
+}
+
+func Benchmark_txn_100(b *testing.B) {
+	benchmark_txn_batch(b, 100)
+}
+
+func Benchmark_txn_1000(b *testing.B) {
+	benchmark_txn_batch(b, 1000)
+}
+
+func Benchmark_txn_10000(b *testing.B) {
+	benchmark_txn_batch(b, 10000)
+}
+
+func Benchmark_txn_100000(b *testing.B) {
+	benchmark_txn_batch(b, 100000)
+}
+
+func benchmark_txn_batch(b *testing.B, batchSize int) {
+	tree := New[int](RootOnlyWatch)
+	n := b.N
+	for n > 0 {
+		txn := tree.Txn()
+		for j := 0; j < batchSize; j++ {
+			txn.Insert(intKey(uint64(j)), j)
+		}
+		tree = txn.Commit()
+		n -= batchSize
+	}
+	txn := tree.Txn()
+	for j := 0; j < n; j++ {
+		txn.Insert(intKey(uint64(j)), j)
+	}
+	txn.Commit()
+	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "objects/sec")
+}
+
+func Benchmark_txn_delete_1(b *testing.B) {
+	benchmark_txn_delete_batch(b, 1)
+}
+
+func Benchmark_txn_delete_10(b *testing.B) {
+	benchmark_txn_delete_batch(b, 10)
+}
+
+func Benchmark_txn_delete_100(b *testing.B) {
+	benchmark_txn_delete_batch(b, 100)
+}
+
+func Benchmark_txn_delete_1000(b *testing.B) {
+	benchmark_txn_delete_batch(b, 1000)
+}
+
+func Benchmark_txn_delete_10000(b *testing.B) {
+	benchmark_txn_delete_batch(b, 10000)
+}
+
+func Benchmark_txn_delete_100000(b *testing.B) {
+	benchmark_txn_delete_batch(b, 100000)
+}
+
+func benchmark_txn_delete_batch(b *testing.B, batchSize int) {
+	tree := New[int](RootOnlyWatch)
+	for j := 0; j < batchSize; j++ {
+		_, _, tree = tree.Insert(intKey(uint64(j)), j)
+	}
+	b.ResetTimer()
+
+	n := b.N
+	for n > 0 {
+		txn := tree.Txn()
+		for j := 0; j < batchSize; j++ {
+			txn.Delete(intKey(uint64(j)))
+		}
+		n -= batchSize
+	}
+	txn := tree.Txn()
+	for j := 0; j < n; j++ {
+		txn.Delete(intKey(uint64(j)))
+	}
+	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "objects/sec")
+}

--- a/part/part_test.go
+++ b/part/part_test.go
@@ -277,6 +277,86 @@ func Test_insert(t *testing.T) {
 	}
 }
 
+func Test_replaceRoot(t *testing.T) {
+	tree := New[int]()
+	keyA := []byte{'a'}
+	keyB := []byte{'a', 'b'}
+	_, _, tree = tree.Insert(keyA, 1)
+	_, _, tree = tree.Insert(keyB, 3)
+	_, _, tree = tree.Delete(keyA)
+	_, _, tree = tree.Insert(keyA, 2)
+	val, _, ok := tree.Get(keyA)
+	if !ok || val != 2 {
+		t.Fatalf("%v not found", keyA)
+	}
+	val, _, ok = tree.Get(keyB)
+	if !ok || val != 3 {
+		t.Fatalf("%v not found", keyB)
+	}
+}
+
+func Test_deleteRoot(t *testing.T) {
+	tree := New[int]()
+	keyA := []byte{'a'}
+	_, _, tree = tree.Insert(keyA, 1)
+	_, _, tree = tree.Delete(keyA)
+	_, _, ok := tree.Get(keyA)
+	if ok {
+		t.Fatal("Root exists")
+	}
+}
+
+func Test_deleteIntermediate(t *testing.T) {
+	tree := New[int]()
+	keyA := []byte{'a'}
+	keyAB := []byte{'a', 'b'}
+	keyABC := []byte{'a', 'b', 'c'}
+	_, _, tree = tree.Insert(keyA, 1)
+	_, _, tree = tree.Insert(keyAB, 2)
+	_, _, tree = tree.Insert(keyABC, 3)
+	_, _, tree = tree.Delete(keyAB)
+	_, _, ok := tree.Get(keyA)
+	if !ok {
+		t.Fatal("A doesn't exist")
+	}
+	_, _, ok = tree.Get(keyAB)
+	if ok {
+		t.Fatal("AB exists")
+	}
+	_, _, ok = tree.Get(keyABC)
+	if !ok {
+		t.Fatal("ABC doesn't exist")
+	}
+}
+
+func Test_deleteNonExistantIntermediate(t *testing.T) {
+	tree := New[int]()
+	keyAB := []byte{'a', 'b'}
+	keyAC := []byte{'a', 'c'}
+	_, _, tree = tree.Insert(keyAB, 1)
+	_, _, tree = tree.Insert(keyAC, 2)
+	_, _, tree = tree.Delete([]byte{'a'})
+	_, _, ok := tree.Get(keyAB)
+	if !ok {
+		t.Fatal("AB doesn't exist")
+	}
+	_, _, ok = tree.Get(keyAC)
+	if !ok {
+		t.Fatal("AC doesn't exist")
+	}
+}
+
+func Test_deleteNonExistantCommonPrefix(t *testing.T) {
+	tree := New[int]()
+	keyAB := []byte{'a', 'b', 'c'}
+	_, _, tree = tree.Insert(keyAB, 1)
+	_, _, tree = tree.Delete([]byte{'a', 'b', 'e'})
+	_, _, ok := tree.Get(keyAB)
+	if !ok {
+		t.Fatal("AB doesn't exist")
+	}
+}
+
 func Test_prefix(t *testing.T) {
 	tree := New[[]byte]()
 	ins := func(s string) { _, _, tree = tree.Insert([]byte(s), []byte(s)) }
@@ -405,6 +485,20 @@ func Test_iterate(t *testing.T) {
 		require.EqualValues(t, i, size)
 	}
 
+}
+
+func Test_lowerbound_bigger(t *testing.T) {
+	tree := New[uint64]()
+	ins := func(n int) { _, _, tree = tree.Insert(intKey(uint64(n)), uint64(n)) }
+
+	// Insert 5..10
+	for i := 5; i <= 10; i++ {
+		ins(i)
+	}
+
+	iter := tree.LowerBound([]byte{4})
+	_, _, ok := iter.Next()
+	require.False(t, ok)
 }
 
 func Benchmark_Insert_RootOnlyWatch(b *testing.B) {

--- a/part/part_test.go
+++ b/part/part_test.go
@@ -114,10 +114,12 @@ func Test_delete(t *testing.T) {
 
 		txn = tree.Txn()
 		for _, i := range keys {
-			_, _, ok := txn.Get(intKey(i))
+			v, _, ok := txn.Get(intKey(i))
 			assert.True(t, ok)
-			_, hadOld = txn.Delete(intKey(i))
+			assert.EqualValues(t, v, i)
+			v, hadOld = txn.Delete(intKey(i))
 			assert.True(t, hadOld)
+			assert.EqualValues(t, v, i)
 			_, _, ok = txn.Get(intKey(i))
 			assert.False(t, ok)
 		}
@@ -258,7 +260,7 @@ func Test_watch(t *testing.T) {
 		t.Fatal("expected to find 'a'")
 	}
 	if string(v) != "b" {
-		t.Fatal("expected value 'b'")
+		t.Fatalf("expected value 'b', got '%s'", v)
 	}
 }
 
@@ -355,6 +357,20 @@ func Test_deleteNonExistantCommonPrefix(t *testing.T) {
 	if !ok {
 		t.Fatal("AB doesn't exist")
 	}
+}
+
+func Test_replace(t *testing.T) {
+	tree := New[int]()
+	key := binary.BigEndian.AppendUint32(nil, uint32(0))
+
+	var v int
+	var hadOld bool
+	_, hadOld, tree = tree.Insert(key, 1)
+	require.False(t, hadOld)
+
+	v, hadOld, tree = tree.Insert(key, 2)
+	require.True(t, hadOld)
+	require.EqualValues(t, 1, v)
 }
 
 func Test_prefix(t *testing.T) {

--- a/part/part_test.go
+++ b/part/part_test.go
@@ -485,6 +485,7 @@ func Test_lowerbound(t *testing.T) {
 func Test_iterate(t *testing.T) {
 	sizes := []int{0, 1, 10, 100, 1000, rand.Intn(1000)}
 	for _, size := range sizes {
+		t.Logf("size=%d", size)
 		tree := New[uint64]()
 		for i := 0; i < size; i++ {
 			_, _, tree = tree.Insert(intKey(uint64(i)), uint64(i))
@@ -499,6 +500,9 @@ func Test_iterate(t *testing.T) {
 			i++
 		}
 		require.EqualValues(t, i, size)
+
+		_, _, ok := iter.Next()
+		require.False(t, ok, "expected exhausted iterator to keep returning false")
 	}
 
 }

--- a/part/tree.go
+++ b/part/tree.go
@@ -3,81 +3,18 @@
 
 package part
 
+// Tree is a persistent (immutable) adaptive radix tree. It supports
+// map-like operations on values keyed by []byte and additionally
+// prefix searching and lower bound searching. Each node in the tree
+// has an associated channel that is closed when that node is mutated.
+// This allows watching any part of the tree (any prefix) for changes.
 type Tree[T any] struct {
 	opts *options
 	root *header[T]
-	size int
+	size int // the number of objects in the tree
 }
 
-func (t *Tree[T]) Txn() *Txn[T] {
-	txn := &Txn[T]{
-		opts:    t.opts,
-		root:    t.root,
-		size:    t.size,
-		mutated: make(map[*header[T]]struct{}),
-		watches: make(map[chan struct{}]struct{}),
-	}
-	return txn
-}
-
-func (t *Tree[T]) Len() int {
-	return t.size
-}
-
-func (t *Tree[T]) Get(key []byte) (T, <-chan struct{}, bool) {
-	value, watch, ok := search(t.root, key)
-	if t.opts.rootOnlyWatch {
-		watch = t.root.watch
-	}
-	return value, watch, ok
-}
-
-func (t *Tree[T]) Prefix(key []byte) (*Iterator[T], <-chan struct{}) {
-	iter, watch := prefixSearch(t.root, key)
-	if t.opts.rootOnlyWatch {
-		watch = t.root.watch
-	}
-	return iter, watch
-}
-
-func (t *Tree[T]) RootWatch() <-chan struct{} {
-	return t.root.watch
-}
-
-func (t *Tree[T]) LowerBound(key []byte) *Iterator[T] {
-	return lowerbound(t.root, key)
-}
-
-func (t *Tree[T]) Insert(key []byte, value T) (old T, hadOld bool, tree *Tree[T]) {
-	txn := t.Txn()
-	old, hadOld = txn.Insert(key, value)
-	tree = txn.Commit()
-	return
-}
-
-func (t *Tree[T]) Delete(key []byte) (old T, hadOld bool, tree *Tree[T]) {
-	txn := t.Txn()
-	old, hadOld = txn.Delete(key)
-	tree = txn.Commit()
-	return
-}
-
-func (t *Tree[T]) Iterator() *Iterator[T] {
-	return newIterator[T](t.root)
-}
-
-func (t *Tree[T]) PrintTree() {
-	t.root.printTree(0)
-}
-
-type options struct {
-	rootOnlyWatch bool
-}
-
-type Option func(*options)
-
-func RootOnlyWatch(o *options) { o.rootOnlyWatch = true }
-
+// New constructs a new tree.
 func New[T any](opts ...Option) *Tree[T] {
 	var o options
 	for _, opt := range opts {
@@ -88,4 +25,96 @@ func New[T any](opts ...Option) *Tree[T] {
 		size: 0,
 		opts: &o,
 	}
+}
+
+type Option func(*options)
+
+// RootOnlyWatch sets the tree to only have a watch channel on the root
+// node. This improves the speed at the cost of having a much more coarse
+// grained notifications.
+func RootOnlyWatch(o *options) { o.rootOnlyWatch = true }
+
+// Txn constructs a new transaction against the tree. Transactions
+// enable efficient large mutations of the tree by caching cloned
+// nodes.
+func (t *Tree[T]) Txn() *Txn[T] {
+	txn := &Txn[T]{
+		Tree:    *t,
+		mutated: make(map[*header[T]]struct{}),
+		watches: make(map[chan struct{}]struct{}),
+	}
+	return txn
+}
+
+// Len returns the number of objects in the tree.
+func (t *Tree[T]) Len() int {
+	return t.size
+}
+
+// Get fetches the value associated with the given key.
+// Returns the value, a watch channel (which is closed on
+// modification to the key) and boolean which is true if
+// value was found.
+func (t *Tree[T]) Get(key []byte) (T, <-chan struct{}, bool) {
+	value, watch, ok := search(t.root, key)
+	if t.opts.rootOnlyWatch {
+		watch = t.root.watch
+	}
+	return value, watch, ok
+}
+
+// Prefix returns an iterator for all objects that starts with the
+// given prefix, and a channel that closes when any objects matching
+// the given prefix are upserted or deleted.
+func (t *Tree[T]) Prefix(prefix []byte) (*Iterator[T], <-chan struct{}) {
+	iter, watch := prefixSearch(t.root, prefix)
+	if t.opts.rootOnlyWatch {
+		watch = t.root.watch
+	}
+	return iter, watch
+}
+
+// RootWatch returns a watch channel for the root of the tree.
+// Since this is the channel associated with the root, this closes
+// when there are any changes to the tree.
+func (t *Tree[T]) RootWatch() <-chan struct{} {
+	return t.root.watch
+}
+
+// LowerBound returns an iterator for all keys that have a value
+// equal to or higher than 'key'.
+func (t *Tree[T]) LowerBound(key []byte) *Iterator[T] {
+	return lowerbound(t.root, key)
+}
+
+// Insert inserts the key into the tree with the given value.
+// Returns the old value if it exists and a new tree.
+func (t *Tree[T]) Insert(key []byte, value T) (old T, hadOld bool, tree *Tree[T]) {
+	txn := t.Txn()
+	old, hadOld = txn.Insert(key, value)
+	tree = txn.Commit()
+	return
+}
+
+// Delete the given key from the tree.
+// Returns the old value if it exists and the new tree.
+func (t *Tree[T]) Delete(key []byte) (old T, hadOld bool, tree *Tree[T]) {
+	txn := t.Txn()
+	old, hadOld = txn.Delete(key)
+	tree = txn.Commit()
+	return
+}
+
+// Iterator returns an iterator for all objects.
+func (t *Tree[T]) Iterator() *Iterator[T] {
+	return newIterator[T](t.root)
+}
+
+// PrintTree to the standard output. For debugging.
+func (t *Tree[T]) PrintTree() {
+	t.root.printTree(0)
+}
+
+type options struct {
+	rootOnlyWatch bool
 }

--- a/part/tree.go
+++ b/part/tree.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package part
+
+type Tree[T any] struct {
+	opts *options
+	root *header[T]
+	size int
+}
+
+func (t *Tree[T]) Txn() *Txn[T] {
+	txn := &Txn[T]{
+		opts:    t.opts,
+		root:    t.root,
+		size:    t.size,
+		mutated: make(map[*header[T]]struct{}),
+		watches: make(map[chan struct{}]struct{}),
+	}
+	return txn
+}
+
+func (t *Tree[T]) Len() int {
+	return t.size
+}
+
+func (t *Tree[T]) Get(key []byte) (T, <-chan struct{}, bool) {
+	value, watch, ok := search(t.root, key)
+	if t.opts.rootOnlyWatch {
+		watch = t.root.watch
+	}
+	return value, watch, ok
+}
+
+func (t *Tree[T]) Prefix(key []byte) (*Iterator[T], <-chan struct{}) {
+	iter, watch := prefixSearch(t.root, key)
+	if t.opts.rootOnlyWatch {
+		watch = t.root.watch
+	}
+	return iter, watch
+}
+
+func (t *Tree[T]) RootWatch() <-chan struct{} {
+	return t.root.watch
+}
+
+func (t *Tree[T]) LowerBound(key []byte) *Iterator[T] {
+	return lowerbound(t.root, key)
+}
+
+func (t *Tree[T]) Insert(key []byte, value T) (old T, hadOld bool, tree *Tree[T]) {
+	txn := t.Txn()
+	old, hadOld = txn.Insert(key, value)
+	tree = txn.Commit()
+	return
+}
+
+func (t *Tree[T]) Delete(key []byte) (old T, hadOld bool, tree *Tree[T]) {
+	txn := t.Txn()
+	old, hadOld = txn.Delete(key)
+	tree = txn.Commit()
+	return
+}
+
+func (t *Tree[T]) Iterator() *Iterator[T] {
+	return newIterator[T](t.root)
+}
+
+func (t *Tree[T]) PrintTree() {
+	t.root.printTree(0)
+}
+
+type options struct {
+	rootOnlyWatch bool
+}
+
+type Option func(*options)
+
+func RootOnlyWatch(o *options) { o.rootOnlyWatch = true }
+
+func New[T any](opts ...Option) *Tree[T] {
+	var o options
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return &Tree[T]{
+		root: newRoot[T](),
+		size: 0,
+		opts: &o,
+	}
+}

--- a/part/tree.go
+++ b/part/tree.go
@@ -84,7 +84,7 @@ func New[T any](opts ...Option) *Tree[T] {
 		opt(&o)
 	}
 	return &Tree[T]{
-		root: newRoot[T](),
+		root: newNode4[T](),
 		size: 0,
 		opts: &o,
 	}

--- a/part/txn.go
+++ b/part/txn.go
@@ -153,7 +153,7 @@ func (txn *Txn[T]) insert(root *header[T], key []byte, value T) (oldValue T, had
 					hadOld = true
 				} else {
 					// This is a non-leaf node, create/replace the existing leaf.
-					this.leaf = newLeaf(txn.opts, key, fullKey, value)
+					this.setLeaf(newLeaf(txn.opts, key, fullKey, value))
 				}
 				return
 			}
@@ -267,7 +267,7 @@ func (txn *Txn[T]) delete(root *header[T], key []byte) (oldValue T, hadOld bool,
 			newRoot = newNode4[T]()
 		} else {
 			newRoot = txn.cloneNode(root)
-			newRoot.leaf = nil
+			newRoot.setLeaf(nil)
 		}
 		return
 	}
@@ -288,11 +288,11 @@ func (txn *Txn[T]) delete(root *header[T], key []byte) (oldValue T, hadOld bool,
 			// This is the node that we want to delete, but it has
 			// children. Clone and clear the leaf.
 			target.node = txn.cloneNode(target.node)
-			target.node.leaf = nil
+			target.node.setLeaf(nil)
 			children[target.index] = target.node
 		}
 
-		if target.node.size() == 0 && (target.node == this || target.node.leaf == nil) {
+		if target.node.size() == 0 && (target.node == this || target.node.getLeaf() == nil) {
 			// The node is empty, remove it from the parent.
 			parent.node.remove(target.index)
 		} else {

--- a/part/txn.go
+++ b/part/txn.go
@@ -255,7 +255,6 @@ type deleteParent[T any] struct {
 }
 
 func (txn *Txn[T]) delete(root *header[T], key []byte) (oldValue T, hadOld bool, newRoot *header[T]) {
-
 	// Reuse the same slice in the transaction to hold the parents in order to avoid
 	// allocations. Pre-allocate 32 levels to cover most of the use-cases without
 	// reallocation.
@@ -294,6 +293,11 @@ func (txn *Txn[T]) delete(root *header[T], key []byte) (oldValue T, hadOld bool,
 
 	oldValue = leaf.value
 	hadOld = true
+
+	// Mark the watch channel of the target node for closing.
+	if this.watch != nil {
+		txn.watches[this.watch] = struct{}{}
+	}
 
 	if this == root {
 		// Target is the root, clear it.

--- a/part/txn.go
+++ b/part/txn.go
@@ -1,0 +1,341 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package part
+
+import (
+	"bytes"
+)
+
+type Txn[T any] struct {
+	opts *options
+	root *header[T]
+	size int
+
+	// The set of nodes mutated in this transaction that we can keep
+	// mutating without cloning them again.
+	mutated map[*header[T]]struct{}
+
+	watches map[chan struct{}]struct{}
+
+	deleteParents []deleteParent[T]
+}
+
+func (txn *Txn[T]) Len() int {
+	return txn.size
+}
+
+func (txn *Txn[T]) Clone() *Txn[T] {
+	// Clear the mutated nodes so that the returned clone won't be changed by
+	// further modifications in this transaction.
+	clear(txn.mutated)
+	return &Txn[T]{
+		opts:          txn.opts,
+		root:          txn.root,
+		size:          txn.size,
+		mutated:       map[*header[T]]struct{}{},
+		watches:       map[chan struct{}]struct{}{},
+		deleteParents: nil,
+	}
+}
+
+func (txn *Txn[T]) Insert(key []byte, value T) (old T, hadOld bool) {
+	old, hadOld, txn.root = txn.insert(txn.root, key, value)
+	if !hadOld {
+		txn.size++
+	}
+	return
+}
+
+func (txn *Txn[T]) Delete(key []byte) (old T, hadOld bool) {
+	old, hadOld, txn.root = txn.delete(txn.root, key)
+	if hadOld {
+		txn.size--
+	}
+	return
+}
+
+func (txn *Txn[T]) RootWatch() <-chan struct{} {
+	return txn.root.watch
+}
+
+func (txn *Txn[T]) Get(key []byte) (T, <-chan struct{}, bool) {
+	value, watch, ok := search(txn.root, key)
+	if txn.opts.rootOnlyWatch {
+		watch = txn.root.watch
+	}
+	return value, watch, ok
+}
+
+func (txn *Txn[T]) Prefix(key []byte) (*Iterator[T], <-chan struct{}) {
+	txn.mutated = nil
+	iter, watch := prefixSearch(txn.root, key)
+	if txn.opts.rootOnlyWatch {
+		watch = txn.root.watch
+	}
+	return iter, watch
+}
+
+func (txn *Txn[T]) LowerBound(key []byte) *Iterator[T] {
+	txn.mutated = nil
+	return lowerbound(txn.root, key)
+}
+
+func (txn *Txn[T]) Iterator() *Iterator[T] {
+	txn.mutated = nil
+	return newIterator[T](txn.root)
+}
+
+func (txn *Txn[T]) Commit() *Tree[T] {
+	txn.mutated = nil
+	for ch := range txn.watches {
+		close(ch)
+	}
+	txn.watches = nil
+	return &Tree[T]{txn.opts, txn.root, txn.size}
+}
+
+func (txn *Txn[T]) CommitOnly() *Tree[T] {
+	txn.mutated = nil
+	return &Tree[T]{txn.opts, txn.root, txn.size}
+}
+
+func (txn *Txn[T]) Notify() {
+	for ch := range txn.watches {
+		close(ch)
+	}
+	txn.watches = nil
+}
+
+func (txn *Txn[T]) PrintTree() {
+	txn.root.printTree(0)
+}
+
+func (txn *Txn[T]) cloneNode(n *header[T]) *header[T] {
+	if _, ok := txn.mutated[n]; ok {
+		return n
+	}
+	if n.watch != nil {
+		txn.watches[n.watch] = struct{}{}
+	}
+	n = n.clone(!txn.opts.rootOnlyWatch || n == txn.root)
+	if txn.mutated == nil {
+		txn.mutated = make(map[*header[T]]struct{})
+	}
+	txn.mutated[n] = struct{}{}
+	return n
+}
+
+func (txn *Txn[T]) insert(root *header[T], key []byte, value T) (oldValue T, hadOld bool, newRoot *header[T]) {
+	fullKey := key
+	mkLeafNode := func(prefix []byte) *header[T] {
+		newLeaf := &node4[T]{}
+		newLeaf.leaf = &leaf[T]{key: fullKey, value: value}
+		newLeaf.setKind(nodeKind4)
+		if !txn.opts.rootOnlyWatch {
+			newLeaf.header.watch = make(chan struct{})
+		}
+		newLeaf.prefix = prefix
+		return newLeaf.self()
+	}
+
+	if root.size() == 0 && root.leaf == nil {
+		txn.watches[root.watch] = struct{}{}
+		newRoot = mkLeafNode(key)
+		if newRoot.watch == nil {
+			newRoot.watch = make(chan struct{})
+		}
+		return
+	}
+
+	newRoot = txn.cloneNode(root)
+	this := newRoot
+	thisp := &newRoot
+	for {
+		if bytes.HasPrefix(key, this.prefix) {
+			key = key[len(this.prefix):]
+			if len(key) == 0 {
+				if this.leaf != nil {
+					oldValue = this.leaf.value
+					hadOld = true
+
+					this.leaf.key = fullKey
+					this.leaf.value = value
+				} else {
+					this.leaf = &leaf[T]{key: fullKey, value: value}
+				}
+				return
+			}
+
+			child, idx := this.findIndex(key[0])
+
+			if child == nil || child.prefix[0] != key[0] {
+				// No node for this key, add it.
+				if this.size()+1 > this.cap() {
+					// too small, need to promote to a larger size.
+					if !txn.opts.rootOnlyWatch || this == newRoot {
+						txn.watches[this.watch] = struct{}{}
+					}
+					this = this.promote(!txn.opts.rootOnlyWatch || this == newRoot)
+				} else {
+					// it fits, just need a clone.
+					this = txn.cloneNode(this)
+				}
+				this.insert(idx, mkLeafNode(key).self())
+				*thisp = this
+				return
+			}
+
+			// Node exists, replace it with a clone and recurse into it.
+			child = txn.cloneNode(child)
+			if this.kind() == nodeKind256 {
+				thisp = &this.node256().children[idx]
+			} else {
+				thisp = &this.children()[idx]
+			}
+			*thisp = child
+			this = child
+		} else {
+			// Reached a node with a different prefix, split it.
+			newPrefix := commonPrefix(key, this.prefix)
+
+			this.prefix = this.prefix[len(newPrefix):]
+			key = key[len(newPrefix):]
+
+			newLeaf := mkLeafNode(key)
+			newNode := &node4[T]{
+				header: header[T]{prefix: newPrefix},
+			}
+			if this.prefix[0] < key[0] {
+				newNode.children[0] = this
+				newNode.children[1] = newLeaf
+			} else {
+				newNode.children[0] = newLeaf
+				newNode.children[1] = this
+			}
+			newNode.setKind(nodeKind4)
+			newNode.setSize(2)
+			if !txn.opts.rootOnlyWatch || this == newRoot {
+				newNode.header.watch = make(chan struct{})
+			}
+			*thisp = newNode.self()
+			return
+		}
+	}
+}
+
+type deleteParent[T any] struct {
+	node  *header[T]
+	index int
+}
+
+func (txn *Txn[T]) delete(root *header[T], key []byte) (oldValue T, hadOld bool, newRoot *header[T]) {
+	newRoot = root
+	this := root
+
+	// Reuse the same slice in the transaction to hold the parents in order to avoid
+	// allocations. Pre-allocate 32 levels to cover most of the use-cases without
+	// reallocation.
+	if txn.deleteParents == nil {
+		txn.deleteParents = make([]deleteParent[T], 0, 32)
+	}
+	parents := txn.deleteParents[:1] // Placeholder for root
+
+	// Find the target node and record the path to it.
+	for {
+		if bytes.HasPrefix(key, this.prefix) {
+			key = key[len(this.prefix):]
+			if len(key) == 0 {
+				if this.leaf == nil {
+					// Not found.
+					return
+				}
+				// Target node found!
+				break
+			}
+			var idx int
+			this, idx = this.findIndex(key[0])
+			if this == nil {
+				return
+			}
+			parents = append(parents, deleteParent[T]{this, idx})
+		} else {
+			// Reached a node with a different prefix, so node not found.
+			return
+		}
+	}
+
+	oldValue = this.leaf.value
+	hadOld = true
+
+	// The target was found, rebuild the tree from the root upwards.
+	newRoot = txn.cloneNode(root)
+	parents[0].node = newRoot
+
+	if this == root {
+		// Target is the root, clear it.
+		newRoot.leaf = nil
+		if newRoot.size() == 0 {
+			// No children so we can clear the prefix.
+			newRoot.prefix = nil
+		}
+		return
+	}
+
+	for i := len(parents) - 1; i > 0; i-- {
+		parent := &parents[i-1]
+		target := &parents[i]
+
+		// Clone the parent to mutate it.
+		parent.node = txn.cloneNode(parent.node)
+		children := parent.node.children()
+
+		if target.node == this && target.node.size() > 0 {
+			// This is the node that we want to delete, but it has
+			// children. Clone and clear the leaf.
+			target.node = txn.cloneNode(target.node)
+			target.node.leaf = nil
+			children[target.index] = target.node
+		}
+
+		if target.node.size() == 0 && (target.node == this || target.node.leaf == nil) {
+			// The node is empty, remove it from the parent.
+			parent.node.remove(target.index)
+		} else {
+			// Update target to point to the cloned node
+			children[target.index] = target.node
+		}
+
+		if parent.node.size() > 0 {
+			// Check if the node should be demoted.
+			// To avoid thrashing we don't demote at the boundary, but at a slightly
+			// smaller size.
+			// TODO: Can we avoid the initial clone of parent.node?
+			var newNode *header[T]
+			switch {
+			case parent.node.kind() == nodeKind256 && parent.node.size() <= 37:
+				newNode = (&node48[T]{header: *parent.node}).self()
+				newNode.setKind(nodeKind48)
+				children := newNode.node48().children[:0]
+				for _, n := range parent.node.node256().children[:] {
+					if n != nil {
+						children = append(children, n)
+					}
+				}
+			case parent.node.kind() == nodeKind48 && parent.node.size() <= 12:
+				newNode = (&node16[T]{header: *parent.node}).self()
+				newNode.setKind(nodeKind16)
+				copy(newNode.children()[:], parent.node.children())
+			case parent.node.kind() == nodeKind16 && parent.node.size() <= 3:
+				newNode = (&node4[T]{header: *parent.node}).self()
+				newNode.setKind(nodeKind4)
+				copy(newNode.children()[:], parent.node.children())
+			}
+			if newNode != nil {
+				parent.node = newNode
+			}
+		}
+	}
+
+	return
+}

--- a/reconciler/benchmark/main.go
+++ b/reconciler/benchmark/main.go
@@ -196,13 +196,14 @@ func main() {
 		}
 	}
 
+	runtime.GC()
+	var memAfter runtime.MemStats
+	runtime.ReadMemStats(&memAfter)
+
 	err = hive.Stop(context.TODO())
 	if err != nil {
 		panic(err)
 	}
-
-	var memAfter runtime.MemStats
-	runtime.ReadMemStats(&memAfter)
 
 	fmt.Printf("\n%d objects reconciled in %.2f seconds (batch size %d)\n",
 		*numObjects, float64(duration)/float64(time.Second), *batchSize)

--- a/types.go
+++ b/types.go
@@ -6,10 +6,9 @@ package statedb
 import (
 	"io"
 
-	iradix "github.com/hashicorp/go-immutable-radix/v2"
-
 	"github.com/cilium/statedb/index"
 	"github.com/cilium/statedb/internal"
+	"github.com/cilium/statedb/part"
 )
 
 type (
@@ -54,13 +53,6 @@ type Table[Obj any] interface {
 	// FirstWatch return the first matching object and a watch channel
 	// that is closed if the query is invalidated.
 	FirstWatch(ReadTxn, Query[Obj]) (obj Obj, rev Revision, watch <-chan struct{}, found bool)
-
-	// Last returns the last matching object.
-	Last(ReadTxn, Query[Obj]) (obj Obj, rev Revision, found bool)
-
-	// LastWatch returns the last matching object and a watch channel
-	// that is closed if the query is invalidated.
-	LastWatch(ReadTxn, Query[Obj]) (obj Obj, rev Revision, watch <-chan struct{}, found bool)
 
 	// LowerBound returns an iterator for objects that have a key
 	// greater or equal to the query. The returned watch channel is closed
@@ -338,15 +330,15 @@ type deleteTracker interface {
 }
 
 type indexEntry struct {
-	tree   *iradix.Tree[object]
-	txn    *iradix.Txn[object]
+	tree   *part.Tree[object]
+	txn    *part.Txn[object]
 	unique bool
 }
 
 type tableEntry struct {
 	meta           TableMeta
 	indexes        []indexEntry
-	deleteTrackers *iradix.Tree[deleteTracker]
+	deleteTrackers *part.Tree[deleteTracker]
 	revision       uint64
 	initializers   int // Number of table initializers pending
 }


### PR DESCRIPTION
Switch StateDB to use custom implementation of Persistent Adaptive Radix Trees (https://db.in.tum.de/~leis/papers/ART.pdf).

The implementation isn't a completely fateful implementation of the paper. The Node16 SIMD tricks and Node48 key array are skipped. This made the implementation simpler, but did leave some performance improvements on the table.

The only functional change to StateDB is to drop the `Last` and `LastWatch` methods since that requires an reverse iterator implementation and since we didn't use them we can just drop them for now.

Benchmark before:

```
goos: linux                                                                                                                                                                                     
goarch: amd64                                                                                                                                                                                   
pkg: github.com/cilium/statedb                                                                                                                                                                  
cpu: Intel(R) Core(TM) i5-10210U CPU @ 1.60GHz                                                                                                                                                  
BenchmarkDB_WriteTxn_1-8                                          307952              4012 ns/op            249227 objects/sec      3080 B/op         53 allocs/op                              
BenchmarkDB_WriteTxn_10-8                                         504811              2373 ns/op            421360 objects/sec      1501 B/op         23 allocs/op                              
BenchmarkDB_WriteTxn_100-8                                        522646              2229 ns/op            448544 objects/sec      1399 B/op         19 allocs/op                              
BenchmarkDB_WriteTxn_1000-8                                       369973              2954 ns/op            338547 objects/sec      1492 B/op         18 allocs/op                              
BenchmarkDB_WriteTxn_10000-8                                      995700              2792 ns/op            358210 objects/sec      1355 B/op         21 allocs/op                              
BenchmarkDB_WriteTxn_100_SecondaryIndex-8                         293709              3843 ns/op            260247 objects/sec      2208 B/op         33 allocs/op                              
BenchmarkDB_RandomInsert-8                                          1032           1192822 ns/op            838348 objects/sec    796015 B/op      12214 allocs/op                              
BenchmarkDB_RandomReplace-8                                          243           4906222 ns/op            203823 objects/sec   2382866 B/op      33380 allocs/op                              
BenchmarkDB_SequentialInsert-8                                       430           2770646 ns/op            360927 objects/sec   1492345 B/op      18256 allocs/op                              
BenchmarkDB_Baseline_SingleRadix_Insert-8                           3109            371203 ns/op           2693945 objects/sec    353662 B/op       5103 allocs/op                              
BenchmarkDB_Baseline_SingleRadix_TrackMutate_Insert-8               3105            373685 ns/op           2676056 objects/sec    353951 B/op       5106 allocs/op                              
BenchmarkDB_Baseline_SingleRadix_Lookup-8                          13185             90097 ns/op          11099219 objects/sec         0 B/op          0 allocs/op                              
BenchmarkDB_Baseline_Part_RootOnlyWatch_Insert-8                    5473            204824 ns/op           4882248 objects/sec    146969 B/op       3065 allocs/op                              
BenchmarkDB_Baseline_Part_Insert-8                                  4282            257142 ns/op           3888905 objects/sec    246580 B/op       4094 allocs/op                              
BenchmarkDB_Baseline_Part_Lookup-8                                 36069             33324 ns/op          30008204 objects/sec         0 B/op          0 allocs/op                              
BenchmarkDB_Baseline_Hashmap_Insert-8                              15986             74292 ns/op          13460333 objects/sec     86561 B/op         64 allocs/op                              
BenchmarkDB_Baseline_Hashmap_Lookup-8                              84038             14228 ns/op          70282379 objects/sec         0 B/op          0 allocs/op                              
BenchmarkDB_DeleteTracker_Baseline-8                                 385           3065639 ns/op            326197 objects/sec   1758394 B/op      23413 allocs/op                              
BenchmarkDB_DeleteTracker-8                                          192           6763615 ns/op            147850 objects/sec   3387030 B/op      40807 allocs/op                              
BenchmarkDB_RandomLookup-8                                          7114            153828 ns/op           6500774 objects/sec       144 B/op          1 allocs/op                              
BenchmarkDB_SequentialLookup-8                                      8168            142537 ns/op           7015728 objects/sec      8000 B/op       1000 allocs/op                              
BenchmarkDB_FullIteration_All-8                                   100930             11497 ns/op          86979024 objects/sec       280 B/op          6 allocs/op                              
BenchmarkDB_FullIteration_Get-8                                    81974             14355 ns/op          69661408 objects/sec       320 B/op          7 allocs/op
BenchmarkDB_PropagationDelay-8                                    243086              4838 ns/op                43.00 50th_µs           50.00 90th_µs          212.0 99th_µs        3083 B/op        50 allocs/op
```

Benchmark after:

```
BenchmarkDB_WriteTxn_1-8                                  380911              3093 ns/op            323322 objects/sec      2440 B/op         38 allocs/op
BenchmarkDB_WriteTxn_10-8                                 901350              1336 ns/op            748741 objects/sec       699 B/op         12 allocs/op
BenchmarkDB_WriteTxn_100-8                               1000000              1075 ns/op            930477 objects/sec       581 B/op          9 allocs/op
BenchmarkDB_WriteTxn_1000-8                              1000000              1262 ns/op            792304 objects/sec       578 B/op          9 allocs/op
BenchmarkDB_WriteTxn_10000-8                             1000000              1262 ns/op            792171 objects/sec       548 B/op          9 allocs/op
BenchmarkDB_WriteTxn_100_SecondaryIndex-8                 705823              1752 ns/op            570791 objects/sec       934 B/op         18 allocs/op
BenchmarkDB_RandomInsert-8                                  1563            743594 ns/op           1344819 objects/sec    481777 B/op       9162 allocs/op
BenchmarkDB_RandomReplace-8                                  530           2266878 ns/op            441135 objects/sec    932101 B/op      19170 allocs/op
BenchmarkDB_SequentialInsert-8                               970           1264837 ns/op            790616 objects/sec    578330 B/op       9168 allocs/op
BenchmarkDB_Baseline_Part_RootOnlyWatch_Insert-8            5121            220673 ns/op           4531599 objects/sec    146970 B/op       3065 allocs/op
BenchmarkDB_Baseline_Part_Insert-8                          4135            281535 ns/op           3551957 objects/sec    246583 B/op       4094 allocs/op
BenchmarkDB_Baseline_Part_Lookup-8                         35305             34346 ns/op          29115518 objects/sec         0 B/op          0 allocs/op
BenchmarkDB_Baseline_Hashmap_Insert-8                      14404             83092 ns/op          12034837 objects/sec     86549 B/op         64 allocs/op
BenchmarkDB_Baseline_Hashmap_Lookup-8                      77744             15222 ns/op          65694567 objects/sec         0 B/op          0 allocs/op
BenchmarkDB_DeleteTracker_Baseline-8                         945           1267367 ns/op            789038 objects/sec    648963 B/op      13062 allocs/op
BenchmarkDB_DeleteTracker-8                                  501           2361545 ns/op            423452 objects/sec   1176999 B/op      20188 allocs/op
BenchmarkDB_RandomLookup-8                                 13999             82787 ns/op          12079196 objects/sec       144 B/op          1 allocs/op
BenchmarkDB_SequentialLookup-8                             14426             77552 ns/op          12894616 objects/sec      8000 B/op       1000 allocs/op
BenchmarkDB_FullIteration_All-8                            86900             12131 ns/op          82435475 objects/sec       264 B/op          6 allocs/op
BenchmarkDB_FullIteration_Get-8                            75100             14046 ns/op          71195485 objects/sec       304 B/op          7 allocs/op
BenchmarkDB_PropagationDelay-8                            398498              3135 ns/op                27.00 50th_µs           32.00 90th_µs          170.0 99th_µs        1479 B/op         28 allocs/op
```

Highlights:
- WriteTxn_1 went from 250k/s to 323k/s
- WriteTxn_100 went from 448k/s to 930k/s
- RandomLookup from 700k/s to 1208k/s
- DeleteTracker up from 150k/s to 423k/s
- Propagation delay down from 43uS to 27uS (50th)
- Reconciler throughput up from ~200k/s to 350k/s, memory usage down 50%