### PR TITLE
Introduce Changes() API

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,11 +22,25 @@ jobs:
           fetch-depth: 0
       - name: test
         run: |
-          make test
+          echo '```' > results.comment
+          echo "$ make test" >> results.comment
+          make test 2>&1 | tee test.out
+          cat test.out | tail -20 >> results.comment
+          echo "-----" >> results.comment
+
       - name: test-race
         run: |
           make test-race
       - name: bench
         run: |
-          make bench
+          echo "$ make bench" >> results.comment
+          make bench 2>&1 | tee bench.out
+          cat bench.out >> results.comment
+          echo '```' >> results.comment
+          
+      - name: results
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          comment_tag: results
+          filePath: results.comment
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,14 +1,11 @@
 name: main
 on:
-  pull_request:
-    branches:
-    - main
   push:
     branches:
     - main
 
 env:
-  GO_VERSION: 1.21.3
+  GO_VERSION: 1.22.2
 
 jobs:
   test:
@@ -22,25 +19,5 @@ jobs:
           fetch-depth: 0
       - name: test
         run: |
-          echo '```' > results.comment
-          echo "$ make test" >> results.comment
-          make test 2>&1 | tee test.out
-          cat test.out | tail -20 >> results.comment
-          echo "-----" >> results.comment
-
-      - name: test-race
-        run: |
-          make test-race
-      - name: bench
-        run: |
-          echo "$ make bench" >> results.comment
-          make bench 2>&1 | tee bench.out
-          cat bench.out >> results.comment
-          echo '```' >> results.comment
-          
-      - name: results
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          comment_tag: results
-          filePath: results.comment
+          make all
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,43 @@
+name: pr
+on:
+  pull_request:
+    branches:
+    - main
+
+env:
+  GO_VERSION: 1.22.2
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: test
+        run: |
+          echo '```' > results.comment
+          echo "$ make test" >> results.comment
+          make test 2>&1 | tee test.out
+          cat test.out | tail -20 >> results.comment
+          echo "-----" >> results.comment
+
+      - name: test-race
+        run: |
+          make test-race
+      - name: bench
+        run: |
+          echo "$ make bench" >> results.comment
+          make bench 2>&1 | tee bench.out
+          cat bench.out >> results.comment
+          echo '```' >> results.comment
+          
+      - name: results
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          comment_tag: results
+          filePath: results.comment
+

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,19 @@
-.PHONY: all build test test-race bench bench-reconciler
+.PHONY: all build test test-race bench
 
-all: build test test-race bench bench-reconciler
+all: build test test-race bench
 
 build:
 	go build ./...
 
 test:
-	go test ./... -cover -test.count 1
+	go test ./... -cover -vet=all -test.count 1
 
 test-race:
 	go test -race ./... -test.count 1
 
 bench:
-	go test ./... -bench . -test.run xxx
+	go test ./... -bench . -benchmem -test.run xxx
+	go run ./reconciler/benchmark -quiet
 
 bench-reconciler:
 	go run ./reconciler/benchmark

--- a/deletetracker.go
+++ b/deletetracker.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cilium/statedb/index"
 )
 
