### PR TITLE
[DRAFT] Rename Get() to Select() and First() to Get()

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -347,7 +347,7 @@ func BenchmarkDB_RandomLookup(b *testing.B) {
 	for j := 0; j < b.N; j++ {
 		txn := db.ReadTxn()
 		for _, q := range queries {
-			_, _, ok := table.First(txn, q)
+			_, _, ok := table.Get(txn, q)
 			if !ok {
 				b.Fatal("object not found")
 			}
@@ -371,7 +371,7 @@ func BenchmarkDB_SequentialLookup(b *testing.B) {
 	txn := db.ReadTxn()
 	for n := 0; n < b.N; n++ {
 		for _, id := range ids {
-			obj, _, ok := table.First(txn, idIndex.Query(id))
+			obj, _, ok := table.Get(txn, idIndex.Query(id))
 			if !ok {
 				b.Fatalf("Object not found")
 			}
@@ -420,7 +420,7 @@ func BenchmarkDB_FullIteration_Get(b *testing.B) {
 
 	for j := 0; j < b.N; j++ {
 		txn := db.ReadTxn()
-		iter, _ := table.Get(txn, tagsIndex.Query("foo"))
+		iter := table.Select(txn, tagsIndex.Query("foo"))
 		i := uint64(0)
 		for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
 			if obj.ID != i {

--- a/derive.go
+++ b/derive.go
@@ -90,7 +90,7 @@ func (d derive[In, Out]) loop(ctx context.Context, health cell.Health) error {
 				case DeriveInsert:
 					_, _, err = out.Insert(wtxn, outObj)
 				case DeriveUpdate:
-					_, _, found := out.First(wtxn, out.PrimaryIndexer().QueryFromObject(outObj))
+					_, _, found := out.Get(wtxn, out.PrimaryIndexer().QueryFromObject(outObj))
 					if found {
 						_, _, err = out.Insert(wtxn, outObj)
 					}

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -230,15 +230,15 @@ func allAction(ctx actionContext) {
 	ctx.log.log("%s: All => %d found", ctx.table.Name(), len(statedb.Collect(iter)))
 }
 
-func getAction(ctx actionContext) {
+func selectAction(ctx actionContext) {
 	id := mkID()
-	iter, _ := ctx.table.Get(ctx.txn, idIndex.Query(mkID()))
-	ctx.log.log("%s: Get(%d) => %d found", ctx.table.Name(), id, len(statedb.Collect(iter)))
+	iter := ctx.table.Select(ctx.txn, idIndex.Query(mkID()))
+	ctx.log.log("%s: Select(%d) => %d found", ctx.table.Name(), id, len(statedb.Collect(iter)))
 }
 
-func firstAction(ctx actionContext) {
+func getAction(ctx actionContext) {
 	id := mkID()
-	obj, rev, ok := ctx.table.First(ctx.txn, idIndex.Query(id))
+	obj, rev, ok := ctx.table.Get(ctx.txn, idIndex.Query(id))
 
 	if e, ok2 := ctx.txnLog.latest[tableAndID{ctx.table.Name(), id}]; ok2 {
 		if e.act == actInsert {
@@ -254,7 +254,7 @@ func firstAction(ctx actionContext) {
 			}
 		}
 	}
-	ctx.log.log("%s: First(%d) => rev=%d, ok=%v", ctx.table.Name(), id, rev, ok)
+	ctx.log.log("%s: Get(%d) => rev=%d, ok=%v", ctx.table.Name(), id, rev, ok)
 }
 
 func lastAction(ctx actionContext) {
@@ -284,9 +284,9 @@ var actions = []action{
 
 	deleteAllAction,
 
-	firstAction, firstAction, firstAction, firstAction, firstAction,
+	getAction, getAction, getAction, getAction, getAction,
 	allAction, lowerboundAction,
-	getAction, getAction, getAction,
+	selectAction, selectAction, selectAction,
 	lastAction, lastAction,
 	prefixAction,
 }

--- a/reconciler/benchmark/main.go
+++ b/reconciler/benchmark/main.go
@@ -171,7 +171,7 @@ func main() {
 	// Wait for all to be reconciled by waiting for the last added objects to be marked
 	// reconciled. This only works here since none of the operations fail.
 	for {
-		obj, _, watch, ok := testObjects.FirstWatch(db.ReadTxn(), idIndex.Query(id-1))
+		obj, _, watch, ok := testObjects.GetWatch(db.ReadTxn(), idIndex.Query(id-1))
 		if ok && obj.status.Kind == reconciler.StatusKindDone {
 			break
 		}

--- a/reconciler/example/main.go
+++ b/reconciler/example/main.go
@@ -192,7 +192,7 @@ func registerHTTPServer(
 			w.WriteHeader(http.StatusOK)
 
 		case "DELETE":
-			memo, _, ok := memos.First(txn, MemoNameIndex.Query(name))
+			memo, _, ok := memos.Get(txn, MemoNameIndex.Query(name))
 			if !ok {
 				w.WriteHeader(http.StatusNotFound)
 				return

--- a/reconciler/incremental.go
+++ b/reconciler/incremental.go
@@ -204,7 +204,7 @@ func (round *incrementalRound[Obj]) processRetries() {
 		}
 		round.retries.Pop()
 
-		obj, rev, ok := round.table.First(round.txn, round.primaryIndexer.QueryFromObject(robj.(Obj)))
+		obj, rev, ok := round.table.Get(round.txn, round.primaryIndexer.QueryFromObject(robj.(Obj)))
 		if !ok {
 			// Object has been deleted unexpectedly (e.g. from outside
 			// the reconciler). Assume that it can be forgotten about.

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -89,8 +89,8 @@ func WaitForReconciliation[Obj any](ctx context.Context, db *statedb.DB, table s
 		txn := db.ReadTxn()
 
 		// See if there are any pending or error'd objects.
-		_, _, watchPending, okPending := table.FirstWatch(txn, statusIndex.Query(StatusKindPending))
-		_, _, watchError, okError := table.FirstWatch(txn, statusIndex.Query(StatusKindError))
+		_, _, watchPending, okPending := table.GetWatch(txn, statusIndex.Query(StatusKindPending))
+		_, _, watchError, okError := table.GetWatch(txn, statusIndex.Query(StatusKindError))
 		if !okPending && !okError {
 			return nil
 		}

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -499,12 +499,12 @@ func (h testHelper) markForDelete(id uint64) {
 
 func (h testHelper) expectStatus(id uint64, kind reconciler.StatusKind, err string) {
 	cond := func() bool {
-		obj, _, ok := h.tbl.First(h.db.ReadTxn(), idIndex.Query(id))
+		obj, _, ok := h.tbl.Get(h.db.ReadTxn(), idIndex.Query(id))
 		return ok && obj.status.Kind == kind && obj.status.Error == err
 	}
 	if !assert.Eventually(h.t, cond, time.Second, time.Millisecond) {
 		actual := "<not found>"
-		obj, _, ok := h.tbl.First(h.db.ReadTxn(), idIndex.Query(id))
+		obj, _, ok := h.tbl.Get(h.db.ReadTxn(), idIndex.Query(id))
 		if ok {
 			actual = string(obj.status.Kind)
 		}
@@ -517,7 +517,7 @@ func (h testHelper) expectStatus(id uint64, kind reconciler.StatusKind, err stri
 func (h testHelper) expectNotFound(id uint64) {
 	h.t.Helper()
 	cond := func() bool {
-		_, _, ok := h.tbl.First(h.db.ReadTxn(), idIndex.Query(id))
+		_, _, ok := h.tbl.Get(h.db.ReadTxn(), idIndex.Query(id))
 		return !ok
 	}
 	require.Eventually(h.t, cond, time.Second, time.Millisecond, "expected object %d to not be found", id)

--- a/regression_test.go
+++ b/regression_test.go
@@ -50,26 +50,26 @@ func Test_Regression_29324(t *testing.T) {
 
 	// Exact match should only return "foo"
 	txn := db.ReadTxn()
-	iter, _ := table.Get(txn, idIndex.Query("foo"))
+	iter := table.Select(txn, idIndex.Query("foo"))
 	items := Collect(iter)
 	if assert.Len(t, items, 1, "Get(\"foo\") should return one match") {
 		assert.EqualValues(t, "foo", items[0].ID)
 	}
 
 	// Partial match on prefix should not return anything
-	iter, _ = table.Get(txn, idIndex.Query("foob"))
+	iter = table.Select(txn, idIndex.Query("foob"))
 	items = Collect(iter)
 	assert.Len(t, items, 0, "Get(\"foob\") should return nothing")
 
 	// Query on non-unique index should only return exact match
-	iter, _ = table.Get(txn, tagIndex.Query("aa"))
+	iter = table.Select(txn, tagIndex.Query("aa"))
 	items = Collect(iter)
 	if assert.Len(t, items, 1, "Get(\"aa\") on tags should return one match") {
 		assert.EqualValues(t, "foo", items[0].ID)
 	}
 
 	// Partial match on prefix should not return anything on non-unique index
-	iter, _ = table.Get(txn, idIndex.Query("a"))
+	iter = table.Select(txn, idIndex.Query("a"))
 	items = Collect(iter)
 	assert.Len(t, items, 0, "Get(\"a\") should return nothing")
 

--- a/types.go
+++ b/types.go
@@ -43,17 +43,26 @@ type Table[Obj any] interface {
 	// channel that is closed when the table changes.
 	All(ReadTxn) (Iterator[Obj], <-chan struct{})
 
-	// Get returns an iterator for all objects matching the given query
+	// Select returns an iterator for all objects matching the given query.
+	//
+	// If one or more optional filter function is given, then only objects for
+	// which all filters return true are emitted.
+	Select(txn ReadTxn, query Query[Obj], filters ...func(Obj) bool) Iterator[Obj]
+
+	// Select returns an iterator for all objects matching the given query
 	// and a watch channel that is closed if the query results are
 	// invalidated by a write to the table.
-	Get(ReadTxn, Query[Obj]) (Iterator[Obj], <-chan struct{})
+	//
+	// If one or more optional filter function is given, then only objects for
+	// which all filters return true are emitted.
+	SelectWatch(txn ReadTxn, query Query[Obj], filters ...func(Obj) bool) (Iterator[Obj], <-chan struct{})
 
-	// First returns the first matching object for the query.
-	First(ReadTxn, Query[Obj]) (obj Obj, rev Revision, found bool)
+	// Get returns the first matching object for the query.
+	Get(ReadTxn, Query[Obj]) (obj Obj, rev Revision, found bool)
 
-	// FirstWatch return the first matching object and a watch channel
+	// GetWatch return the first matching object and a watch channel
 	// that is closed if the query is invalidated.
-	FirstWatch(ReadTxn, Query[Obj]) (obj Obj, rev Revision, watch <-chan struct{}, found bool)
+	GetWatch(ReadTxn, Query[Obj]) (obj Obj, rev Revision, watch <-chan struct{}, found bool)
 
 	// Last returns the last matching object.
 	Last(ReadTxn, Query[Obj]) (obj Obj, rev Revision, found bool)


### PR DESCRIPTION
Playing around with slightly nicer query method names. WDYT?

---
Rename Get() to Select()/SelectWatch and First() to Get(), and FirstWatch to GetWatch().

```
  iter := tbl.Select(txn, Index.Query("foo"))
  iter, watch := tbl.SelectWatch(txn, Index.Query("foo"))
  iter, watch := tbl.SelectWatch(txn, Index.Query("foo"), func(obj *Object) bool { return obj.IsValid })

  obj, rev, ok := tbl.Get(txn, Index.Query("foo"))
  obj, rev, watch, ok := tbl.GetWatch(txn, Index.Query("foo"))
```

And add support for specifying filters alongside query:
```
  func (obj *Object) isValid() bool { ... }

  iter := tbl.Select(txn, Index.Query("foo"))
  iter = statedb.Filter(iter, Object.isValid)

  // above can be expressed as:

  iter := tbl.Select(
    txn,
    Index.Query("foo"),
    Object.isValid,
  )
```