### PR TITLE
part: Optimizations to node layout

### DIFF
--- a/part/cache.go
+++ b/part/cache.go
@@ -1,0 +1,37 @@
+package part
+
+import "unsafe"
+
+const nodeMutatedSize = 32 // must be power-of-two
+
+type nodeMutated[T any] struct {
+	ptrs [nodeMutatedSize]*header[T]
+	used bool
+}
+
+func (p *nodeMutated[T]) put(ptr *header[T]) {
+	ptrInt := uintptr(unsafe.Pointer(ptr))
+	p.ptrs[slot(ptrInt)] = ptr
+	p.used = true
+}
+
+func (p *nodeMutated[T]) exists(ptr *header[T]) bool {
+	ptrInt := uintptr(unsafe.Pointer(ptr))
+	return p.ptrs[slot(ptrInt)] == ptr
+}
+
+func slot(p uintptr) int {
+	var slot uint8
+	// use some relevant bits from the pointer
+	slot = slot + uint8(p>>4)
+	slot = slot + uint8(p>>12)
+	slot = slot + uint8(p>>20)
+	return int(slot & (nodeMutatedSize - 1))
+}
+
+func (p *nodeMutated[T]) clear() {
+	if p.used {
+		clear(p.ptrs[:])
+	}
+	p.used = false
+}

