### PR TITLE
part: Map/Set zero values and JSON marshalling

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -27,7 +27,7 @@ func BenchmarkDB_WriteTxn_1(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		txn := db.WriteTxn(table)
-		_, _, err := table.Insert(txn, testObject{ID: 123, Tags: part.StringSet})
+		_, _, err := table.Insert(txn, testObject{ID: 123})
 		if err != nil {
 			b.Fatalf("Insert error: %s", err)
 		}
@@ -59,7 +59,7 @@ func benchmarkDB_WriteTxn_batch(b *testing.B, batchSize int) {
 	for n > 0 {
 		txn := db.WriteTxn(table)
 		for j := 0; j < batchSize; j++ {
-			_, _, err := table.Insert(txn, testObject{ID: uint64(j), Tags: part.StringSet})
+			_, _, err := table.Insert(txn, testObject{ID: uint64(j)})
 			if err != nil {
 				b.Fatalf("Insert error: %s", err)
 			}
@@ -69,7 +69,7 @@ func benchmarkDB_WriteTxn_batch(b *testing.B, batchSize int) {
 	}
 	txn := db.WriteTxn(table)
 	for j := 0; j < n; j++ {
-		_, _, err := table.Insert(txn, testObject{ID: uint64(j), Tags: part.StringSet})
+		_, _, err := table.Insert(txn, testObject{ID: uint64(j)})
 		if err != nil {
 			b.Fatalf("Insert error: %s", err)
 		}
@@ -85,7 +85,7 @@ func BenchmarkDB_WriteTxn_100_SecondaryIndex(b *testing.B) {
 	for n > 0 {
 		txn := db.WriteTxn(table)
 		for j := 0; j < 100; j++ {
-			_, _, err := table.Insert(txn, testObject{ID: uint64(j), Tags: part.NewStringSet(tags...)})
+			_, _, err := table.Insert(txn, testObject{ID: uint64(j), Tags: part.NewSet(tags...)})
 			if err != nil {
 				b.Fatalf("Insert error: %s", err)
 			}
@@ -95,7 +95,7 @@ func BenchmarkDB_WriteTxn_100_SecondaryIndex(b *testing.B) {
 	}
 	txn := db.WriteTxn(table)
 	for j := 0; j < n; j++ {
-		_, _, err := table.Insert(txn, testObject{ID: uint64(j), Tags: part.NewStringSet(tags...)})
+		_, _, err := table.Insert(txn, testObject{ID: uint64(j), Tags: part.NewSet(tags...)})
 		if err != nil {
 			b.Fatalf("Insert error: %s", err)
 		}
@@ -118,7 +118,7 @@ func BenchmarkDB_RandomInsert(b *testing.B) {
 	for j := 0; j < b.N; j++ {
 		txn := db.WriteTxn(table)
 		for _, id := range ids {
-			_, _, err := table.Insert(txn, testObject{ID: id, Tags: part.StringSet})
+			_, _, err := table.Insert(txn, testObject{ID: id, Tags: part.Set[string]{}})
 			if err != nil {
 				b.Fatalf("Insert error: %s", err)
 			}
@@ -144,7 +144,7 @@ func BenchmarkDB_RandomReplace(b *testing.B) {
 		if i%2 == 0 {
 			tag = "even"
 		}
-		table.Insert(txn, testObject{ID: uint64(i), Tags: part.NewStringSet(tag)})
+		table.Insert(txn, testObject{ID: uint64(i), Tags: part.NewSet(tag)})
 		ids = append(ids, uint64(i))
 	}
 	txn.Commit()
@@ -160,7 +160,7 @@ func BenchmarkDB_RandomReplace(b *testing.B) {
 			if id%2 == 0 {
 				tag = "even"
 			}
-			_, _, err := table.Insert(txn, testObject{ID: id, Tags: part.NewStringSet(tag)})
+			_, _, err := table.Insert(txn, testObject{ID: id, Tags: part.NewSet(tag)})
 			if err != nil {
 				b.Fatalf("Insert error: %s", err)
 			}
@@ -179,7 +179,7 @@ func BenchmarkDB_SequentialInsert(b *testing.B) {
 	for j := 0; j < b.N; j++ {
 		txn := db.WriteTxn(table)
 		for id := uint64(0); id < uint64(numObjectsToInsert); id++ {
-			_, _, err := table.Insert(txn, testObject{ID: id, Tags: part.StringSet})
+			_, _, err := table.Insert(txn, testObject{ID: id})
 			if err != nil {
 				b.Fatalf("Insert error: %s", err)
 			}
@@ -198,7 +198,7 @@ func BenchmarkDB_Changes_Baseline(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		txn := db.WriteTxn(table)
 		for i := uint64(0); i < numObjectsToInsert; i++ {
-			_, _, err := table.Insert(txn, testObject{ID: uint64(i), Tags: part.StringSet})
+			_, _, err := table.Insert(txn, testObject{ID: uint64(i)})
 			if err != nil {
 				b.Fatalf("Insert: %s", err)
 			}
@@ -226,7 +226,7 @@ func BenchmarkDB_Changes(b *testing.B) {
 		// Create objects
 		txn = db.WriteTxn(table)
 		for i := 0; i < numObjectsToInsert; i++ {
-			_, _, err := table.Insert(txn, testObject{ID: uint64(i), Tags: part.StringSet})
+			_, _, err := table.Insert(txn, testObject{ID: uint64(i)})
 			if err != nil {
 				b.Fatalf("Insert: %s", err)
 			}
@@ -281,7 +281,7 @@ func BenchmarkDB_RandomLookup(b *testing.B) {
 	queries := []Query[testObject]{}
 	for i := 0; i < numObjectsToInsert; i++ {
 		queries = append(queries, idIndex.Query(uint64(i)))
-		_, _, err := table.Insert(wtxn, testObject{ID: uint64(i), Tags: part.StringSet})
+		_, _, err := table.Insert(wtxn, testObject{ID: uint64(i)})
 		require.NoError(b, err)
 	}
 	wtxn.Commit()
@@ -310,7 +310,7 @@ func BenchmarkDB_SequentialLookup(b *testing.B) {
 	for i := 0; i < numObjectsToInsert; i++ {
 		queries = append(queries, idIndex.Query(uint64(i)))
 		ids = append(ids, uint64(i))
-		_, _, err := table.Insert(wtxn, testObject{ID: uint64(i), Tags: part.StringSet})
+		_, _, err := table.Insert(wtxn, testObject{ID: uint64(i)})
 		require.NoError(b, err)
 	}
 	wtxn.Commit()
@@ -334,7 +334,7 @@ func BenchmarkDB_FullIteration_All(b *testing.B) {
 	db, table := newTestDBWithMetrics(b, &NopMetrics{})
 	wtxn := db.WriteTxn(table)
 	for i := 0; i < numObjectsIteration; i++ {
-		_, _, err := table.Insert(wtxn, testObject{ID: uint64(i), Tags: part.StringSet})
+		_, _, err := table.Insert(wtxn, testObject{ID: uint64(i)})
 		require.NoError(b, err)
 	}
 	wtxn.Commit()
@@ -365,7 +365,7 @@ func BenchmarkDB_FullIteration_Get(b *testing.B) {
 	for i := 0; i < numObjectsIteration; i++ {
 		queries = append(queries, idIndex.Query(uint64(i)))
 		ids = append(ids, uint64(i))
-		_, _, err := table.Insert(wtxn, testObject{ID: uint64(i), Tags: part.StringSet})
+		_, _, err := table.Insert(wtxn, testObject{ID: uint64(i)})
 		require.NoError(b, err)
 	}
 	wtxn.Commit()
@@ -440,7 +440,7 @@ func BenchmarkDB_PropagationDelay(b *testing.B) {
 		// Commit a batch to the first table.
 		wtxn := db.WriteTxn(table1)
 		for i := 0; i < batchSize; i++ {
-			table1.Insert(wtxn, testObject{ID: uint64(i), Tags: part.StringSet})
+			table1.Insert(wtxn, testObject{ID: uint64(i)})
 		}
 		wtxn.Commit()
 

--- a/db_test.go
+++ b/db_test.go
@@ -154,11 +154,11 @@ func TestDB_LowerBound_ByRevision(t *testing.T) {
 
 	{
 		txn := db.WriteTxn(table)
-		table.Insert(txn, testObject{ID: 42, Tags: part.NewStringSet("hello", "world")})
+		table.Insert(txn, testObject{ID: 42, Tags: part.NewSet("hello", "world")})
 		txn.Commit()
 
 		txn = db.WriteTxn(table)
-		table.Insert(txn, testObject{ID: 71, Tags: part.NewStringSet("foo")})
+		table.Insert(txn, testObject{ID: 71, Tags: part.NewSet("foo")})
 		txn.Commit()
 	}
 
@@ -191,7 +191,7 @@ func TestDB_LowerBound_ByRevision(t *testing.T) {
 
 	{
 		txn := db.WriteTxn(table)
-		table.Insert(txn, testObject{ID: 71, Tags: part.NewStringSet("foo", "modified")})
+		table.Insert(txn, testObject{ID: 71, Tags: part.NewSet("foo", "modified")})
 		txn.Commit()
 	}
 
@@ -217,9 +217,9 @@ func TestDB_Prefix(t *testing.T) {
 
 	{
 		txn := db.WriteTxn(table)
-		table.Insert(txn, testObject{ID: 42, Tags: part.NewStringSet("a", "b")})
-		table.Insert(txn, testObject{ID: 82, Tags: part.NewStringSet("abc")})
-		table.Insert(txn, testObject{ID: 71, Tags: part.NewStringSet("ab")})
+		table.Insert(txn, testObject{ID: 42, Tags: part.NewSet("a", "b")})
+		table.Insert(txn, testObject{ID: 82, Tags: part.NewSet("abc")})
+		table.Insert(txn, testObject{ID: 71, Tags: part.NewSet("ab")})
 		txn.Commit()
 	}
 
@@ -236,7 +236,7 @@ func TestDB_Prefix(t *testing.T) {
 
 	{
 		txn := db.WriteTxn(table)
-		table.Insert(txn, testObject{ID: 12, Tags: part.NewStringSet("bc")})
+		table.Insert(txn, testObject{ID: 12, Tags: part.NewSet("bc")})
 		txn.Commit()
 	}
 
@@ -248,7 +248,7 @@ func TestDB_Prefix(t *testing.T) {
 
 	{
 		txn := db.WriteTxn(table)
-		table.Insert(txn, testObject{ID: 99, Tags: part.NewStringSet("abcd")})
+		table.Insert(txn, testObject{ID: 99, Tags: part.NewSet("abcd")})
 		txn.Commit()
 	}
 
@@ -270,9 +270,9 @@ func TestDB_EventIterator(t *testing.T) {
 
 	{
 		txn := db.WriteTxn(table)
-		table.Insert(txn, testObject{ID: 42, Tags: part.NewStringSet("hello", "world")})
-		table.Insert(txn, testObject{ID: 71, Tags: part.NewStringSet("foo")})
-		table.Insert(txn, testObject{ID: 83, Tags: part.NewStringSet("bar")})
+		table.Insert(txn, testObject{ID: 42, Tags: part.NewSet("hello", "world")})
+		table.Insert(txn, testObject{ID: 71, Tags: part.NewSet("foo")})
+		table.Insert(txn, testObject{ID: 83, Tags: part.NewSet("bar")})
 		txn.Commit()
 	}
 
@@ -305,7 +305,7 @@ func TestDB_EventIterator(t *testing.T) {
 
 		// Reinsert and redelete to test updating graveyard with existing object.
 		txn = db.WriteTxn(table)
-		table.Insert(txn, testObject{ID: 71, Tags: part.NewStringSet("foo")})
+		table.Insert(txn, testObject{ID: 71, Tags: part.NewSet("foo")})
 		txn.Commit()
 
 		txn = db.WriteTxn(table)
@@ -391,7 +391,7 @@ func TestDB_EventIterator(t *testing.T) {
 	// Insert a new object and consume the event
 	{
 		wtxn := db.WriteTxn(table)
-		table.Insert(wtxn, testObject{ID: 88, Tags: part.NewStringSet("foo")})
+		table.Insert(wtxn, testObject{ID: 88, Tags: part.NewSet("foo")})
 		wtxn.Commit()
 	}
 
@@ -453,7 +453,7 @@ func TestDB_EventIterator(t *testing.T) {
 	iter2.Close()
 	{
 		txn := db.WriteTxn(table)
-		table.Insert(txn, testObject{ID: 78, Tags: part.NewStringSet("world")})
+		table.Insert(txn, testObject{ID: 78, Tags: part.NewSet("world")})
 		txn.Commit()
 		txn = db.WriteTxn(table)
 		table.DeleteAll(txn)
@@ -593,7 +593,7 @@ func TestDB_GetFirstLast(t *testing.T) {
 			if i%2 == 0 {
 				tag = "even"
 			}
-			_, _, err := table.Insert(txn, testObject{ID: uint64(i), Tags: part.NewStringSet(tag)})
+			_, _, err := table.Insert(txn, testObject{ID: uint64(i), Tags: part.NewSet(tag)})
 			require.NoError(t, err)
 		}
 		// Check that we can query the not-yet-committed write transaction.
@@ -645,7 +645,7 @@ func TestDB_GetFirstLast(t *testing.T) {
 
 	// Modify the testObject(2) to trigger closing of the watch channels.
 	wtxn := db.WriteTxn(table)
-	_, hadOld, err := table.Insert(wtxn, testObject{ID: uint64(2), Tags: part.NewStringSet("even", "modified")})
+	_, hadOld, err := table.Insert(wtxn, testObject{ID: uint64(2), Tags: part.NewSet("even", "modified")})
 	require.True(t, hadOld)
 	require.NoError(t, err)
 	wtxn.Commit()
@@ -687,7 +687,7 @@ func TestDB_CommitAbort(t *testing.T) {
 	db := dbX.NewHandle("test-handle")
 
 	txn := db.WriteTxn(table)
-	_, _, err := table.Insert(txn, testObject{ID: 123, Tags: part.StringSet})
+	_, _, err := table.Insert(txn, testObject{ID: 123})
 	require.NoError(t, err)
 	txn.Commit()
 
@@ -702,14 +702,14 @@ func TestDB_CommitAbort(t *testing.T) {
 	require.EqualValues(t, obj.ID, 123, "expected obj.ID to equal 123")
 	require.Zero(t, obj.Tags.Len(), "expected no tags")
 
-	_, _, err = table.Insert(txn, testObject{ID: 123, Tags: part.NewStringSet("insert-after-commit")})
+	_, _, err = table.Insert(txn, testObject{ID: 123, Tags: part.NewSet("insert-after-commit")})
 	require.ErrorIs(t, err, ErrTransactionClosed)
 	txn.Commit() // should be no-op
 
 	txn = db.WriteTxn(table)
 	txn.Abort()
 
-	_, _, err = table.Insert(txn, testObject{ID: 123, Tags: part.NewStringSet("insert-after-abort")})
+	_, _, err = table.Insert(txn, testObject{ID: 123, Tags: part.NewSet("insert-after-abort")})
 	require.ErrorIs(t, err, ErrTransactionClosed)
 	txn.Commit() // should be no-op
 
@@ -750,7 +750,7 @@ func TestDB_CompareAndSwap_CompareAndDelete(t *testing.T) {
 
 	// Updating an object with matching revision number works
 	wtxn = db.WriteTxn(table)
-	obj.Tags = part.NewStringSet("updated") // NOTE: testObject stored by value so no explicit copy needed.
+	obj.Tags = part.NewSet("updated") // NOTE: testObject stored by value so no explicit copy needed.
 	oldObj, hadOld, err := table.CompareAndSwap(wtxn, rev1, obj)
 	require.NoError(t, err)
 	require.True(t, hadOld)
@@ -765,7 +765,7 @@ func TestDB_CompareAndSwap_CompareAndDelete(t *testing.T) {
 
 	// Updating an object with mismatching revision number fails
 	wtxn = db.WriteTxn(table)
-	obj.Tags = part.NewStringSet("mismatch")
+	obj.Tags = part.NewSet("mismatch")
 	oldObj, hadOld, err = table.CompareAndSwap(wtxn, rev1, obj)
 	require.ErrorIs(t, ErrRevisionNotEqual, err)
 	require.True(t, hadOld)
@@ -780,7 +780,7 @@ func TestDB_CompareAndSwap_CompareAndDelete(t *testing.T) {
 
 	// Deleting an object with mismatching revision number fails
 	wtxn = db.WriteTxn(table)
-	obj.Tags = part.NewStringSet("mismatch")
+	obj.Tags = part.NewSet("mismatch")
 	oldObj, hadOld, err = table.CompareAndDelete(wtxn, rev1, obj)
 	require.ErrorIs(t, ErrRevisionNotEqual, err)
 	require.True(t, hadOld)
@@ -795,7 +795,7 @@ func TestDB_CompareAndSwap_CompareAndDelete(t *testing.T) {
 
 	// Deleting with matching revision number works
 	wtxn = db.WriteTxn(table)
-	obj.Tags = part.NewStringSet("mismatch")
+	obj.Tags = part.NewSet("mismatch")
 	oldObj, hadOld, err = table.CompareAndDelete(wtxn, rev2, obj)
 	require.NoError(t, err)
 	require.True(t, hadOld)

--- a/derive_test.go
+++ b/derive_test.go
@@ -117,7 +117,7 @@ func TestDerive(t *testing.T) {
 	wtxn := db.WriteTxn(inTable)
 	inTable.Insert(wtxn, testObject{ID: 1})
 	inTable.Insert(wtxn, testObject{ID: 2})
-	inTable.Insert(wtxn, testObject{ID: 3, Tags: part.NewStringSet("skip")})
+	inTable.Insert(wtxn, testObject{ID: 3, Tags: part.NewSet("skip")})
 	wtxn.Commit()
 
 	require.Eventually(t,
@@ -150,7 +150,7 @@ func TestDerive(t *testing.T) {
 
 	// Delete 1 (testing DeriveDelete)
 	wtxn = db.WriteTxn(inTable)
-	inTable.Insert(wtxn, testObject{ID: 1, Tags: part.NewStringSet("delete")})
+	inTable.Insert(wtxn, testObject{ID: 1, Tags: part.NewSet("delete")})
 	wtxn.Commit()
 	wtxn = db.WriteTxn(inTable)
 	inTable.Delete(wtxn, testObject{ID: 1})

--- a/http_test.go
+++ b/http_test.go
@@ -26,10 +26,10 @@ func httpFixture(t *testing.T) (*DB, Table[testObject], *httptest.Server) {
 	t.Cleanup(ts.Close)
 
 	wtxn := db.WriteTxn(table)
-	table.Insert(wtxn, testObject{1, part.NewStringSet("foo")})
-	table.Insert(wtxn, testObject{2, part.NewStringSet("foo")})
-	table.Insert(wtxn, testObject{3, part.NewStringSet("foobar")})
-	table.Insert(wtxn, testObject{4, part.NewStringSet("baz")})
+	table.Insert(wtxn, testObject{1, part.NewSet("foo")})
+	table.Insert(wtxn, testObject{2, part.NewSet("foo")})
+	table.Insert(wtxn, testObject{3, part.NewSet("foobar")})
+	table.Insert(wtxn, testObject{4, part.NewSet("baz")})
 	wtxn.Commit()
 
 	return db, table, ts

--- a/part/registry.go
+++ b/part/registry.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package part
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"reflect"
+	"sync"
+	"unicode/utf8"
+)
+
+// keyTypeRegistry is a registry of functions to convert to/from keys (of type K).
+// This mechanism enables use of zero value and JSON marshalling and unmarshalling
+// with Map and Set.
+var keyTypeRegistry sync.Map // map[reflect.Type]func(K) []byte
+
+// RegisterKeyType registers a new key type to be used with the Map and Set types.
+// Intended to be called from init() functions.
+// For Set-only usage only the [bytesFromKey] function is needed.
+func RegisterKeyType[K any](bytesFromKey func(K) []byte) {
+	keyType := reflect.TypeFor[K]()
+	keyTypeRegistry.Store(
+		keyType,
+		bytesFromKey,
+	)
+}
+
+func lookupKeyType[K any]() func(K) []byte {
+	keyType := reflect.TypeFor[K]()
+	funcAny, ok := keyTypeRegistry.Load(keyType)
+	if !ok {
+		panic(fmt.Sprintf("Key type %q not registered with part.RegisterMapKeyType()", keyType))
+	}
+	return funcAny.(func(K) []byte)
+}
+
+func init() {
+	// Register common key types.
+	RegisterKeyType[string](func(s string) []byte { return []byte(s) })
+	RegisterKeyType[[]byte](func(b []byte) []byte { return b })
+	RegisterKeyType[byte](func(b byte) []byte { return []byte{b} })
+	RegisterKeyType[rune](func(r rune) []byte { return utf8.AppendRune(nil, r) })
+	RegisterKeyType[complex128](func(c complex128) []byte {
+		buf := make([]byte, 0, 16)
+		buf = binary.BigEndian.AppendUint64(buf, math.Float64bits(real(c)))
+		buf = binary.BigEndian.AppendUint64(buf, math.Float64bits(imag(c)))
+		return buf
+	})
+	RegisterKeyType[float64](func(x float64) []byte { return binary.BigEndian.AppendUint64(nil, math.Float64bits(x)) })
+	RegisterKeyType[float32](func(x float32) []byte { return binary.BigEndian.AppendUint32(nil, math.Float32bits(x)) })
+	RegisterKeyType[uint64](func(x uint64) []byte { return binary.BigEndian.AppendUint64(nil, x) })
+	RegisterKeyType[uint32](func(x uint32) []byte { return binary.BigEndian.AppendUint32(nil, x) })
+	RegisterKeyType[uint16](func(x uint16) []byte { return binary.BigEndian.AppendUint16(nil, x) })
+	RegisterKeyType[int64](func(x int64) []byte { return binary.BigEndian.AppendUint64(nil, uint64(x)) })
+	RegisterKeyType[int32](func(x int32) []byte { return binary.BigEndian.AppendUint32(nil, uint32(x)) })
+	RegisterKeyType[int16](func(x int16) []byte { return binary.BigEndian.AppendUint16(nil, uint16(x)) })
+	RegisterKeyType[int](func(x int) []byte { return binary.BigEndian.AppendUint64(nil, uint64(x)) })
+
+	var (
+		trueBytes  = []byte{'T'}
+		falseBytes = []byte{'F'}
+	)
+	RegisterKeyType[bool](func(b bool) []byte {
+		if b {
+			return trueBytes
+		} else {
+			return falseBytes
+		}
+	})
+
+}

--- a/part/set.go
+++ b/part/set.go
@@ -3,55 +3,42 @@
 
 package part
 
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
 // Set is a persistent (immutable) set of values. A Set can be
 // defined for any type for which a byte slice key can be derived.
+//
+// A zero value Set[T] can be used provided that the conversion
+// function for T have been registered with RegisterKeyType.
+// For Set-only use only [bytesFromKey] needs to be defined.
 type Set[T any] struct {
 	toBytes func(T) []byte
 	tree    *Tree[T]
 }
 
-// NewSet creates a new set of T when given a function to convert T
-// into a byte slice key.
-func NewSet[T any](toBytes func(T) []byte, values ...T) Set[T] {
-	if len(values) == 0 {
-		return Set[T]{toBytes, nil}
+// NewSet creates a new set of T.
+// The value type T must be registered with RegisterKeyType.
+func NewSet[T any](values ...T) Set[T] {
+	s := Set[T]{tree: New[T](RootOnlyWatch)}
+	s.toBytes = lookupKeyType[T]()
+	if len(values) > 0 {
+		txn := s.tree.Txn()
+		for _, v := range values {
+			txn.Insert(s.toBytes(v), v)
+		}
+		s.tree = txn.CommitOnly()
 	}
-
-	s := Set[T]{toBytes, New[T](RootOnlyWatch)}
-	txn := s.tree.Txn()
-	for _, v := range values {
-		txn.Insert(toBytes(v), v)
-	}
-	s.tree = txn.CommitOnly()
 	return s
-}
-
-// StringSet is an empty set of strings.
-// Short form for "part.NewStringSet()"
-var StringSet = NewStringSet()
-
-// NewStringSet creates a new set of strings.
-func NewStringSet(values ...string) Set[string] {
-	return NewSet(
-		func(s string) []byte { return []byte(s) },
-		values...,
-	)
-}
-
-// BytesSet is an empty set of byte slices.
-// Short form for "part.NewBytesSet()"
-var BytesSet = NewBytesSet()
-
-// NewBytesSet creates a new set of byte slices.
-func NewBytesSet(values ...[]byte) Set[[]byte] {
-	identity := func(b []byte) []byte { return b }
-	return NewSet(identity, values...)
 }
 
 // Set a value. Returns a new set. Original is unchanged.
 func (s Set[T]) Set(v T) Set[T] {
 	if s.tree == nil {
-		s.tree = New[T]()
+		return NewSet(v)
 	}
 	_, _, tree := s.tree.Insert(s.toBytes(v), v)
 	s.tree = tree // As Set is passed by value we can just modify it.
@@ -86,8 +73,15 @@ func (s Set[T]) All() SetIterator[T] {
 	return SetIterator[T]{s.tree.Iterator()}
 }
 
-// Union combines the values in the two sets. Returns a new set.
+// Union returns a set that is the union of the values
+// in the input sets.
 func (s Set[T]) Union(s2 Set[T]) Set[T] {
+	if s2.tree == nil {
+		return s
+	}
+	if s.tree == nil {
+		return s2
+	}
 	txn := s.tree.Txn()
 	iter := s2.tree.Iterator()
 	for k, v, ok := iter.Next(); ok; k, v, ok = iter.Next() {
@@ -97,8 +91,8 @@ func (s Set[T]) Union(s2 Set[T]) Set[T] {
 	return s
 }
 
-// Difference removes the values in the second set from the first
-// set. Returns a new set, the original sets are unchanged.
+// Difference returns a set with values that only
+// appear in the first set.
 func (s Set[T]) Difference(s2 Set[T]) Set[T] {
 	if s.tree == nil || s2.tree == nil {
 		return s
@@ -121,11 +115,39 @@ func (s Set[T]) Len() int {
 	return s.tree.size
 }
 
+// Equal returns true if the two sets contain the equal keys.
+func (s Set[T]) Equal(other Set[T]) bool {
+	switch {
+	case s.tree == nil && other.tree == nil:
+		return true
+	case s.Len() != other.Len():
+		return false
+	default:
+		iter1 := s.tree.Iterator()
+		iter2 := other.tree.Iterator()
+		for {
+			k1, _, ok := iter1.Next()
+			if !ok {
+				break
+			}
+			k2, _, _ := iter2.Next()
+			// Equal lengths, no need to check 'ok' for 'iter2'.
+			if !bytes.Equal(k1, k2) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
 // Slice converts the set into a slice.
 // Note that this allocates a new slice and appends
 // all values into it. If you just want to iterate over
 // the set use All() instead.
 func (s Set[T]) Slice() []T {
+	if s.tree == nil {
+		return nil
+	}
 	xs := make([]T, 0, s.Len())
 	iter := s.All()
 	for v, ok := iter.Next(); ok; v, ok = iter.Next() {
@@ -139,6 +161,64 @@ func (s Set[T]) Slice() []T {
 // in the key.
 func (s Set[T]) ToBytesFunc() func(T) []byte {
 	return s.toBytes
+}
+
+func (s Set[T]) MarshalJSON() ([]byte, error) {
+	if s.tree == nil {
+		return []byte("[]"), nil
+	}
+	var b bytes.Buffer
+	b.WriteRune('[')
+	iter := s.tree.Iterator()
+	_, v, ok := iter.Next()
+	for ok {
+		bs, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		b.Write(bs)
+		_, v, ok = iter.Next()
+		if ok {
+			b.WriteRune(',')
+		}
+	}
+	b.WriteRune(']')
+	return b.Bytes(), nil
+}
+
+func (s *Set[T]) UnmarshalJSON(data []byte) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	t, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	if d, ok := t.(json.Delim); !ok || d != '[' {
+		return fmt.Errorf("%T.UnmarshalJSON: expected '[' got %v", s, t)
+	}
+
+	if s.tree == nil {
+		*s = NewSet[T]()
+	}
+	txn := s.tree.Txn()
+
+	for dec.More() {
+		var x T
+		err := dec.Decode(&x)
+		if err != nil {
+			return err
+		}
+		txn.Insert(s.toBytes(x), x)
+	}
+	s.tree = txn.CommitOnly()
+
+	t, err = dec.Token()
+	if err != nil {
+		return err
+	}
+	if d, ok := t.(json.Delim); !ok || d != ']' {
+		return fmt.Errorf("%T.UnmarshalJSON: expected ']' got %v", s, t)
+	}
+	return nil
 }
 
 // SetIterator iterates over values in a set.

--- a/part/set_test.go
+++ b/part/set_test.go
@@ -1,14 +1,16 @@
 package part_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/cilium/statedb/part"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStringSet(t *testing.T) {
-	s := part.StringSet
+	var s part.Set[string]
 
 	assert.False(t, s.Has("nothing"), "Has nothing")
 
@@ -23,7 +25,7 @@ func TestStringSet(t *testing.T) {
 	assert.False(t, ok, "Next")
 	assert.Equal(t, "", v)
 
-	s2 := part.NewStringSet("bar")
+	s2 := part.NewSet("bar")
 
 	s3 := s.Union(s2)
 	assert.False(t, s.Has("bar"), "s has no bar")
@@ -45,4 +47,16 @@ func TestStringSet(t *testing.T) {
 	xs := s3.Slice()
 	assert.Len(t, xs, 1)
 	assert.Equal(t, "bar", xs[0])
+}
+
+func TestSetJSON(t *testing.T) {
+	s := part.NewSet("foo", "bar", "baz")
+
+	bs, err := json.Marshal(s)
+	require.NoError(t, err, "Marshal")
+
+	var s2 part.Set[string]
+	err = json.Unmarshal(bs, &s2)
+	require.NoError(t, err, "Unmarshal")
+	require.True(t, s.Equal(s2), "Equal")
 }


### PR DESCRIPTION
While trying to use part.Map and part.Set in some real-world code I quickly realized it was missing support for JSON marshalling and unmarshalling. To implement this we need a way to implement `func (m *Map[K, V) UnmarshalJSON(data []byte) error` and for that to work the zero value has to be usable. To get around this and in general make these a bit easier to use this PR moves the "toBytes" into a global registry rather than passing these functions in with `NewMap` and so on. **Is this easy enough to use?**, e.g. to use part.Map with a new key type one does this:
```
type MyKey string
func init() {
  part.RegisterKeyType(func(k MyKey) []byte { return []byte(k) })
}
```
If this is not done, then e.g. `Map.Set` will panic telling the user to do this. In some sense this idea is similar to e.g. https://pkg.go.dev/encoding/gob#Register (or what k8s client-go does) in that in order to support marshalling one needs to tell it about the type.

I'm also dropping the "fromBytes" (`func([]byte) K`) function as it was rather inconvenient and inefficient for complex composite key types to implement and opted to make the iterator just return the raw key ([]byte). **Is this a reasonable trade-off?** The reason I'm doing this is because it's rather annoying writing this function for `loadbalancer.L3n4Addr`, and we have fair bit of cases where we want these sort of composite key types and I think on iteration we're far more likely interested in the value anyway (the key often is within the value anyway).
EDIT: Hmm, or maybe we'll just store `K` along with the value. Taking a look at that.
EDIT2: Ok done this, now the `Map`  stores `(key, value)` pairs and the JSON encoding is `[(k,v), ...]`.
