### PR TITLE
Fix API asymmetries with Watch variants

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -342,7 +342,7 @@ func BenchmarkDB_FullIteration_All(b *testing.B) {
 
 	for j := 0; j < b.N; j++ {
 		txn := db.ReadTxn()
-		iter, _ := table.All(txn)
+		iter := table.All(txn)
 		i := uint64(0)
 		for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
 			if obj.ID != i {
@@ -449,11 +449,11 @@ func BenchmarkDB_PropagationDelay(b *testing.B) {
 
 		// Grab a watch channel on the second table
 		txn := db.ReadTxn()
-		_, watch2 := table2.All(txn)
+		_, watch2 := table2.AllWatch(txn)
 
 		// Propagate the batch from first table to the second table
 		var iter Iterator[testObject]
-		iter, watch1 = table1.LowerBound(txn, ByRevision[testObject](revision))
+		iter, watch1 = table1.LowerBoundWatch(txn, ByRevision[testObject](revision))
 		wtxn = db.WriteTxn(table2)
 		for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
 			table2.Insert(wtxn, testObject2(obj))

--- a/derive_test.go
+++ b/derive_test.go
@@ -106,8 +106,7 @@ func TestDerive(t *testing.T) {
 
 	getDerived := func() []derived {
 		txn := db.ReadTxn()
-		iter, _ := outTable.All(txn)
-		objs := Collect(iter)
+		objs := Collect(outTable.All(txn))
 		// Log so we can trace the failed eventually calls
 		t.Logf("derived: %+v", objs)
 		return objs

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -140,7 +140,7 @@ func (a *realActionLog) validateTable(txn statedb.ReadTxn, table statedb.Table[f
 	// Since everything was deleted we can clear the log entries for this table now
 	a.log[table.Name()] = nil
 
-	iter, _ := table.All(txn)
+	iter := table.All(txn)
 	actual := map[string]struct{}{}
 	for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
 		actual[obj.id] = struct{}{}
@@ -247,7 +247,7 @@ func deleteManyAction(ctx actionContext) {
 	// nothing bad happens when the iterator is used while deleting.
 	toDelete := ctx.table.NumObjects(ctx.txn) / 3
 
-	iter, _ := ctx.table.All(ctx.txn)
+	iter := ctx.table.All(ctx.txn)
 	n := 0
 	for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
 		ctx.log.log("%s: DeleteMany %s (%d/%d)", ctx.table.Name(), obj.id, n+1, toDelete)
@@ -267,7 +267,7 @@ func deleteManyAction(ctx actionContext) {
 }
 
 func allAction(ctx actionContext) {
-	iter, _ := ctx.table.All(ctx.txn)
+	iter := ctx.table.All(ctx.txn)
 	ctx.log.log("%s: All => %d found", ctx.table.Name(), len(statedb.Collect(iter)))
 }
 
@@ -319,13 +319,13 @@ func getAction(ctx actionContext) {
 
 func lowerboundAction(ctx actionContext) {
 	id := mkID()
-	iter, _ := ctx.table.LowerBound(ctx.txn, idIndex.Query(id))
+	iter, _ := ctx.table.LowerBoundWatch(ctx.txn, idIndex.Query(id))
 	ctx.log.log("%s: LowerBound(%s) => %d found", ctx.table.Name(), id, len(statedb.Collect(iter)))
 }
 
 func prefixAction(ctx actionContext) {
 	id := mkID()
-	iter, _ := ctx.table.Prefix(ctx.txn, idIndex.Query(id))
+	iter := ctx.table.Prefix(ctx.txn, idIndex.Query(id))
 	ctx.log.log("%s: Prefix(%s) => %d found", ctx.table.Name(), id, len(statedb.Collect(iter)))
 }
 
@@ -417,7 +417,7 @@ func trackerWorker(i int, stop <-chan struct{}) {
 			// Validate that the observed changes match with the database state at this
 			// snapshot.
 			state2 := maps.Clone(state)
-			iterAll, _ := tableFuzz1.LowerBound(txn, statedb.ByRevision[fuzzObj](0))
+			iterAll := tableFuzz1.LowerBound(txn, statedb.ByRevision[fuzzObj](0))
 			for obj, rev, ok := iterAll.Next(); ok; obj, rev, ok = iterAll.Next() {
 				change, found := state[obj.id]
 				if !found {

--- a/iterator.go
+++ b/iterator.go
@@ -244,7 +244,7 @@ func (it *changeIterator[Obj]) Watch(txn ReadTxn) <-chan struct{} {
 			return it.watch
 		}
 
-		updateIter, watch := it.table.LowerBound(txn, ByRevision[Obj](it.revision+1))
+		updateIter, watch := it.table.LowerBoundWatch(txn, ByRevision[Obj](it.revision+1))
 		deleteIter := it.dt.deleted(txn, it.revision+1)
 		it.iter = NewDualIterator(deleteIter, updateIter)
 

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -38,7 +38,7 @@ func TestFilter(t *testing.T) {
 	table.Insert(txn, &testObject{ID: 5})
 	txn.Commit()
 
-	iter, _ := table.All(db.ReadTxn())
+	iter := table.All(db.ReadTxn())
 	filtered := Collect(
 		Map(
 			Filter(

--- a/reconciler/benchmark/main.go
+++ b/reconciler/benchmark/main.go
@@ -205,7 +205,7 @@ func main() {
 	}
 
 	// Check that all statuses are correctly set.
-	iter, _ := testObjects.All(db.ReadTxn())
+	iter := testObjects.All(db.ReadTxn())
 	for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
 		if obj.status.Kind != reconciler.StatusKindDone {
 			log.Fatalf("Object with unexpected status: %#v", obj)

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -111,7 +111,7 @@ func (r *reconciler[Obj]) reconcileLoop(ctx context.Context, health cell.Health)
 
 // prune performs the Prune operation to delete unexpected objects in the target system.
 func (r *reconciler[Obj]) prune(ctx context.Context, txn statedb.ReadTxn) error {
-	iter, _ := r.config.Table.All(txn)
+	iter := r.config.Table.All(txn)
 	start := time.Now()
 	err := r.config.Operations.Prune(ctx, txn, iter)
 	if err != nil {
@@ -145,7 +145,7 @@ outer:
 		// Iterate over the objects in revision order, e.g. oldest modification first.
 		// We look for objects that are older than [RefreshInterval] and mark them for
 		// pending in order for them to be reconciled again.
-		iter, _ := r.config.Table.LowerBound(r.DB.ReadTxn(), statedb.ByRevision[Obj](lastRevision+1))
+		iter := r.config.Table.LowerBound(r.DB.ReadTxn(), statedb.ByRevision[Obj](lastRevision+1))
 		indexer := r.config.Table.PrimaryIndexer()
 		for obj, rev, ok := iter.Next(); ok; obj, rev, ok = iter.Next() {
 			status := r.config.GetObjectStatus(obj)

--- a/types.go
+++ b/types.go
@@ -42,9 +42,12 @@ type Table[Obj any] interface {
 	// increments in a write transaction on each Insert and Delete.
 	Revision(ReadTxn) Revision
 
-	// All returns an iterator for all objects in the table and a watch
+	// All returns an iterator for all objects in the table.
+	All(ReadTxn) Iterator[Obj]
+
+	// AllWatch returns an iterator for all objects in the table and a watch
 	// channel that is closed when the table changes.
-	All(ReadTxn) (Iterator[Obj], <-chan struct{})
+	AllWatch(ReadTxn) (Iterator[Obj], <-chan struct{})
 
 	// List returns an iterator for all objects matching the given query.
 	List(ReadTxn, Query[Obj]) Iterator[Obj]
@@ -62,13 +65,21 @@ type Table[Obj any] interface {
 	GetWatch(ReadTxn, Query[Obj]) (obj Obj, rev Revision, watch <-chan struct{}, found bool)
 
 	// LowerBound returns an iterator for objects that have a key
+	// greater or equal to the query.
+	LowerBound(ReadTxn, Query[Obj]) Iterator[Obj]
+
+	// LowerBoundWatch returns an iterator for objects that have a key
 	// greater or equal to the query. The returned watch channel is closed
 	// when anything in the table changes as more fine-grained notifications
 	// are not possible with a lower bound search.
-	LowerBound(ReadTxn, Query[Obj]) (iter Iterator[Obj], watch <-chan struct{})
+	LowerBoundWatch(ReadTxn, Query[Obj]) (iter Iterator[Obj], watch <-chan struct{})
 
 	// Prefix searches the table by key prefix.
-	Prefix(ReadTxn, Query[Obj]) (iter Iterator[Obj], watch <-chan struct{})
+	Prefix(ReadTxn, Query[Obj]) Iterator[Obj]
+
+	// PrefixWatch searches the table by key prefix. Returns an iterator and a watch
+	// channel that closes when the query results have become stale.
+	PrefixWatch(ReadTxn, Query[Obj]) (iter Iterator[Obj], watch <-chan struct{})
 
 	// Changes returns an iterator for changes happening to the table.
 	// This uses the revision index to iterate over the objects in the order


### PR DESCRIPTION
Add *Watch variants to LowerBound, Prefix and All to make them work the same way as List and Get.