--- a/part/tree.go
+++ b/part/tree.go
@@ -40,7 +40,6 @@ func RootOnlyWatch(o *options) { o.rootOnlyWatch = true }
 func (t *Tree[T]) Txn() *Txn[T] {
 	txn := &Txn[T]{
 		Tree:    *t,
-		mutated: make(map[*header[T]]struct{}),
 		watches: make(map[chan struct{}]struct{}),
 	}
 	return txn


### PR DESCRIPTION
Implement few more of the optimizations in the paper. Namely do linear search for node4 & node16, embed the key array into the nodes and use a 256-ary index array in node48 for direct lookup instead of binary search.

Use a small cache for node reuse instead of a hash map. The cache hashes some bits of the pointer for direct lookup into an array. In benchmarks this yields better performance without a significant change to average number of allocations.

Benchmark results:
```

Part (-count 10):

                         │   old.txt    │               new.txt                │
                         │ objects/sec  │ objects/sec  vs base                 │
_Insert_RootOnlyWatch-8    3.026M ±  6%   4.193M ± 5%   +38.56% (p=0.000 n=10)
_Insert-8                  2.511M ±  4%   3.084M ± 4%   +22.83% (p=0.000 n=10)
_Replace-8                 11.53M ±  6%   26.47M ± 7%  +129.56% (p=0.000 n=10)
_Replace_RootOnlyWatch-8   11.76M ±  5%   26.51M ± 5%  +125.43% (p=0.000 n=10)
_txn_1-8                   1.311M ±  7%   1.636M ± 2%   +24.82% (p=0.000 n=10)
_txn_10-8                  2.375M ±  3%   3.505M ± 5%   +47.56% (p=0.000 n=10)
_txn_100-8                 2.714M ±  5%   4.123M ± 5%   +51.90% (p=0.000 n=10)
_txn_1000-8                2.161M ±  6%   3.412M ± 3%   +57.89% (p=0.000 n=10)
_txn_10000-8               2.017M ±  5%   2.517M ± 5%   +24.77% (p=0.000 n=10)
_txn_100000-8              1.766M ± 12%   2.308M ± 4%   +30.70% (p=0.000 n=10)
_txn_delete_1-8            1.365M ± 10%   1.511M ± 5%   +10.71% (p=0.000 n=10)
_txn_delete_10-8           3.238M ±  5%   4.126M ± 2%   +27.40% (p=0.000 n=10)
_txn_delete_100-8          2.792M ±  5%   5.910M ± 3%  +111.71% (p=0.000 n=10)
_txn_delete_1000-8         4.432M ±  6%   5.947M ± 7%   +34.19% (p=0.000 n=10)
_txn_delete_10000-8        3.098M ±  8%   4.882M ± 7%   +57.60% (p=0.000 n=10)
_txn_delete_100000-8       3.323M ±  3%   4.630M ± 7%   +39.33% (p=0.000 n=10)
_Get-8                     20.21M ±  3%   27.16M ± 3%   +34.39% (p=0.000 n=10)
_Hashmap_Insert-8          8.957M ±  3%   8.739M ± 6%         ~ (p=0.105 n=10)
_Hashmap_Get_Uint64-8      49.33M ±  3%   49.35M ± 3%         ~ (p=0.315 n=10)
_Hashmap_Get_Bytes-8       45.56M ±  4%   46.25M ± 2%         ~ (p=0.393 n=10)
geomean                    4.563M         6.351M        +39.17%

StateDB (-count 5):

                                 │   old.txt    │               new.txt                │
                                 │ objects/sec  │  objects/sec   vs base               │
DB_WriteTxn_1-8                    237.9k ± ∞ ¹    237.9k ± ∞ ¹        ~ (p=0.841 n=5)
DB_WriteTxn_10-8                   557.6k ± ∞ ¹    631.7k ± ∞ ¹  +13.29% (p=0.008 n=5)
DB_WriteTxn_100-8                  676.6k ± ∞ ¹    792.1k ± ∞ ¹  +17.06% (p=0.008 n=5)
DB_WriteTxn_1000-8                 567.5k ± ∞ ¹    722.7k ± ∞ ¹  +27.35% (p=0.008 n=5)
DB_WriteTxn_10000-8                563.4k ± ∞ ¹    618.1k ± ∞ ¹   +9.70% (p=0.008 n=5)
DB_WriteTxn_100_SecondaryIndex-8   381.6k ± ∞ ¹    405.7k ± ∞ ¹   +6.30% (p=0.032 n=5)
DB_RandomInsert-8                  963.8k ± ∞ ¹   1103.6k ± ∞ ¹  +14.51% (p=0.008 n=5)
DB_RandomReplace-8                 304.8k ± ∞ ¹    325.4k ± ∞ ¹   +6.74% (p=0.032 n=5)
DB_SequentialInsert-8              591.8k ± ∞ ¹    687.2k ± ∞ ¹  +16.13% (p=0.008 n=5)
DB_Changes_Baseline-8              513.4k ± ∞ ¹    618.8k ± ∞ ¹  +20.54% (p=0.008 n=5)
DB_Changes-8                       278.8k ± ∞ ¹    322.8k ± ∞ ¹  +15.77% (p=0.008 n=5)
DB_RandomLookup-8                  9.827M ± ∞ ¹   10.415M ± ∞ ¹   +5.99% (p=0.016 n=5)
DB_SequentialLookup-8              8.444M ± ∞ ¹    8.513M ± ∞ ¹        ~ (p=0.690 n=5)
DB_FullIteration_All-8             57.49M ± ∞ ¹    50.72M ± ∞ ¹  -11.78% (p=0.016 n=5)
DB_FullIteration_Get-8             49.06M ± ∞ ¹    44.54M ± ∞ ¹   -9.21% (p=0.032 n=5)
geomean                            1.319M          1.430M         +8.37%

                      │   50th_µs   │   50th_µs    vs base              │
DB_PropagationDelay-8   31.00 ± ∞ ¹   30.00 ± ∞ ¹  -3.23% (p=0.032 n=5)
                      │   90th_µs   │   90th_µs    vs base              │
DB_PropagationDelay-8   61.00 ± ∞ ¹   57.00 ± ∞ ¹  -6.56% (p=0.008 n=5)
                      │   99th_µs   │   99th_µs    vs base               │
DB_PropagationDelay-8   122.0 ± ∞ ¹   135.0 ± ∞ ¹  +10.66% (p=0.008 n=5)

Reconciler (best of 3 runs, before and after):

benchmark % go run . -objects 1000000 -incrbatchsize 1000 -batchsize 1000
Inserting batch 1000/1000 ...
Waiting for reconciliation to finish ...

1000000 objects reconciled in 4.73 seconds (batch size 1000)
Throughput 211494.01 objects per second
Allocated 6011573 objects, 409311kB bytes, 477848kB bytes still in use

---
benchmark % go run . -objects 1000000 -incrbatchsize 1000 -batchsize 1000
Inserting batch 1000/1000 ...
Waiting for reconciliation to finish ...

1000000 objects reconciled in 4.41 seconds (batch size 1000)
Throughput 226686.69 objects per second
Allocated 6011521 objects, 409307kB bytes, 519200kB bytes still in use
```