### PR TITLE
reconciler: Add the ability to mutate object from operations

### DIFF
--- a/reconciler/benchmark/main.go
+++ b/reconciler/benchmark/main.go
@@ -42,8 +42,14 @@ func (t *testObject) GetStatus() reconciler.Status {
 	return t.status
 }
 
-func (t *testObject) WithStatus(status reconciler.Status) *testObject {
-	return &testObject{id: t.id, status: status}
+func (t *testObject) SetStatus(status reconciler.Status) *testObject {
+	t.status = status
+	return t
+}
+
+func (t *testObject) Clone() *testObject {
+	t2 := *t
+	return &t2
 }
 
 type mockOps struct {
@@ -135,7 +141,8 @@ func main() {
 					RetryBackoffMaxDuration: 10 * time.Millisecond,
 					IncrementalRoundSize:    *incrBatchSize,
 					GetObjectStatus:         (*testObject).GetStatus,
-					WithObjectStatus:        (*testObject).WithStatus,
+					SetObjectStatus:         (*testObject).SetStatus,
+					CloneObject:             (*testObject).Clone,
 					Operations:              mt,
 				}
 			}),

--- a/reconciler/example/main.go
+++ b/reconciler/example/main.go
@@ -139,7 +139,8 @@ func NewReconcilerConfig(ops reconciler.Operations[*Memo], m *reconciler.ExpVarM
 		RetryBackoffMaxDuration:   5 * time.Second,
 		IncrementalRoundSize:      100,
 		GetObjectStatus:           (*Memo).GetStatus,
-		WithObjectStatus:          (*Memo).WithStatus,
+		SetObjectStatus:           (*Memo).SetStatus,
+		CloneObject:               (*Memo).Clone,
 		Operations:                ops,
 	}
 }
@@ -197,9 +198,8 @@ func registerHTTPServer(
 				w.WriteHeader(http.StatusNotFound)
 				return
 			}
-			memos.Insert(
-				txn,
-				memo.WithStatus(reconciler.StatusPendingDelete()))
+			memo = memo.Clone().SetStatus(reconciler.StatusPendingDelete())
+			memos.Insert(txn, memo)
 			log.Info("Deleted memo", "name", name)
 			w.WriteHeader(http.StatusOK)
 		}

--- a/reconciler/example/types.go
+++ b/reconciler/example/types.go
@@ -35,14 +35,17 @@ func (memo *Memo) GetStatus() reconciler.Status {
 	return memo.Status
 }
 
-// WithStatus returns a copy of the memo with a new reconciliation status.
+// SetStatus sets the reconciliation status.
 // Used by the reconciler to update the reconciliation status of the memo.
-func (memo *Memo) WithStatus(newStatus reconciler.Status) *Memo {
-	return &Memo{
-		Name:    memo.Name,
-		Content: memo.Content,
-		Status:  newStatus,
-	}
+func (memo *Memo) SetStatus(newStatus reconciler.Status) *Memo {
+	memo.Status = newStatus
+	return memo
+}
+
+// Clone returns a shallow copy of the memo.
+func (memo *Memo) Clone() *Memo {
+	m := *memo
+	return &m
 }
 
 // MemoNameIndex allows looking up the memo by its name, e.g.

--- a/reconciler/types.go
+++ b/reconciler/types.go
@@ -56,9 +56,16 @@ type Config[Obj any] struct {
 	// GetObjectStatus returns the reconciliation status for the object.
 	GetObjectStatus func(Obj) Status
 
-	// WithObjectStatus returns a COPY of the object with the status set to
-	// the given value.
-	WithObjectStatus func(Obj, Status) Obj
+	// SetObjectStatus sets the reconciliation status for the object.
+	// This is called with a copy of the object returned by CloneObject.
+	SetObjectStatus func(Obj, Status) Obj
+
+	// CloneObject returns a shallow copy of the object. This is used to
+	// make it possible for the reconciliation operations to mutate
+	// the object (to for example provide additional information that the
+	// reconciliation produces) and to be able to set the reconciliation
+	// status after the reconciliation.
+	CloneObject func(Obj) Obj
 
 	// RateLimiter is optional and if set will use the limiter to wait between
 	// reconciliation rounds. This allows trading latency with throughput by
@@ -76,8 +83,11 @@ func (cfg Config[Obj]) validate() error {
 	if cfg.GetObjectStatus == nil {
 		return fmt.Errorf("%T.GetObjectStatus cannot be nil", cfg)
 	}
-	if cfg.WithObjectStatus == nil {
-		return fmt.Errorf("%T.WithObjectStatus cannot be nil", cfg)
+	if cfg.SetObjectStatus == nil {
+		return fmt.Errorf("%T.SetObjectStatus cannot be nil", cfg)
+	}
+	if cfg.CloneObject == nil {
+		return fmt.Errorf("%T.CloneObject cannot be nil", cfg)
 	}
 	if cfg.IncrementalRoundSize <= 0 {
 		return fmt.Errorf("%T.IncrementalBatchSize needs to be >0", cfg)
@@ -119,6 +129,9 @@ type Operations[Obj any] interface {
 	// during full reconciliation to catch cases where the realized state has
 	// gone out of sync due to outside influence. This is tracked in the
 	// "full_out_of_sync_total" metric.
+	//
+	// The object handed to Update is a clone produced by Config.CloneObject
+	// and thus Update can mutate the object.
 	Update(ctx context.Context, txn statedb.ReadTxn, obj Obj, changed *bool) error
 
 	// Delete the object in the target. Same semantics as with Update.


### PR DESCRIPTION
We need to sometimes augment the object based on the result of the operation. Modify the reconciler to allow for this by adding a CloneObject function to the configuration and clone the object before passing it to the operations.

The concrete use-case for this is in Cilium's load-balancing control-plane where the low-level operations would allocate a numeric identity to a service during the reconciliation and we want to expose this for debugging purposes in the object.