-type DeleteTracker[Obj any] struct {
+type deleteTracker[Obj any] struct {
 	db          *DB
 	trackerName string
 	table       Table[Obj]
@@ -22,20 +22,20 @@ type DeleteTracker[Obj any] struct {
 
 // setRevision is called to set the starting low watermark when
 // this deletion tracker is inserted into the table.
-func (dt *DeleteTracker[Obj]) setRevision(rev uint64) {
+func (dt *deleteTracker[Obj]) setRevision(rev uint64) {
 	dt.revision.Store(rev)
 }
 
 // getRevision is called by the graveyard garbage collector to
 // compute the global low watermark.
-func (dt *DeleteTracker[Obj]) getRevision() uint64 {
+func (dt *deleteTracker[Obj]) getRevision() uint64 {
 	return dt.revision.Load()
 }
 
 // Deleted returns an iterator for deleted objects in this table starting from
 // 'minRevision'. The deleted objects are not garbage-collected unless 'Mark' is
 // called!
-func (dt *DeleteTracker[Obj]) Deleted(txn ReadTxn, minRevision Revision) Iterator[Obj] {
+func (dt *deleteTracker[Obj]) deleted(txn ReadTxn, minRevision Revision) Iterator[Obj] {
 	indexTxn := txn.getTxn().mustIndexReadTxn(dt.table, GraveyardRevisionIndexPos)
 	iter := indexTxn.LowerBound(index.Uint64(minRevision))
 	return &iterator[Obj]{iter}
@@ -43,7 +43,7 @@ func (dt *DeleteTracker[Obj]) Deleted(txn ReadTxn, minRevision Revision) Iterato
 
 // Mark the revision up to which deleted objects have been processed. This sets
 // the low watermark for deleted object garbage collection.
-func (dt *DeleteTracker[Obj]) Mark(upTo Revision) {
+func (dt *deleteTracker[Obj]) mark(upTo Revision) {
 	// Store the new low watermark and trigger a round of garbage collection.
 	dt.revision.Store(upTo)
 	select {
@@ -52,7 +52,7 @@ func (dt *DeleteTracker[Obj]) Mark(upTo Revision) {
 	}
 }
 
-func (dt *DeleteTracker[Obj]) Close() {
+func (dt *deleteTracker[Obj]) close() {
 	// Remove the delete tracker from the table.
 	txn := dt.db.WriteTxn(dt.table).getTxn()
 	db := txn.db
@@ -71,58 +71,6 @@ func (dt *DeleteTracker[Obj]) Close() {
 	case db.gcTrigger <- struct{}{}:
 	default:
 	}
-
-}
-
-// IterateWithError iterates updates and deletes to a table in revision order.
-//
-// The 'processFn' is called for each updated or deleted object in order. If an error
-// is returned by the function the iteration is stopped and the error is returned.
-// On further calls the processing continues from the next unprocessed (or error'd) revision.
-func (dt *DeleteTracker[Obj]) IterateWithError(txn ReadTxn, processFn func(obj Obj, deleted bool, rev Revision) error) (<-chan struct{}, error) {
-	upTo := dt.table.Revision(txn)
-	lastRevision := dt.revision.Load()
-
-	// Get all new and updated objects with revision number equal or
-	// higher than 'minRevision'.
-	// The returned watch channel watches the whole table and thus
-	// is closed when either insert or delete happens.
-	updatedIter, watch := dt.table.LowerBound(txn, ByRevision[Obj](lastRevision+1))
-
-	// Get deleted objects with revision equal or higher than 'minRevision'.
-	deletedIter := dt.Deleted(txn.getTxn(), lastRevision+1)
-
-	// Combine the iterators into one. This can be done as insert and delete
-	// both assign the object a new fresh monotonically increasing revision
-	// number.
-	iter := NewDualIterator[Obj](deletedIter, updatedIter)
-
-	for obj, rev, isDeleted, ok := iter.Next(); ok; obj, rev, isDeleted, ok = iter.Next() {
-		err := processFn(obj, isDeleted, rev)
-		if err != nil {
-			// Mark deleted objects processed up to previous revision since we may
-			// not have processed all objects with this revision fully yet.
-			dt.Mark(rev - 1)
-
-			// Processing failed, stop here and try again from this same revision.
-			return closedWatchChannel, err
-		}
-
-	}
-
-	// Fully processed up to latest table revision. GC deleted objects
-	// and return the next revision.
-	dt.Mark(upTo)
-	return watch, nil
-}
-
-// Iterate over updated and deleted objects in revision order.
-func (dt *DeleteTracker[Obj]) Iterate(txn ReadTxn, iterateFn func(obj Obj, deleted bool, rev Revision)) <-chan struct{} {
-	watch, _ := dt.IterateWithError(txn, func(obj Obj, deleted bool, rev Revision) error {
-		iterateFn(obj, deleted, rev)
-		return nil
-	})
-	return watch
 }
 
 var closedWatchChannel = func() <-chan struct{} {

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -44,10 +44,11 @@ func newDebugLogger(worker int) *debugLogger {
 }
 
 const (
-	numUniqueIDs    = 2000
-	numUniqueValues = 3000
+	numUniqueIDs    = 3000
+	numUniqueValues = 2000
 	numWorkers      = 20
-	numIterations   = 5000
+	numTrackers     = 5
+	numIterations   = 1000
 )
 
 type fuzzObj struct {
@@ -514,8 +515,8 @@ func TestDB_Fuzz(t *testing.T) {
 	// Start change trackers to observe changes.
 	stop := make(chan struct{})
 	var wg2 sync.WaitGroup
-	wg2.Add(3)
-	for i := 0; i < 3; i++ {
+	wg2.Add(numTrackers)
+	for i := 0; i < numTrackers; i++ {
 		i := i
 		go func() {
 			trackerWorker(i, stop)

--- a/graveyard.go
+++ b/graveyard.go
@@ -48,10 +48,7 @@ func graveyardWorker(db *DB, ctx context.Context, gcRateLimitInterval time.Durat
 			dtIter := table.deleteTrackers.Iterator()
 			for _, dt, ok := dtIter.Next(); ok; _, dt, ok = dtIter.Next() {
 				rev := dt.getRevision()
-				// If the revision is higher than zero than the tracker has been observed
-				// at least once. If it is zero, then no objects have been seen and thus
-				// we don't need to hold onto deleted objects for it.
-				if rev > 0 && rev < lowWatermark {
+				if rev < lowWatermark {
 					lowWatermark = rev
 				}
 			}

--- a/part/iterator.go
+++ b/part/iterator.go
@@ -111,22 +111,20 @@ loop:
 	for {
 		switch bytes.Compare(this.prefix, key[:min(len(key), len(this.prefix))]) {
 		case -1:
-			// Prefix is smaller, which means there is no node smaller than
-			// the given lowerbound.
-			return &Iterator[T]{nil}
+			// Prefix is smaller, stop here and return an iterator for
+			// the larger nodes in the parent's.
+			break loop
 
 		case 0:
 			if len(this.prefix) == len(key) {
 				// Exact match.
 				edges = append(edges, []*header[T]{this})
 				break loop
-			} else if len(key) == 0 {
-				// Search key exhausted, find the minimum node.
-				edges = traverseToMin(this, edges)
-				break loop
 			}
 
-			// Prefix matches, keep going.
+			// Prefix matches the beginning of the key, but more
+			// remains of the key. Drop the matching part and keep
+			// going further.
 			key = key[len(this.prefix):]
 
 			if this.kind() == nodeKind256 {

--- a/part/node.go
+++ b/part/node.go
@@ -212,24 +212,24 @@ func (n *header[T]) printTree(level int) {
 	var children []*header[T]
 	switch n.kind() {
 	case nodeKindLeaf:
-		fmt.Printf("leaf[%v]:", n.prefix)
+		fmt.Printf("leaf[%x]:", n.prefix)
 	case nodeKind4:
-		fmt.Printf("node4[%v]:", n.prefix)
+		fmt.Printf("node4[%x]:", n.prefix)
 		children = n.node4().children[:n.size()]
 	case nodeKind16:
-		fmt.Printf("node16[%v]:", n.prefix)
+		fmt.Printf("node16[%x]:", n.prefix)
 		children = n.node16().children[:n.size()]
 	case nodeKind48:
-		fmt.Printf("node48[%v]:", n.prefix)
+		fmt.Printf("node48[%x]:", n.prefix)
 		children = n.node48().children[:n.size()]
 	case nodeKind256:
-		fmt.Printf("node256[%v]:", n.prefix)
+		fmt.Printf("node256[%x]:", n.prefix)
 		children = n.node256().children[:]
 	default:
 		panic("unknown node kind")
 	}
 	if leaf := n.getLeaf(); leaf != nil {
-		fmt.Printf(" %v -> %v", leaf.key, leaf.value)
+		fmt.Printf(" %x -> %v", leaf.key, leaf.value)
 	}
 	fmt.Printf("(%p)\n", n)
 

--- a/part/part_test.go
+++ b/part/part_test.go
@@ -5,6 +5,7 @@ package part
 
 import (
 	"encoding/binary"
+	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -54,24 +55,28 @@ func Test_search(t *testing.T) {
 	}
 }
 
-func intKey(n uint64) []byte {
+func uint64Key(n uint64) []byte {
 	return binary.BigEndian.AppendUint64(nil, n)
+}
+
+func uint32Key(n uint32) []byte {
+	return binary.BigEndian.AppendUint32(nil, n)
 }
 
 func Test_simple_delete(t *testing.T) {
 	tree := New[uint64]()
 	txn := tree.Txn()
 
-	_, hadOld := txn.Insert(intKey(1), 1)
+	_, hadOld := txn.Insert(uint64Key(1), 1)
 	require.False(t, hadOld)
 
-	_, hadOld = txn.Insert(intKey(2), 2)
+	_, hadOld = txn.Insert(uint64Key(2), 2)
 	require.False(t, hadOld)
 
-	_, hadOld = txn.Delete(intKey(1))
+	_, hadOld = txn.Delete(uint64Key(1))
 	require.True(t, hadOld)
 
-	_, _, ok := txn.Get(intKey(1))
+	_, _, ok := txn.Get(uint64Key(1))
 	require.False(t, ok)
 }
 
@@ -79,10 +84,10 @@ func Test_delete(t *testing.T) {
 	tree := New[uint64]()
 
 	// Do multiple rounds with the same tree.
-	for round := 0; round < 10; round++ {
+	for round := 0; round < 100; round++ {
 		// Use a random amount of keys in random order to exercise different
 		// tree structures each time.
-		numKeys := 10 + rand.Intn(5000)
+		numKeys := 10 + rand.Intn(1000)
 		t.Logf("numKeys=%d", numKeys)
 
 		keys := []uint64{}
@@ -98,9 +103,9 @@ func Test_delete(t *testing.T) {
 
 		txn := tree.Txn()
 		for _, i := range keys {
-			_, hadOld = txn.Insert(intKey(i), i)
+			_, hadOld = txn.Insert(uint64Key(i), i)
 			assert.False(t, hadOld)
-			v, _, ok := txn.Get(intKey(i))
+			v, _, ok := txn.Get(uint64Key(i))
 			assert.True(t, ok)
 			assert.EqualValues(t, v, i)
 		}
@@ -114,20 +119,20 @@ func Test_delete(t *testing.T) {
 
 		txn = tree.Txn()
 		for _, i := range keys {
-			v, _, ok := txn.Get(intKey(i))
+			v, _, ok := txn.Get(uint64Key(i))
 			assert.True(t, ok)
 			assert.EqualValues(t, v, i)
-			v, hadOld = txn.Delete(intKey(i))
+			v, hadOld = txn.Delete(uint64Key(i))
 			assert.True(t, hadOld)
 			assert.EqualValues(t, v, i)
-			_, _, ok = txn.Get(intKey(i))
+			_, _, ok = txn.Get(uint64Key(i))
 			assert.False(t, ok)
 		}
 		tree = txn.Commit()
 
 		assert.Equal(t, 0, tree.Len())
 		for _, i := range keys {
-			_, _, ok := tree.Get(intKey(i))
+			_, _, ok := tree.Get(uint64Key(i))
 			assert.False(t, ok)
 		}
 
@@ -141,9 +146,9 @@ func Test_delete(t *testing.T) {
 
 		txn = tree.Txn()
 		for _, i := range keys {
-			_, hadOld = txn.Insert(intKey(i), i)
+			_, hadOld = txn.Insert(uint64Key(i), i)
 			assert.False(t, hadOld)
-			v, watch, ok := txn.Get(intKey(i))
+			v, watch, ok := txn.Get(uint64Key(i))
 			watches[i] = watch
 			assert.True(t, ok)
 			assert.EqualValues(t, v, i)
@@ -156,7 +161,7 @@ func Test_delete(t *testing.T) {
 			// Lookup with a Txn
 			txn = tree.Txn()
 			for _, i := range keys {
-				v, _, ok := txn.Get(intKey(i))
+				v, _, ok := txn.Get(uint64Key(i))
 				assert.True(t, ok)
 				assert.EqualValues(t, v, i)
 			}
@@ -178,15 +183,33 @@ func Test_delete(t *testing.T) {
 			assert.Equal(t, num, len(keys))
 
 			// Test that lowerbound iteration is ordered and correct
-			prev = keys[len(keys)/2]
-			iter = tree.LowerBound(intKey(prev + 1))
+			idx := len(keys) / 2
+			prev = keys[idx]
+			num = 0
+			start := prev + 1
+			iter = tree.LowerBound(uint64Key(start))
+			obs := []uint64{}
 			for {
 				_, v, ok := iter.Next()
 				if !ok {
 					break
 				}
+				num++
+				obs = append(obs, v)
 				require.Greater(t, v, prev)
 				prev = v
+			}
+			exp := 0
+			for _, k := range keys {
+				if k >= start {
+					exp++
+				}
+			}
+			if !assert.Equal(t, exp, num) {
+				t.Logf("LowerBound from %d failed", start)
+				t.Logf("observed: %v", obs)
+				tree.PrintTree()
+				t.Fatal()
 			}
 
 			// Test that prefix iteration is ordered and correct
@@ -203,7 +226,7 @@ func Test_delete(t *testing.T) {
 
 			// Remove half the keys
 			for _, k := range keys[:len(keys)/2] {
-				_, _, tree = tree.Delete(intKey(k))
+				_, _, tree = tree.Delete(uint64Key(k))
 			}
 			keys = keys[len(keys)/2:]
 		}
@@ -234,7 +257,7 @@ func Test_delete(t *testing.T) {
 
 		// Check that everything is gone after commit.
 		for _, i := range keys {
-			_, _, ok := tree.Get(intKey(i))
+			_, _, ok := tree.Get(uint64Key(i))
 			assert.False(t, ok)
 		}
 
@@ -412,7 +435,7 @@ func Test_prefix(t *testing.T) {
 
 func Test_txn(t *testing.T) {
 	tree := New[uint64]()
-	ins := func(n uint64) { _, _, tree = tree.Insert(intKey(n), n) }
+	ins := func(n uint64) { _, _, tree = tree.Insert(uint64Key(n), n) }
 
 	var iter *Iterator[uint64]
 	next := func(exOK bool, exVal int) {
@@ -430,9 +453,9 @@ func Test_txn(t *testing.T) {
 	}
 
 	txn := tree.Txn()
-	txn.Delete(intKey(2))
-	txn.Delete(intKey(3))
-	txn.Insert(intKey(4), 4)
+	txn.Delete(uint64Key(2))
+	txn.Delete(uint64Key(3))
+	txn.Insert(uint64Key(4), 4)
 
 	iter = txn.Iterator()
 	next(true, 1)
@@ -443,7 +466,7 @@ func Test_txn(t *testing.T) {
 
 	// Original tree should be untouched.
 	for i := 1; i <= 3; i++ {
-		_, _, ok := tree.Get(intKey(uint64(i)))
+		_, _, ok := tree.Get(uint64Key(uint64(i)))
 		assert.True(t, ok, "Get(%d)", i)
 	}
 
@@ -456,7 +479,7 @@ func Test_txn(t *testing.T) {
 
 func Test_lowerbound(t *testing.T) {
 	tree := New[uint64]()
-	ins := func(n int) { _, _, tree = tree.Insert(intKey(uint64(n)), uint64(n)) }
+	ins := func(n int) { _, _, tree = tree.Insert(uint64Key(uint64(n)), uint64(n)) }
 
 	// Insert 1..3
 	for i := 1; i <= 3; i++ {
@@ -477,18 +500,148 @@ func Test_lowerbound(t *testing.T) {
 	next(true, 3)
 	next(false, 0)
 
-	iter = tree.LowerBound(intKey(0))
+	iter = tree.LowerBound(uint64Key(0))
 	next(true, 1)
 	next(true, 2)
 	next(true, 3)
 	next(false, 0)
 
-	iter = tree.LowerBound(intKey(3))
+	iter = tree.LowerBound(uint64Key(3))
 	next(true, 3)
 	next(false, 0)
 
-	iter = tree.LowerBound(intKey(4))
+	iter = tree.LowerBound(uint64Key(4))
 	next(false, 0)
+}
+
+func Test_lowerbound_edge_cases(t *testing.T) {
+	tree := New[uint32]()
+	keys := []uint32{}
+	ins := func(n uint32) {
+		_, _, tree = tree.Insert(uint32Key(n), n)
+		keys = append(keys, n)
+		fmt.Printf("%x:\n", keys)
+		tree.root.printTree(2)
+	}
+
+	var iter *Iterator[uint32]
+	next := func(exOK bool, exVal uint32) {
+		t.Helper()
+		_, v, ok := iter.Next()
+		assert.Equal(t, exOK, ok)
+		require.Equal(t, exVal, v)
+	}
+
+	// Empty tree
+	iter = tree.LowerBound([]byte{})
+	next(false, 0)
+	iter = tree.LowerBound(uint32Key(0x1))
+	next(false, 0)
+
+	// case 0: Leaf at the root
+	ins(0x1)
+	iter = tree.LowerBound([]byte{})
+	next(true, 0x1)
+	next(false, 0)
+	iter = tree.LowerBound(uint32Key(0x1))
+	next(true, 0x1)
+	next(false, 0)
+	iter = tree.LowerBound(uint32Key(0x2))
+	next(false, 0)
+
+	// Two leafs, node4 root
+	ins(0x2)
+	iter = tree.LowerBound([]byte{})
+	next(true, 0x1)
+	next(true, 0x2)
+	next(false, 0)
+	iter = tree.LowerBound(uint32Key(0x2))
+	next(true, 0x2)
+	next(false, 0)
+	iter = tree.LowerBound(uint32Key(0x3))
+	next(false, 0)
+
+	// Different prefix
+	ins(0x0101)
+	iter = tree.LowerBound(uint32Key(0x100))
+	next(true, 0x101)
+	next(false, 0)
+
+	// case -1: Matching prefix (0x1??) but only smaller nodes behind it
+	ins(0x1100)
+	iter = tree.LowerBound(uint32Key(0x102))
+	next(true, 0x1100)
+	next(false, 0)
+
+	// Short search keys
+	ins(0x010000)
+
+	iter = tree.LowerBound([]byte{1})
+	next(false, 0)
+
+	iter = tree.LowerBound([]byte{0, 0})
+	next(true, 0x1)
+	next(true, 0x2)
+	next(true, 0x0101)
+	next(true, 0x1100)
+	next(true, 0x010000)
+	next(false, 0)
+
+	iter = tree.LowerBound([]byte{0, 1, 0})
+	next(true, 0x010000)
+	next(false, 0)
+
+	// Node256
+	fmt.Println("node256:")
+	for i := 1; i < 50; i += 2 { // add less than 256 for some holes in node256.children
+		n := uint32(0x20000 + i)
+		_, _, tree = tree.Insert(uint32Key(n), n)
+		keys = append(keys, n)
+	}
+	tree.PrintTree()
+
+	iter = tree.LowerBound(uint32Key(0x20000))
+	for i := 1; i < 50; i += 2 {
+		n := uint32(0x20000 + i)
+		next(true, n)
+	}
+	next(false, 0)
+
+	iter = tree.LowerBound([]byte{})
+	for i := range keys {
+		next(true, keys[i])
+	}
+	next(false, 0)
+
+}
+
+func Test_lowerbound_regression(t *testing.T) {
+	// Regression test for bug in lowerbound() where the lowerbound search ended up
+	// in a smaller node and thought there were no larger nodes in the tree to iterate
+	// over.
+
+	tree := New[uint64]()
+	ins := func(n uint64) { _, _, tree = tree.Insert(uint64Key(uint64(n)), uint64(n)) }
+
+	values := []uint64{
+		70370, // ... 1 18 226
+		70411, // ... 1 19 11
+		70412,
+	}
+
+	for _, v := range values {
+		ins(v)
+	}
+
+	tree.PrintTree()
+
+	iter := tree.LowerBound(uint64Key(70399))
+	i := 1
+	for _, obj, ok := iter.Next(); ok; _, obj, ok = iter.Next() {
+		require.Equal(t, values[i], obj)
+		i++
+	}
+	require.Equal(t, len(values), i)
 }
 
 func Test_iterate(t *testing.T) {
@@ -497,7 +650,7 @@ func Test_iterate(t *testing.T) {
 		t.Logf("size=%d", size)
 		tree := New[uint64]()
 		for i := 0; i < size; i++ {
-			_, _, tree = tree.Insert(intKey(uint64(i)), uint64(i))
+			_, _, tree = tree.Insert(uint64Key(uint64(i)), uint64(i))
 		}
 
 		iter := tree.LowerBound([]byte{})
@@ -518,7 +671,7 @@ func Test_iterate(t *testing.T) {
 
 func Test_lowerbound_bigger(t *testing.T) {
 	tree := New[uint64]()
-	ins := func(n int) { _, _, tree = tree.Insert(intKey(uint64(n)), uint64(n)) }
+	ins := func(n int) { _, _, tree = tree.Insert(uint64Key(uint64(n)), uint64(n)) }
 
 	// Insert 5..10
 	for i := 5; i <= 10; i++ {
@@ -610,14 +763,14 @@ func benchmark_txn_batch(b *testing.B, batchSize int) {
 	for n > 0 {
 		txn := tree.Txn()
 		for j := 0; j < batchSize; j++ {
-			txn.Insert(intKey(uint64(j)), j)
+			txn.Insert(uint64Key(uint64(j)), j)
 		}
 		tree = txn.Commit()
 		n -= batchSize
 	}
 	txn := tree.Txn()
 	for j := 0; j < n; j++ {
-		txn.Insert(intKey(uint64(j)), j)
+		txn.Insert(uint64Key(uint64(j)), j)
 	}
 	txn.Commit()
 	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "objects/sec")
@@ -650,7 +803,7 @@ func Benchmark_txn_delete_100000(b *testing.B) {
 func benchmark_txn_delete_batch(b *testing.B, batchSize int) {
 	tree := New[int](RootOnlyWatch)
 	for j := 0; j < batchSize; j++ {
-		_, _, tree = tree.Insert(intKey(uint64(j)), j)
+		_, _, tree = tree.Insert(uint64Key(uint64(j)), j)
 	}
 	b.ResetTimer()
 
@@ -658,13 +811,13 @@ func benchmark_txn_delete_batch(b *testing.B, batchSize int) {
 	for n > 0 {
 		txn := tree.Txn()
 		for j := 0; j < batchSize; j++ {
-			txn.Delete(intKey(uint64(j)))
+			txn.Delete(uint64Key(uint64(j)))
 		}
 		n -= batchSize
 	}
 	txn := tree.Txn()
 	for j := 0; j < n; j++ {
-		txn.Delete(intKey(uint64(j)))
+		txn.Delete(uint64Key(uint64(j)))
 	}
 	b.ReportMetric(float64(b.N)/b.Elapsed().Seconds(), "objects/sec")
 }

--- a/types.go
+++ b/types.go
@@ -352,6 +352,7 @@ type anyIndexer struct {
 type anyDeleteTracker interface {
 	setRevision(uint64)
 	getRevision() uint64
+	close()
 }
 
 type indexEntry struct {


### PR DESCRIPTION
DeleteTracker() is confusing to users. It is essentially just providing an iterator for updates and deletes, so let's call it that: Changes().

```
var tbl Table[*Foo]
iter, err := tbl.Changes(db.ReadTxn())
if err != nil { return }
defer iter.Close()

for {
  for ev, rev, ok := iter.Next(); ok; ev, rev, ok = iter.Next() {
    if ev.Deleted {
      // ev.Object deleted
    } else {
      // ev.Object created or updated
    }

  }
  select {
  case <-ctx.Done():
    return
  case <-iter.Watch():
  }
}
```

Functional difference to before is that this does not allow "reiterating" as one could do with DeleteTracker's IterateWithError that stops on error and allows picking up iteration again to retry. But that's not needed with Changes() as the caller can take care of retrying the failed event before iterating again.