### PR TITLE
Rename First to Get and Get to List/ListWatch

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -293,7 +293,7 @@ func BenchmarkDB_RandomLookup(b *testing.B) {
 	for j := 0; j < b.N; j++ {
 		txn := db.ReadTxn()
 		for _, q := range queries {
-			_, _, ok := table.First(txn, q)
+			_, _, ok := table.Get(txn, q)
 			if !ok {
 				b.Fatal("object not found")
 			}
@@ -319,7 +319,7 @@ func BenchmarkDB_SequentialLookup(b *testing.B) {
 	txn := db.ReadTxn()
 	for n := 0; n < b.N; n++ {
 		for _, q := range queries {
-			_, _, ok := table.First(txn, q)
+			_, _, ok := table.Get(txn, q)
 			if !ok {
 				b.Fatalf("Object not found")
 			}
@@ -374,7 +374,7 @@ func BenchmarkDB_FullIteration_Get(b *testing.B) {
 	txn := db.ReadTxn()
 	for n := 0; n < b.N; n++ {
 		for _, q := range queries {
-			_, _, ok := table.First(txn, q)
+			_, _, ok := table.Get(txn, q)
 			if !ok {
 				b.Fatalf("Object not found")
 			}

--- a/derive.go
+++ b/derive.go
@@ -68,7 +68,7 @@ type derive[In, Out any] struct {
 	transform func(obj In, deleted bool) (Out, DeriveResult)
 }
 
-func (d derive[In, Out]) loop(ctx context.Context, health cell.Health) error {
+func (d derive[In, Out]) loop(ctx context.Context, _ cell.Health) error {
 	out := d.OutTable
 	txn := d.DB.WriteTxn(d.InTable)
 	iter, err := d.InTable.Changes(txn)
@@ -85,7 +85,7 @@ func (d derive[In, Out]) loop(ctx context.Context, health cell.Health) error {
 			case DeriveInsert:
 				_, _, err = out.Insert(wtxn, outObj)
 			case DeriveUpdate:
-				_, _, found := out.First(wtxn, out.PrimaryIndexer().QueryFromObject(outObj))
+				_, _, found := out.Get(wtxn, out.PrimaryIndexer().QueryFromObject(outObj))
 				if found {
 					_, _, err = out.Insert(wtxn, outObj)
 				}

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -271,9 +271,9 @@ func allAction(ctx actionContext) {
 	ctx.log.log("%s: All => %d found", ctx.table.Name(), len(statedb.Collect(iter)))
 }
 
-func getAction(ctx actionContext) {
+func listAction(ctx actionContext) {
 	value := mkValue()
-	iter, _ := ctx.table.Get(ctx.txn, valueIndex.Query(value))
+	iter := ctx.table.List(ctx.txn, valueIndex.Query(value))
 	ctx.log.log("%s: Get(%d)", ctx.table.Name(), value)
 	for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
 		if e, ok2 := ctx.txnLog.latest[tableAndID{ctx.table.Name(), obj.id}]; ok2 {
@@ -296,25 +296,25 @@ func getAction(ctx actionContext) {
 	}
 }
 
-func firstAction(ctx actionContext) {
+func getAction(ctx actionContext) {
 	id := mkID()
-	obj, rev, ok := ctx.table.First(ctx.txn, idIndex.Query(id))
+	obj, rev, ok := ctx.table.Get(ctx.txn, idIndex.Query(id))
 
 	if e, ok2 := ctx.txnLog.latest[tableAndID{ctx.table.Name(), id}]; ok2 {
 		if e.act == actInsert {
 			if !ok {
-				panic("First() returned not found, expected last inserted value")
+				panic("Get() returned not found, expected last inserted value")
 			}
 			if e.value != obj.value {
-				panic("First() did not return the last write")
+				panic("Get() did not return the last write")
 			}
 		} else if e.act == actDelete {
 			if ok {
-				panic("First() returned value even though it was deleted")
+				panic("Get() returned value even though it was deleted")
 			}
 		}
 	}
-	ctx.log.log("%s: First(%s) => rev=%d, ok=%v", ctx.table.Name(), id, rev, ok)
+	ctx.log.log("%s: Get(%s) => rev=%d, ok=%v", ctx.table.Name(), id, rev, ok)
 }
 
 func lowerboundAction(ctx actionContext) {
@@ -358,10 +358,10 @@ var actions = []action{
 	deleteAction, deleteAction, deleteAction,
 	deleteManyAction, deleteAllAction,
 
-	firstAction, firstAction, firstAction, firstAction, firstAction,
-	firstAction, firstAction, firstAction, firstAction, firstAction,
-	firstAction, firstAction, firstAction, firstAction, firstAction,
 	getAction, getAction, getAction, getAction, getAction,
+	getAction, getAction, getAction, getAction, getAction,
+	getAction, getAction, getAction, getAction, getAction,
+	listAction, listAction, listAction, listAction, listAction,
 	allAction, allAction,
 	lowerboundAction, lowerboundAction, lowerboundAction,
 	prefixAction, prefixAction, prefixAction,

--- a/reconciler/benchmark/main.go
+++ b/reconciler/benchmark/main.go
@@ -188,7 +188,7 @@ func main() {
 	// Wait for all to be reconciled by waiting for the last added objects to be marked
 	// reconciled. This only works here since none of the operations fail.
 	for {
-		obj, _, watch, ok := testObjects.FirstWatch(db.ReadTxn(), idIndex.Query(id-1))
+		obj, _, watch, ok := testObjects.GetWatch(db.ReadTxn(), idIndex.Query(id-1))
 		if ok && obj.status.Kind == reconciler.StatusKindDone {
 			break
 		}

--- a/reconciler/example/main.go
+++ b/reconciler/example/main.go
@@ -194,7 +194,7 @@ func registerHTTPServer(
 			w.WriteHeader(http.StatusOK)
 
 		case "DELETE":
-			memo, _, ok := memos.First(txn, MemoNameIndex.Query(name))
+			memo, _, ok := memos.Get(txn, MemoNameIndex.Query(name))
 			if !ok {
 				w.WriteHeader(http.StatusNotFound)
 				return

--- a/reconciler/incremental.go
+++ b/reconciler/incremental.go
@@ -183,7 +183,7 @@ func (round *incrementalRound[Obj]) processRetries() {
 		}
 		round.retries.Pop()
 
-		obj, rev, found := round.table.First(round.txn, round.primaryIndexer.QueryFromObject(robj.(Obj)))
+		obj, rev, found := round.table.Get(round.txn, round.primaryIndexer.QueryFromObject(robj.(Obj)))
 		if found {
 			status := round.config.GetObjectStatus(obj)
 			if status.Kind != StatusKindError {

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -95,8 +95,8 @@ func WaitForReconciliation[Obj any](ctx context.Context, db *statedb.DB, table s
 		txn := db.ReadTxn()
 
 		// See if there are any pending or error'd objects.
-		_, _, watchPending, okPending := table.FirstWatch(txn, statusIndex.Query(StatusKindPending))
-		_, _, watchError, okError := table.FirstWatch(txn, statusIndex.Query(StatusKindError))
+		_, _, watchPending, okPending := table.GetWatch(txn, statusIndex.Query(StatusKindPending))
+		_, _, watchError, okError := table.GetWatch(txn, statusIndex.Query(StatusKindError))
 		if !okPending && !okError {
 			return nil
 		}

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -508,12 +508,12 @@ func (h testHelper) markForDelete(id uint64) {
 
 func (h testHelper) expectStatus(id uint64, kind reconciler.StatusKind, err string) {
 	cond := func() bool {
-		obj, _, ok := h.tbl.First(h.db.ReadTxn(), idIndex.Query(id))
+		obj, _, ok := h.tbl.Get(h.db.ReadTxn(), idIndex.Query(id))
 		return ok && obj.status.Kind == kind && obj.status.Error == err
 	}
 	if !assert.Eventually(h.t, cond, time.Second, time.Millisecond) {
 		actual := "<not found>"
-		obj, _, ok := h.tbl.First(h.db.ReadTxn(), idIndex.Query(id))
+		obj, _, ok := h.tbl.Get(h.db.ReadTxn(), idIndex.Query(id))
 		if ok {
 			actual = string(obj.status.Kind)
 		}
@@ -525,12 +525,12 @@ func (h testHelper) expectStatus(id uint64, kind reconciler.StatusKind, err stri
 
 func (h testHelper) expectNumUpdates(id uint64, n int) {
 	cond := func() bool {
-		obj, _, ok := h.tbl.First(h.db.ReadTxn(), idIndex.Query(id))
+		obj, _, ok := h.tbl.Get(h.db.ReadTxn(), idIndex.Query(id))
 		return ok && obj.updates == n
 	}
 	if !assert.Eventually(h.t, cond, time.Second, time.Millisecond) {
 		actual := "<not found>"
-		obj, _, ok := h.tbl.First(h.db.ReadTxn(), idIndex.Query(id))
+		obj, _, ok := h.tbl.Get(h.db.ReadTxn(), idIndex.Query(id))
 		if ok {
 			actual = fmt.Sprintf("%d", obj.updates)
 		}
@@ -542,7 +542,7 @@ func (h testHelper) expectNumUpdates(id uint64, n int) {
 func (h testHelper) expectNotFound(id uint64) {
 	h.t.Helper()
 	cond := func() bool {
-		_, _, ok := h.tbl.First(h.db.ReadTxn(), idIndex.Query(id))
+		_, _, ok := h.tbl.Get(h.db.ReadTxn(), idIndex.Query(id))
 		return !ok
 	}
 	require.Eventually(h.t, cond, time.Second, time.Millisecond, "expected object %d to not be found", id)

--- a/regression_test.go
+++ b/regression_test.go
@@ -50,26 +50,26 @@ func Test_Regression_29324(t *testing.T) {
 
 	// Exact match should only return "foo"
 	txn := db.ReadTxn()
-	iter, _ := table.Get(txn, idIndex.Query("foo"))
+	iter := table.List(txn, idIndex.Query("foo"))
 	items := Collect(iter)
 	if assert.Len(t, items, 1, "Get(\"foo\") should return one match") {
 		assert.EqualValues(t, "foo", items[0].ID)
 	}
 
 	// Partial match on prefix should not return anything
-	iter, _ = table.Get(txn, idIndex.Query("foob"))
+	iter = table.List(txn, idIndex.Query("foob"))
 	items = Collect(iter)
 	assert.Len(t, items, 0, "Get(\"foob\") should return nothing")
 
 	// Query on non-unique index should only return exact match
-	iter, _ = table.Get(txn, tagIndex.Query("aa"))
+	iter = table.List(txn, tagIndex.Query("aa"))
 	items = Collect(iter)
 	if assert.Len(t, items, 1, "Get(\"aa\") on tags should return one match") {
 		assert.EqualValues(t, "foo", items[0].ID)
 	}
 
 	// Partial match on prefix should not return anything on non-unique index
-	iter, _ = table.Get(txn, idIndex.Query("a"))
+	iter = table.List(txn, idIndex.Query("a"))
 	items = Collect(iter)
 	assert.Len(t, items, 0, "Get(\"a\") should return nothing")
 

--- a/table.go
+++ b/table.go
@@ -197,12 +197,12 @@ func (t *genTable[Obj]) NumObjects(txn ReadTxn) int {
 	return table.indexes[PrimaryIndexPos].tree.Len()
 }
 
-func (t *genTable[Obj]) First(txn ReadTxn, q Query[Obj]) (obj Obj, revision uint64, ok bool) {
-	obj, revision, _, ok = t.FirstWatch(txn, q)
+func (t *genTable[Obj]) Get(txn ReadTxn, q Query[Obj]) (obj Obj, revision uint64, ok bool) {
+	obj, revision, _, ok = t.GetWatch(txn, q)
 	return
 }
 
-func (t *genTable[Obj]) FirstWatch(txn ReadTxn, q Query[Obj]) (obj Obj, revision uint64, watch <-chan struct{}, ok bool) {
+func (t *genTable[Obj]) GetWatch(txn ReadTxn, q Query[Obj]) (obj Obj, revision uint64, watch <-chan struct{}, ok bool) {
 	indexTxn := txn.getTxn().mustIndexReadTxn(t, t.indexPos(q.index))
 	var iobj object
 	if indexTxn.unique {
@@ -261,7 +261,12 @@ func (t *genTable[Obj]) All(txn ReadTxn) (Iterator[Obj], <-chan struct{}) {
 	return &iterator[Obj]{indexTxn.Iterator()}, watch
 }
 
-func (t *genTable[Obj]) Get(txn ReadTxn, q Query[Obj]) (Iterator[Obj], <-chan struct{}) {
+func (t *genTable[Obj]) List(txn ReadTxn, q Query[Obj]) Iterator[Obj] {
+	iter, _ := t.ListWatch(txn, q)
+	return iter
+}
+
+func (t *genTable[Obj]) ListWatch(txn ReadTxn, q Query[Obj]) (Iterator[Obj], <-chan struct{}) {
 	indexTxn := txn.getTxn().mustIndexReadTxn(t, t.indexPos(q.index))
 	iter, watch := indexTxn.Prefix(q.key)
 	if indexTxn.unique {

--- a/types.go
+++ b/types.go
@@ -42,17 +42,20 @@ type Table[Obj any] interface {
 	// channel that is closed when the table changes.
 	All(ReadTxn) (Iterator[Obj], <-chan struct{})
 
-	// Get returns an iterator for all objects matching the given query
+	// List returns an iterator for all objects matching the given query.
+	List(ReadTxn, Query[Obj]) Iterator[Obj]
+
+	// ListWatch returns an iterator for all objects matching the given query
 	// and a watch channel that is closed if the query results are
 	// invalidated by a write to the table.
-	Get(ReadTxn, Query[Obj]) (Iterator[Obj], <-chan struct{})
+	ListWatch(ReadTxn, Query[Obj]) (Iterator[Obj], <-chan struct{})
 
-	// First returns the first matching object for the query.
-	First(ReadTxn, Query[Obj]) (obj Obj, rev Revision, found bool)
+	// Get returns the first matching object for the query.
+	Get(ReadTxn, Query[Obj]) (obj Obj, rev Revision, found bool)
 
-	// FirstWatch return the first matching object and a watch channel
+	// GetWatch return the first matching object and a watch channel
 	// that is closed if the query is invalidated.
-	FirstWatch(ReadTxn, Query[Obj]) (obj Obj, rev Revision, watch <-chan struct{}, found bool)
+	GetWatch(ReadTxn, Query[Obj]) (obj Obj, rev Revision, watch <-chan struct{}, found bool)
 
 	// LowerBound returns an iterator for objects that have a key
 	// greater or equal to the query. The returned watch channel is closed


### PR DESCRIPTION
The First() method name has been an eye sore from the start. This is now a good point to rename it as we're about to switch Cilium to using cilium/statedb and need to refactor a bunch of code anyway.

Before:
```
  obj, rev, found := table.First(txn, MyIndex.Query("foo"))
  obj, rev, found, watch := table.FirstWatch(txn, MyIndex.Query("foo"))

  iter, watch := table.Get(txn, MyIndex.Query("foo"))
```

Now:
```
  obj, rev, found := table.Get(txn, MyIndex.Query("foo"))
  obj, rev, found, watch := table.GetWatch(txn, MyIndex.Query("foo"))

  iter := table.List(txn, MyIndex.Query("foo"))
  iter, watch := table.ListWatch(txn, MyIndex.Query("foo"))
```