### PR TITLE
Fix http test and add SetTransport

### DIFF
--- a/http.go
+++ b/http.go
@@ -17,7 +17,7 @@ func (db *DB) HTTPHandler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /dump", h.dumpAll)
 	mux.HandleFunc("GET /dump/{table}", h.dumpTable)
-	mux.HandleFunc("/query", h.query)
+	mux.HandleFunc("GET /query", h.query)
 	return mux
 }
 

--- a/http_client.go
+++ b/http_client.go
@@ -62,7 +62,7 @@ func (t *RemoteTable[Obj]) query(ctx context.Context, lowerBound bool, q Query[O
 	}
 
 	url := t.base.JoinPath("/query")
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url.String(), bytes.NewBuffer(bs))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), bytes.NewBuffer(bs))
 	if err != nil {
 		errChanSend <- err
 		return

--- a/http_test.go
+++ b/http_test.go
@@ -67,7 +67,7 @@ func Test_http_dump(t *testing.T) {
 	require.Len(t, test, tbl.NumObjects(db.ReadTxn()))
 }
 
-func Test_runQuery(t *testing.T) {
+func Test_http_runQuery(t *testing.T) {
 	db, table, _ := httpFixture(t)
 	txn := db.ReadTxn()
 
@@ -109,7 +109,7 @@ func Test_runQuery(t *testing.T) {
 	}
 }
 
-func Test_RemoteTable(t *testing.T) {
+func Test_http_RemoteTable(t *testing.T) {
 	ctx := context.TODO()
 	_, table, ts := httpFixture(t)
 


### PR DESCRIPTION
Finish the http /dump test.
Add SetTransport to `RemoteTable[Obj]` to allow cilium-dbg to override the transport for doing requests over UNIX socket.
Switch "POST /query" to "GET /query"