### PR TITLE
reconciler: Add ability to provide default metrics

### DIFF
--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -71,14 +71,16 @@ func testReconciler(t *testing.T, batchOps bool) {
 			"test",
 			"Test",
 
+			cell.Provide(func() reconciler.Metrics {
+				return expVarMetrics
+			}),
+
 			cell.Provide(func(db_ *statedb.DB) (statedb.RWTable[*testObject], error) {
 				db = db_
 				return testObjects, db.RegisterTable(testObjects)
 			}),
 			cell.Provide(func() reconciler.Config[*testObject] {
 				cfg := reconciler.Config[*testObject]{
-					Metrics: expVarMetrics,
-
 					// Don't run the full reconciliation via timer, but rather explicitly so that the full
 					// reconciliation operations don't mix with incremental when not expected.
 					FullReconcilationInterval: time.Hour,

--- a/reconciler/types.go
+++ b/reconciler/types.go
@@ -27,6 +27,14 @@ type Reconciler[Obj any] interface {
 }
 
 type Config[Obj any] struct {
+	// Metrics to use with this reconciler. The metrics capture the duration
+	// of operations during incremental and full reconcilation and the errors
+	// that occur during either.
+	//
+	// If nil, then the default metrics are used via Params.
+	// A simple implementation of metrics based on the expvar package come
+	// with the reconciler and a custom one can be used by implementing the
+	// Metrics interface.
 	Metrics Metrics
 
 	// FullReconcilationInterval is the amount of time to wait between full


### PR DESCRIPTION
Noticed that we need the ability to provide the default metrics implementation in cilium/cilium as most reconcilers would not want their own specific implementation. It would be unnecessary boilerplate to have to depend on metrics and pass it in the configuration, so add it as an optional to Params[T].