### PR TITLE
reconciler: Move Table from Params to Config

### DIFF
--- a/reconciler/benchmark/main.go
+++ b/reconciler/benchmark/main.go
@@ -122,9 +122,9 @@ func main() {
 			"test",
 			"Test",
 
-			cell.Provide(func(db_ *statedb.DB) (statedb.RWTable[*testObject], error) {
+			cell.Invoke(func(db_ *statedb.DB) error {
 				db = db_
-				return testObjects, db.RegisterTable(testObjects)
+				return db.RegisterTable(testObjects)
 			}),
 			cell.Provide(
 				func() (*mockOps, reconciler.Operations[*testObject]) {
@@ -133,6 +133,8 @@ func main() {
 			),
 			cell.Provide(func() reconciler.Config[*testObject] {
 				return reconciler.Config[*testObject]{
+					Table: testObjects,
+
 					// Don't run the full reconciliation via timer, but rather explicitly so that the full
 					// reconciliation operations don't mix with incremental when not expected.
 					FullReconcilationInterval: time.Hour,

--- a/reconciler/example/main.go
+++ b/reconciler/example/main.go
@@ -131,8 +131,9 @@ var Hive = hive.New(
 	),
 )
 
-func NewReconcilerConfig(ops reconciler.Operations[*Memo], m *reconciler.ExpVarMetrics) reconciler.Config[*Memo] {
+func NewReconcilerConfig(ops reconciler.Operations[*Memo], tbl statedb.RWTable[*Memo], m *reconciler.ExpVarMetrics) reconciler.Config[*Memo] {
 	return reconciler.Config[*Memo]{
+		Table:                     tbl,
 		Metrics:                   m,
 		FullReconcilationInterval: 10 * time.Second,
 		RetryBackoffMinDuration:   100 * time.Millisecond,

--- a/reconciler/incremental.go
+++ b/reconciler/incremental.go
@@ -52,7 +52,7 @@ func (r *reconciler[Obj]) incremental(ctx context.Context, txn statedb.ReadTxn, 
 		oldRevision:    rev,
 		ctx:            ctx,
 		txn:            txn,
-		table:          r.Table,
+		table:          r.Config.Table,
 		results:        make(map[Obj]opResult),
 	}
 

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -75,12 +75,13 @@ func testReconciler(t *testing.T, batchOps bool) {
 				return expVarMetrics
 			}),
 
-			cell.Provide(func(db_ *statedb.DB) (statedb.RWTable[*testObject], error) {
+			cell.Invoke(func(db_ *statedb.DB) error {
 				db = db_
-				return testObjects, db.RegisterTable(testObjects)
+				return db.RegisterTable(testObjects)
 			}),
 			cell.Provide(func() reconciler.Config[*testObject] {
 				cfg := reconciler.Config[*testObject]{
+					Table: testObjects,
 					// Don't run the full reconciliation via timer, but rather explicitly so that the full
 					// reconciliation operations don't mix with incremental when not expected.
 					FullReconcilationInterval: time.Hour,

--- a/reconciler/types.go
+++ b/reconciler/types.go
@@ -27,6 +27,9 @@ type Reconciler[Obj any] interface {
 }
 
 type Config[Obj any] struct {
+	// Table to reconcile.
+	Table statedb.RWTable[Obj]
+
 	// Metrics to use with this reconciler. The metrics capture the duration
 	// of operations during incremental and full reconcilation and the errors
 	// that occur during either.
@@ -88,6 +91,9 @@ type Config[Obj any] struct {
 }
 
 func (cfg Config[Obj]) validate() error {
+	if cfg.Table == nil {
+		return fmt.Errorf("%T.Table cannot be nil", cfg)
+	}
 	if cfg.GetObjectStatus == nil {
 		return fmt.Errorf("%T.GetObjectStatus cannot be nil", cfg)
 	}


### PR DESCRIPTION
With Hive cannot currently have to private providers for the same type, even when they're in different scopes. To allow for the situation where the RWTable is provided privately in one module, but still accessible via a method for reconciliation use, move the Table from Params to Config so it can be provided directly and not via Hive.

The exact setup where this problem occurred was:
```
  // module 1
  var Cell = cell.Module(...,
    cell.ProvidePrivate(NewRWTableFoo),
    cell.Provide(NewWriter),
  ),
  type Writer struct {
    table RWTable[Foo]
  }
  func NewWriter(t RWTable[Foo]) *Writer
  func (w *Writer) UnsafeRWTable() RWTable[Foo] { return w.table }

  // module 2
  var Cell = cell.Module(...,
    cell.ProvidePrivate((*m1.Writer).UnsafeRWTable),
    cell.Invoke(reconciler.Register[Foo]),
  )
```
The above lead to:
```
  level=fatal msg="Failed to apply cell"
  error="cannot provide function \"...UnsafeRWTable: this function introduces a cycle
  (long error about NewWriter depending on RWTable[Foo] provided by UnsafeRWTable)
```

Hive's (uber/dig's) cycle detection doesn't seem to care about the private providers, and thinks the private provide of "module 2" can be reached by "NewWriter" in module 1. So to fix this and add more flexibility, just make the table a config parameter.