### PR TITLE
Fixes for v0.1.0 release

### DIFF
--- a/reconciler/incremental.go
+++ b/reconciler/incremental.go
@@ -5,6 +5,7 @@ package reconciler
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/cilium/hive/cell"
@@ -35,8 +36,13 @@ type incrementalRound[Obj comparable] struct {
 	// not lock the table while reconciling. If an object has changed in the meanwhile
 	// the stale reconciliation result for that object is dropped.
 	results map[Obj]opResult
+}
 
-	errs []error
+// opResult is the outcome from reconciling a single object
+type opResult struct {
+	original any              // the original object
+	rev      statedb.Revision // revision of the object
+	err      error
 }
 
 func (r *reconciler[Obj]) incremental(ctx context.Context, txn statedb.ReadTxn, changes statedb.ChangeIterator[Obj]) []error {
@@ -65,11 +71,14 @@ func (r *reconciler[Obj]) incremental(ctx context.Context, txn statedb.ReadTxn, 
 	round.processRetries()
 
 	// Finally commit the status updates.
-	round.commitStatus()
+	newErrors := round.commitStatus()
 
-	r.metrics.IncrementalReconciliationErrors(r.ModuleID, round.errs)
-
-	return round.errs
+	// Since all failures are retried, we can return the errors from the retry
+	// queue which includes both errors occurred in this round and the old
+	// errors.
+	errs := round.retries.errors()
+	round.metrics.IncrementalReconciliationErrors(r.ModuleID, newErrors, len(errs))
+	return errs
 }
 
 func (round *incrementalRound[Obj]) single(changes statedb.ChangeIterator[Obj]) {
@@ -88,10 +97,7 @@ func (round *incrementalRound[Obj]) single(changes statedb.ChangeIterator[Obj]) 
 		// Clear retries as the object has changed.
 		round.retries.Clear(obj)
 
-		err := round.processSingle(obj, change.Revision, change.Deleted)
-		if err != nil {
-			round.errs = append(round.errs, err)
-		}
+		round.processSingle(obj, change.Revision, change.Deleted)
 		round.numReconciled++
 		if round.numReconciled >= round.config.IncrementalRoundSize {
 			break
@@ -119,12 +125,13 @@ func (round *incrementalRound[Obj]) batch(changes statedb.ChangeIterator[Obj]) {
 		round.retries.Clear(obj)
 
 		// Clone the object so we or the operations can mutate it.
+		orig := obj
 		obj = round.config.CloneObject(obj)
 
 		if change.Deleted {
-			deleteBatch = append(deleteBatch, BatchEntry[Obj]{Object: obj, Revision: rev})
+			deleteBatch = append(deleteBatch, BatchEntry[Obj]{Object: obj, Revision: rev, original: orig})
 		} else {
-			updateBatch = append(updateBatch, BatchEntry[Obj]{Object: obj, Revision: rev})
+			updateBatch = append(updateBatch, BatchEntry[Obj]{Object: obj, Revision: rev, original: orig})
 		}
 
 		round.numReconciled++
@@ -145,8 +152,7 @@ func (round *incrementalRound[Obj]) batch(changes statedb.ChangeIterator[Obj]) {
 		for _, entry := range deleteBatch {
 			if entry.Result != nil {
 				// Delete failed, queue a retry for it.
-				round.errs = append(round.errs, entry.Result)
-				round.retries.Add(entry.Object, entry.Revision, true)
+				round.retries.Add(entry.original, entry.Revision, true, entry.Result)
 			}
 		}
 	}
@@ -163,13 +169,9 @@ func (round *incrementalRound[Obj]) batch(changes statedb.ChangeIterator[Obj]) {
 
 		for _, entry := range updateBatch {
 			if entry.Result == nil {
-				// Reconciling succeeded, so clear the retries.
 				round.retries.Clear(entry.Object)
-				round.results[entry.Object] = opResult{rev: entry.Revision, status: StatusDone()}
-			} else {
-				round.errs = append(round.errs, entry.Result)
-				round.results[entry.Object] = opResult{rev: entry.Revision, status: StatusError(entry.Result)}
 			}
+			round.results[entry.Object] = opResult{rev: entry.Revision, err: entry.Result, original: entry.original}
 		}
 	}
 }
@@ -182,17 +184,12 @@ func (round *incrementalRound[Obj]) processRetries() {
 			break
 		}
 		round.retries.Pop()
-
-		err := round.processSingle(item.object.(Obj), item.rev, item.delete)
-		if err != nil {
-			round.errs = append(round.errs, err)
-		}
-
+		round.processSingle(item.object.(Obj), item.rev, item.delete)
 		round.numReconciled++
 	}
 }
 
-func (round *incrementalRound[Obj]) processSingle(obj Obj, rev statedb.Revision, delete bool) error {
+func (round *incrementalRound[Obj]) processSingle(obj Obj, rev statedb.Revision, delete bool) {
 	start := time.Now()
 
 	var (
@@ -204,31 +201,24 @@ func (round *incrementalRound[Obj]) processSingle(obj Obj, rev statedb.Revision,
 		err = round.config.Operations.Delete(round.ctx, round.txn, obj)
 		if err != nil {
 			// Deletion failed. Retry again later.
-			round.retries.Add(obj, rev, true)
+			round.retries.Add(obj, rev, true, err)
 		}
 	} else {
 		// Clone the object so it can be mutated by Update()
+		orig := obj
 		obj = round.config.CloneObject(obj)
 		op = OpUpdate
 		err = round.config.Operations.Update(round.ctx, round.txn, obj)
-		if err == nil {
-			round.results[obj] = opResult{rev: rev, status: StatusDone()}
-		} else {
-			round.results[obj] = opResult{rev: rev, status: StatusError(err)}
-		}
+		round.results[obj] = opResult{original: orig, rev: rev, err: err}
 	}
 	round.metrics.IncrementalReconciliationDuration(round.moduleID, op, time.Since(start))
 
 	if err == nil {
-		// Reconciling succeeded, so clear the object.
 		round.retries.Clear(obj)
 	}
-
-	return err
-
 }
 
-func (round *incrementalRound[Obj]) commitStatus() {
+func (round *incrementalRound[Obj]) commitStatus() (numErrors int) {
 	if len(round.results) == 0 {
 		// Nothing to commit.
 		return
@@ -242,12 +232,24 @@ func (round *incrementalRound[Obj]) commitStatus() {
 		// Update the object if it is unchanged. It may happen that the object has
 		// been updated in the meanwhile, in which case we ignore the status as the
 		// update will be picked up by next reconciliation round.
-		round.table.CompareAndSwap(wtxn, result.rev, round.config.SetObjectStatus(obj, result.status))
+		var status Status
+		if result.err == nil {
+			status = StatusDone()
+		} else {
+			status = StatusError(result.err)
+			numErrors++
+		}
+		_, _, err := round.table.CompareAndSwap(wtxn, result.rev,
+			round.config.SetObjectStatus(obj, status))
 
-		if result.status.Kind == StatusKindError {
-			// Reconciling the object failed, so add it to be retried now that its
-			// status is updated.
-			round.retries.Add(obj, result.rev, false)
+		if result.err != nil && err == nil {
+			// Reconciliation of the object had failed and the status was updated
+			// successfully (object had not changed). Queue the retry for the object.
+			newRevision := round.table.Revision(wtxn)
+			round.retries.Add(result.original.(Obj), newRevision, false, result.err)
+		} else if result.err != nil && err != nil {
+			fmt.Printf("FAIL queued %v for retry due to %s ! %s\n", result.original, result.err, err)
 		}
 	}
+	return
 }

--- a/reconciler/metrics.go
+++ b/reconciler/metrics.go
@@ -12,7 +12,7 @@ import (
 
 type Metrics interface {
 	IncrementalReconciliationDuration(moduleID cell.FullModuleID, operation string, duration time.Duration)
-	IncrementalReconciliationErrors(moduleID cell.FullModuleID, errs []error)
+	IncrementalReconciliationErrors(moduleID cell.FullModuleID, newErrors, currentErrors int)
 
 	FullReconciliationErrors(moduleID cell.FullModuleID, errs []error)
 	FullReconciliationDuration(moduleID cell.FullModuleID, operation string, duration time.Duration)
@@ -53,12 +53,12 @@ func (m *ExpVarMetrics) IncrementalReconciliationDuration(moduleID cell.FullModu
 	m.IncrementalReconciliationDurationVar.AddFloat(moduleID.String()+"/"+operation, duration.Seconds())
 }
 
-func (m *ExpVarMetrics) IncrementalReconciliationErrors(moduleID cell.FullModuleID, errs []error) {
+func (m *ExpVarMetrics) IncrementalReconciliationErrors(moduleID cell.FullModuleID, newErrors, currentErrors int) {
 	m.IncrementalReconciliationCountVar.Add(moduleID.String(), 1)
-	m.IncrementalReconciliationTotalErrorsVar.Add(moduleID.String(), int64(len(errs)))
+	m.IncrementalReconciliationTotalErrorsVar.Add(moduleID.String(), int64(newErrors))
 
 	var intVar expvar.Int
-	intVar.Set(int64(len(errs)))
+	intVar.Set(int64(currentErrors))
 	m.IncrementalReconciliationCurrentErrorsVar.Set(moduleID.String(), &intVar)
 }
 

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -180,7 +180,7 @@ func (r *reconciler[Obj]) loop(ctx context.Context, health cell.Health) error {
 				fmt.Sprintf("OK, %d objects", r.Config.Table.NumObjects(txn)))
 		} else {
 			health.Degraded(
-				fmt.Sprintf("%d failure(s)", len(errs)),
+				fmt.Sprintf("%d error(s)", len(errs)),
 				joinErrors(errs))
 		}
 	}

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -150,7 +150,7 @@ func testReconciler(t *testing.T, batchOps bool) {
 			h.expectOp(opFail(opUpdate(ID_1)))
 			h.expectStatus(ID_1, reconciler.StatusKindError, "update fail")
 			h.expectRetried(ID_1)
-			h.expectHealth(cell.StatusDegraded, "1 failure(s)", "update fail")
+			h.expectHealth(cell.StatusDegraded, "1 error(s)", "update fail")
 
 			// Fix the object => object will reconcile again.
 			t.Log("Setting '1' non-faulty")
@@ -172,7 +172,7 @@ func testReconciler(t *testing.T, batchOps bool) {
 			h.setTargetFaulty(true)
 			h.markForDelete(ID_3)
 			h.expectOp(opFail(opDelete(3)))
-			h.expectHealth(cell.StatusDegraded, "1 failure(s)", "delete fail")
+			h.expectHealth(cell.StatusDegraded, "1 error(s)", "delete fail")
 
 			t.Log("Set the target non-faulty to delete '3'")
 			h.setTargetFaulty(false)
@@ -239,7 +239,7 @@ func testReconciler(t *testing.T, batchOps bool) {
 				opFail(opUpdate(ID_2)),
 				opFail(opUpdate(ID_3)),
 			)
-			h.expectHealth(cell.StatusDegraded, "3 failure(s)", "update fail")
+			h.expectHealth(cell.StatusDegraded, "3 error(s)", "update fail")
 
 			// Expect the objects to be retried also after the full reconciliation.
 			h.expectRetried(ID_1)

--- a/reconciler/retries.go
+++ b/reconciler/retries.go
@@ -18,11 +18,11 @@ type exponentialBackoff struct {
 }
 
 func (e *exponentialBackoff) Duration(attempt int) time.Duration {
-	dur := time.Duration(float64(e.min) * math.Pow(2, float64(attempt)))
-	if dur > e.max {
-		dur = e.max
+	dur := float64(e.min) * math.Pow(2, float64(attempt))
+	if dur > float64(e.max) {
+		return e.max
 	}
-	return dur
+	return time.Duration(dur)
 }
 
 func newRetries(minDuration, maxDuration time.Duration, objectToKey func(any) index.Key) *retries {

--- a/reconciler/retries_test.go
+++ b/reconciler/retries_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/statedb/index"
 )
@@ -102,5 +103,18 @@ func TestRetries(t *testing.T) {
 	}
 	_, ok = rq.Top()
 	assert.False(t, ok)
+}
 
+func TestExponentialBackoff(t *testing.T) {
+	backoff := exponentialBackoff{
+		min: time.Millisecond,
+		max: time.Second,
+	}
+
+	for i := 0; i < 1000; i++ {
+		dur := backoff.Duration(i)
+		require.GreaterOrEqual(t, dur, backoff.min)
+		require.LessOrEqual(t, dur, backoff.max)
+	}
+	require.Equal(t, backoff.Duration(0)*2, backoff.Duration(1))
 }

--- a/reconciler/types.go
+++ b/reconciler/types.go
@@ -157,6 +157,8 @@ type BatchEntry[Obj any] struct {
 	Object   Obj
 	Revision statedb.Revision
 	Result   error
+
+	original Obj
 }
 
 type BatchOperations[Obj any] interface {
@@ -254,10 +256,4 @@ func StatusError(err error) Status {
 		UpdatedAt: time.Now(),
 		Error:     err.Error(),
 	}
-}
-
-// opResult is the outcome from reconciling a single object
-type opResult struct {
-	rev    statedb.Revision // revision of the object
-	status Status           // the status to commit
 }


### PR DESCRIPTION
```
reconciler: Do not query for object when retrying

    There's no need to requery for the object when retrying as the entry will be
    cleared from the queue if it has changed.

    This will also retain the original status of the object which allows the
    operations to distinquish whether the Update() call is a retry of a normal
    update or a refresh.

    Signed-off-by: Jussi Maki <jussi.maki@isovalent.com>

reconciler: Fix health reporting of retries

    The objects waiting for retry were not properly reflected in the health
    status. A reconciliation round after the failures cleared the health status
    rather than reflected the number of objects still waiting for retry.

    Fix this by remembering the error in the retry queue items and returning 
    those. Also modify the metrics implementation to properly reflect the
    "new" and "current" (new + waiting to retry) errors.

    Signed-off-by: Jussi Maki <jussi.maki@isovalent.com>

reconciler: Fix max backoff calculation

    With enough retry attempts the duration becomes too large and overflows on
    conversion to time.Duration leading to negative durations. Fix this by
    checking the bounds with a float64 before conversion.

    Signed-off-by: Jussi Maki <jussi.maki@isovalent.com>

reconciler: Fix retries.Add() when called multiple times

    The Add() function did not properly handle the case when an item was Add()'d
    that was still in the queue. This happened via the full reconciliation where
    it was queueing retries for failed refreshes.

    The effect of the bug was that the same item could end up in the retry queue
    multiple times. This combined with the miscalculation of the retryAt time
    eventually caused an item to be retried without any backoff.

    Signed-off-by: Jussi Maki <jussi.maki@isovalent.com>
```