### PR TITLE
reconciler: Make the Status.String() prettier

### DIFF
--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -624,3 +624,30 @@ func concatLabels(m map[string]string) string {
 	}
 	return strings.Join(labels, ",")
 }
+
+func TestStatusString(t *testing.T) {
+	now := time.Now()
+
+	s := reconciler.Status{
+		Kind:      reconciler.StatusKindPending,
+		UpdatedAt: now,
+		Error:     "",
+	}
+	assert.Regexp(t, `Pending \([0-9]+\.[0-9]+m?s ago\)`, s.String())
+	s.UpdatedAt = now.Add(-time.Hour)
+	assert.Regexp(t, `Pending \([0-9]+\.[0-9]+h ago\)`, s.String())
+
+	s = reconciler.Status{
+		Kind:      reconciler.StatusKindDone,
+		UpdatedAt: now,
+		Error:     "",
+	}
+	assert.Regexp(t, `Done \([0-9]+\.[0-9]+m?s ago\)`, s.String())
+
+	s = reconciler.Status{
+		Kind:      reconciler.StatusKindError,
+		UpdatedAt: now,
+		Error:     "hey I'm an error",
+	}
+	assert.Regexp(t, `Error: hey I'm an error \([0-9]+\.[0-9]+m?s ago\)`, s.String())
+}

--- a/reconciler/types.go
+++ b/reconciler/types.go
@@ -174,9 +174,9 @@ type BatchOperations[Obj any] interface {
 type StatusKind string
 
 const (
-	StatusKindPending StatusKind = "pending"
-	StatusKindDone    StatusKind = "done"
-	StatusKindError   StatusKind = "error"
+	StatusKindPending StatusKind = "Pending"
+	StatusKindDone    StatusKind = "Done"
+	StatusKindError   StatusKind = "Error"
 )
 
 // Key implements an optimized construction of index.Key for StatusKind
@@ -205,9 +205,30 @@ type Status struct {
 
 func (s Status) String() string {
 	if s.Kind == StatusKindError {
-		return fmt.Sprintf("%s (updated: %s ago, error: %s)", s.Kind, time.Now().Sub(s.UpdatedAt), s.Error)
+		return fmt.Sprintf("Error: %s (%s ago)", s.Error, prettySince(s.UpdatedAt))
 	}
-	return fmt.Sprintf("%s (updated: %s ago)", s.Kind, time.Now().Sub(s.UpdatedAt))
+	return fmt.Sprintf("%s (%s ago)", s.Kind, prettySince(s.UpdatedAt))
+}
+
+func prettySince(t time.Time) string {
+	ago := float64(time.Now().Sub(t)) / float64(time.Millisecond)
+	// millis
+	if ago < 1000.0 {
+		return fmt.Sprintf("%.1fms", ago)
+	}
+	// secs
+	ago /= 1000.0
+	if ago < 60.0 {
+		return fmt.Sprintf("%.1fs", ago)
+	}
+	// mins
+	ago /= 60.0
+	if ago < 60.0 {
+		return fmt.Sprintf("%.1fm", ago)
+	}
+	// hours
+	ago /= 60.0
+	return fmt.Sprintf("%.1fh", ago)
 }
 
 // StatusPending constructs the status for marking the object as


### PR DESCRIPTION
Before: "done (updated: 4.734193304s ago)"
After: "Done (4.7s ago)"