### PR TITLE
Add support for named initializers

### DIFF
--- a/reconciler/example/main.go
+++ b/reconciler/example/main.go
@@ -161,7 +161,9 @@ func registerHTTPServer(
 	mux.HandleFunc("/statedb", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		db.ReadTxn().WriteJSON(w)
+		if err := db.ReadTxn().WriteJSON(w); err != nil {
+			panic(err)
+		}
 	})
 
 	// For creating and deleting memos:

--- a/reconciler/example/types.go
+++ b/reconciler/example/types.go
@@ -61,11 +61,11 @@ var MemoNameIndex = statedb.Index[*Memo, string]{
 
 // MemoStatusIndex indexes memos by their reconciliation status.
 // This is mainly used by the reconciler to implement WaitForReconciliation.
-var MemoStatusIndex = reconciler.NewStatusIndex[*Memo]((*Memo).GetStatus)
+var MemoStatusIndex = reconciler.NewStatusIndex((*Memo).GetStatus)
 
 // NewMemoTable creates and registers the memos table.
 func NewMemoTable(db *statedb.DB) (statedb.RWTable[*Memo], statedb.Index[*Memo, reconciler.StatusKind], error) {
-	tbl, err := statedb.NewTable[*Memo](
+	tbl, err := statedb.NewTable(
 		"memos",
 		MemoNameIndex,
 		MemoStatusIndex,

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -78,7 +78,6 @@ type reconciler[Obj comparable] struct {
 	retries             *retries
 	externalFullTrigger chan struct{}
 	primaryIndexer      statedb.Indexer[Obj]
-	changes             *statedb.ChangeIterator[Obj]
 }
 
 func (r *reconciler[Obj]) TriggerFullReconciliation() {
@@ -132,7 +131,9 @@ func (r *reconciler[Obj]) loop(ctx context.Context, health cell.Health) error {
 
 	for {
 		if r.Config.RateLimiter != nil {
-			r.Config.RateLimiter.Wait(ctx)
+			if err := r.Config.RateLimiter.Wait(ctx); err != nil {
+				return err
+			}
 		}
 
 		// Wait for trigger

--- a/regression_test.go
+++ b/regression_test.go
@@ -38,7 +38,7 @@ func Test_Regression_29324(t *testing.T) {
 	}
 
 	db, _, _ := newTestDB(t)
-	table, err := NewTable[object]("objects", idIndex, tagIndex)
+	table, err := NewTable("objects", idIndex, tagIndex)
 	require.NoError(t, err)
 	require.NoError(t, db.RegisterTable(table))
 


### PR DESCRIPTION
```
Support named table initializers

    Add support for naming the table initializer and the ability to check if a
    specific table initializer is still pending. This will be needed in Cilium
    for implementing the two-stage GC'ing of local and remote (ClusterMesh)
    services, so I'm adding this in already.

    Example:

      var t RWTable[Foo]

      wtxn := db.WriteTxn(t)
     done := t.RegisterInitializer(txn, "example")
     wtxn.Commit()

      txn := db.ReadTxn()
     t.Initialized(txn) == false
     t.PendingInitializers(txn) == []string{"example"}

      wtxn = db.WriteTxn(t)
     // Initialize the table
     t.Insert(wtxn, Foo{...})
     ...
     done(wtxn)
     wtxn.Commmit()

      // The old ReadTxn/snapshot of course still uninitialized.
     t.Initialized(txn) == false

      txn = db.ReadTxn()
     t.Initialized(txn) == true
     t.PendingInitializers(txn) == []string{}

    Signed-off-by: Jussi Maki <jussi.maki@isovalent.com>
```

```
Fix golangci-lint warnings

    Go through the code and fix up all the relevant golangci-lint warnings.

    Signed-off-by: Jussi Maki <jussi.maki@isovalent.com>
```
