### PR TITLE
part: Add QuickTests

### DIFF
--- a/part/part_test.go
+++ b/part/part_test.go
@@ -594,6 +594,32 @@ func Test_prefix(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func Test_deleteEmptyKey(t *testing.T) {
+	tree := New[string]()
+
+	_, _, tree = tree.Insert([]byte{}, "x")
+
+	v, watch, ok := tree.Get([]byte{})
+	assert.True(t, ok)
+	assert.Equal(t, "x", v)
+	select {
+	case <-watch:
+		t.Fatalf("channel closed")
+	default:
+	}
+
+	_, _, tree = tree.Delete([]byte{})
+
+	_, _, ok = tree.Get([]byte{})
+	assert.False(t, ok)
+
+	select {
+	case <-watch:
+	default:
+		t.Fatalf("channel not closed")
+	}
+}
+
 func Test_txn(t *testing.T) {
 	tree := New[uint64]()
 	ins := func(n uint64) { _, _, tree = tree.Insert(uint64Key(n), n) }

--- a/part/quick_test.go
+++ b/part/quick_test.go
@@ -1,0 +1,120 @@
+package part_test
+
+import (
+	"testing"
+	"testing/quick"
+
+	"github.com/cilium/statedb/part"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQuick_InsertGetPrefix(t *testing.T) {
+	tree := part.New[string]()
+	insert := func(key, value string) any {
+		_, _, tree = tree.Insert([]byte(key), value)
+		return value
+	}
+
+	get := func(key, value string) any {
+		val, _, _ := tree.Get([]byte(key))
+		if val != value {
+			return val
+		}
+
+		iter, _ := tree.Prefix([]byte(key))
+		_, v, _ := iter.Next()
+		return v
+	}
+
+	require.NoError(t,
+		quick.CheckEqual(insert, get, nil),
+	)
+}
+
+func TestQuick_Delete(t *testing.T) {
+	tree := part.New[string]()
+
+	do := func(key, value string, delete bool) bool {
+		_, _, tree = tree.Insert([]byte(key), value)
+		treeAfterInsert := tree
+		v, watch, ok := tree.Get([]byte(key))
+		if !ok || v != value {
+			t.Logf("value not in tree after insert")
+			return false
+		}
+
+		// delete some of the time to construct different variations of trees.
+		if delete {
+			_, _, tree = tree.Delete([]byte(key))
+			_, _, ok := tree.Get([]byte(key))
+			if ok {
+				t.Logf("value exists after delete")
+				return false
+			}
+
+			_, _, ok = treeAfterInsert.Get([]byte(key))
+			if !ok {
+				t.Logf("value deleted from original")
+			}
+
+			// Check that watch channel closed.
+			select {
+			case <-watch:
+			default:
+				t.Logf("watch channel not closed")
+				return false
+			}
+		}
+		return true
+	}
+
+	require.NoError(t, quick.Check(do, nil))
+}
+
+func TestQuick_ClosedWatch(t *testing.T) {
+	tree := part.New[string]()
+	insert := func(key, value string) bool {
+		_, _, tree = tree.Insert([]byte(key), value)
+		treeAfterInsert := tree
+
+		val, watch, ok := tree.Get([]byte(key))
+		if !ok {
+			return false
+		}
+		if val != value {
+			return false
+		}
+
+		select {
+		case <-watch:
+			return false
+		default:
+		}
+
+		// Changing the key makes the channel close.
+		_, _, tree = tree.Insert([]byte(key), "x")
+		select {
+		case <-watch:
+		default:
+			t.Logf("channel not closed!")
+			return false
+		}
+
+		// Original tree unaffected.
+		val, _, ok = treeAfterInsert.Get([]byte(key))
+		if !ok || val != value {
+			t.Logf("original changed!")
+			return false
+		}
+
+		val, _, ok = tree.Get([]byte(key))
+		if !ok || val != "x" {
+			t.Logf("new tree does not have x!")
+			return false
+		}
+
+		return true
+	}
+
+	require.NoError(t, quick.Check(insert, nil))
+}

--- a/part/txn.go
+++ b/part/txn.go
@@ -374,9 +374,9 @@ func (txn *Txn[T]) delete(root *header[T], key []byte) (oldValue T, hadOld bool,
 	oldValue = leaf.value
 	hadOld = true
 
-	// Mark the watch channel of the target node for closing if not mutated already.
-	if this.watch != nil && !txn.mutated.exists(this) {
-		txn.watches[this.watch] = struct{}{}
+	// Mark the watch channel of the target for closing if not mutated already.
+	if leaf.watch != nil {
+		txn.watches[leaf.watch] = struct{}{}
 	}
 
 	if this == root {


### PR DESCRIPTION
Add generative QuickTests to test out different
operations on generated inputs.

Fix the bug with closing the watch channel when
deleting single element tree with a zero-sized key.