### PR TITLE
reconciler: Remove StatusKindDelete

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -246,7 +246,7 @@ func (it *changeIterator[Obj]) Watch(txn ReadTxn) <-chan struct{} {
 
 		updateIter, watch := it.table.LowerBound(txn, ByRevision[Obj](it.revision+1))
 		deleteIter := it.dt.deleted(txn, it.revision+1)
-		it.iter = NewDualIterator[Obj](deleteIter, updateIter)
+		it.iter = NewDualIterator(deleteIter, updateIter)
 
 		// It is enough to watch the revision index and not the graveyard since
 		// any object that is inserted into the graveyard will be deleted from

--- a/reconciler/example/main.go
+++ b/reconciler/example/main.go
@@ -199,8 +199,7 @@ func registerHTTPServer(
 				w.WriteHeader(http.StatusNotFound)
 				return
 			}
-			memo = memo.Clone().SetStatus(reconciler.StatusPendingDelete())
-			memos.Insert(txn, memo)
+			memos.Delete(txn, memo)
 			log.Info("Deleted memo", "name", name)
 			w.WriteHeader(http.StatusOK)
 		}

--- a/reconciler/helpers.go
+++ b/reconciler/helpers.go
@@ -29,7 +29,7 @@ func omittedError(n int) error {
 
 func joinErrors(errs []error) error {
 	if len(errs) > maxJoinedErrors {
-		errs = append(slices.Clone(errs)[:maxJoinedErrors], omittedError(len(errs)))
+		errs = append(slices.Clone(errs)[:maxJoinedErrors], omittedError(len(errs)-maxJoinedErrors))
 	}
 	return errors.Join(errs...)
 }

--- a/table.go
+++ b/table.go
@@ -340,7 +340,7 @@ func (t *genTable[Obj]) Changes(txn WriteTxn) (ChangeIterator[Obj], error) {
 	// Prepare the iterator
 	updateIter, watch := t.LowerBound(txn, ByRevision[Obj](0)) // observe all current objects
 	deleteIter := iter.dt.deleted(txn, iter.dt.getRevision())  // only observe new deletions
-	iter.iter = NewDualIterator[Obj](deleteIter, updateIter)
+	iter.iter = NewDualIterator(deleteIter, updateIter)
 	iter.watch = watch
 
 	return iter, nil

--- a/types.go
+++ b/types.go
@@ -221,7 +221,8 @@ type WriteTxn interface {
 
 	// Commit the changes in the current transaction to the target tables.
 	// This is a no-op if Abort() or Commit() has already been called.
-	Commit()
+	// Returns a ReadTxn for reading the database at the time of commit.
+	Commit() ReadTxn
 }
 
 type Query[Obj any] struct {


### PR DESCRIPTION
To be able to use multiple reconcilers against a single object we cannot do soft-deletes and have the reconciler delete the object, as then we would have multiple reconcilers wanting to delete the same object.

To fix this, drop the StatusKindDelete and use the ChangeIterator to iterate over both inserts and deletes.

The downside is that we can't observe failed deletions via the table, but it will be visible via module health. On the other hand, it is less confusing to users to not have deleted objects visible in the tables.