### PR TITLE
part: Fix bug with short and long key with shared prefix

### DIFF
--- a/part/node.go
+++ b/part/node.go
@@ -171,6 +171,7 @@ func (n *header[T]) promote(watch bool) *header[T] {
 		node4 := n.node4()
 		node16 := &node16[T]{header: *n}
 		node16.setKind(nodeKind16)
+		node16.leaf = n.getLeaf()
 		size := node4.size()
 		copy(node16.children[:], node4.children[:size])
 		copy(node16.keys[:], node4.keys[:size])
@@ -182,6 +183,7 @@ func (n *header[T]) promote(watch bool) *header[T] {
 		node16 := n.node16()
 		node48 := &node48[T]{header: *n}
 		node48.setKind(nodeKind48)
+		node48.leaf = n.getLeaf()
 		copy(node48.children[:], node16.children[:node16.size()])
 		for i, k := range node16.keys[:node16.size()] {
 			node48.index[k] = int8(i)
@@ -194,6 +196,7 @@ func (n *header[T]) promote(watch bool) *header[T] {
 		node48 := n.node48()
 		node256 := &node256[T]{header: *n}
 		node256.setKind(nodeKind256)
+		node256.leaf = n.getLeaf()
 
 		// Since Node256 has children indexed directly, iterate over the children
 		// to assign them to the right index.

--- a/part/part_test.go
+++ b/part/part_test.go
@@ -641,6 +641,23 @@ func Test_lowerbound_regression(t *testing.T) {
 	require.Equal(t, len(values), i)
 }
 
+func Test_prefix_regression(t *testing.T) {
+	// Regression test for bug where a long key and a short key was inserted and where
+	// the keys shared a prefix.
+
+	tree := New[string]()
+	_, _, tree = tree.Insert([]byte("foobar"), "foobar")
+	_, _, tree = tree.Insert([]byte("foo"), "foo")
+
+	s, _, found := tree.Get([]byte("foobar"))
+	require.True(t, found)
+	require.Equal(t, s, "foobar")
+
+	s, _, found = tree.Get([]byte("foo"))
+	require.True(t, found)
+	require.Equal(t, s, "foo")
+}
+
 func Test_iterate(t *testing.T) {
 	sizes := []int{0, 1, 10, 100, 1000, rand.Intn(1000)}
 	for _, size := range sizes {

--- a/part/txn.go
+++ b/part/txn.go
@@ -299,8 +299,8 @@ func (txn *Txn[T]) delete(root *header[T], key []byte) (oldValue T, hadOld bool,
 	oldValue = leaf.value
 	hadOld = true
 
-	// Mark the watch channel of the target node for closing.
-	if this.watch != nil {
+	// Mark the watch channel of the target node for closing if not mutated already.
+	if this.watch != nil && !txn.mutated.exists(this) {
 		txn.watches[this.watch] = struct{}{}
 	}
 

--- a/part/txn.go
+++ b/part/txn.go
@@ -207,11 +207,7 @@ func (txn *Txn[T]) insert(root *header[T], key []byte, value T) (oldValue T, had
 
 			// Node exists, replace it with a clone and recurse into it.
 			child = txn.cloneNode(child)
-			if this.kind() == nodeKind256 {
-				thisp = &this.node256().children[idx]
-			} else {
-				thisp = &this.children()[idx]
-			}
+			thisp = &this.children()[idx]
 			*thisp = child
 			this = child
 		} else {
@@ -356,6 +352,7 @@ func (txn *Txn[T]) delete(root *header[T], key []byte) (oldValue T, hadOld bool,
 				newNode = (&node48[T]{header: *parent.node}).self()
 				newNode.setKind(nodeKind48)
 				n48 := newNode.node48()
+				n48.leaf = parent.node.getLeaf()
 				children := n48.children[:0]
 				for k, n := range parent.node.node256().children[:] {
 					if n != nil {
@@ -368,6 +365,7 @@ func (txn *Txn[T]) delete(root *header[T], key []byte) (oldValue T, hadOld bool,
 				newNode.setKind(nodeKind16)
 				copy(newNode.children()[:], parent.node.children())
 				n16 := newNode.node16()
+				n16.leaf = parent.node.getLeaf()
 				size := n16.size()
 				for i := 0; i < size; i++ {
 					n16.keys[i] = n16.children[i].prefix[0]
@@ -378,6 +376,7 @@ func (txn *Txn[T]) delete(root *header[T], key []byte) (oldValue T, hadOld bool,
 				n16 := parent.node.node16()
 				size := n16.size()
 				n4 := newNode.node4()
+				n4.leaf = n16.leaf
 				copy(n4.children[:], n16.children[:size])
 				copy(n4.keys[:], n16.keys[:size])
 			}

--- a/part/txn.go
+++ b/part/txn.go
@@ -173,12 +173,14 @@ func (txn *Txn[T]) insert(root *header[T], key []byte, value T) (oldValue T, had
 		if bytes.HasPrefix(key, this.prefix) {
 			key = key[len(this.prefix):]
 			if len(key) == 0 {
+				leaf := this.getLeaf()
+				if leaf != nil {
+					oldValue = leaf.value
+					hadOld = true
+				}
 				if this.isLeaf() {
 					// This is a leaf node and we just cloned it. Update the value.
-					leaf := this.getLeaf()
-					oldValue = leaf.value
 					leaf.value = value
-					hadOld = true
 				} else {
 					// This is a non-leaf node, create/replace the existing leaf.
 					this.setLeaf(newLeaf(txn.opts, key, fullKey, value))


### PR DESCRIPTION
If we insert "foobar" and then "foo" we ended up in a case where "foo" was the common prefix and the rest of the key become empty leading to out-of-bounds access to the key slice.

Handle the case where the key becomes empty when splitting a node by just inserting it as the leaf of the split node.

Added a regression test and validated it catched the bug:
```
--- FAIL: Test_prefix_regression (0.00s)
panic: runtime error: index out of range [0] with length 0 [recovered]
        panic: runtime error: index out of range [0] with length 0

goroutine 32 [running]:
testing.tRunner.func1.2({0x5f3380, 0xc00001a288})
        /home/jussi/sdk/go1.22.0/src/testing/testing.go:1631 +0x24a
testing.tRunner.func1()
        /home/jussi/sdk/go1.22.0/src/testing/testing.go:1634 +0x377
panic({0x5f3380?, 0xc00001a288?})
        /home/jussi/sdk/go1.22.0/src/runtime/panic.go:770 +0x132
github.com/cilium/statedb/part.(*Txn[...]).insert(0x6725e0, ...
        /home/jussi/go/src/github.com/cilium/statedb/part/txn.go:228 +0xdaf
```