### PR TITLE
reconciler: Fix refresh timer calculation

### DIFF
--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"expvar"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -18,7 +19,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
-	"golang.org/x/exp/slices"
 	"golang.org/x/time/rate"
 
 	"github.com/cilium/hive"


### PR DESCRIPTION
The refresh loop was supposed to wait until the oldest object's UpdatedAt time exceeds the RefreshInterval. Unfortunately the calculation was reversed (`UpdatedSince - RefreshInterval` when it should've been `RefreshInterval - UpdatedSince`) and the refresh duration to wait became negative, which caused the refreshLoop to busy-loop looking for the next object to refresh. 

This did not affect correctness as the timer was only used to wait before checking for expired objects and thus was not catched.

Before: 
```
agent.datapath.sysctl                            job-refresh     OK      Refreshing in -2m39.041586521s ...    
```
(job-refresh busy-loop'd constantly updating the health and resetting the timer to a negative value which then immediately fired)

After:
```
agent.datapath.sysctl                            job-refresh      OK      Next refresh in 9m45.997072899s  ...
```

Refresh in action:
```
root@kind-worker:/home/cilium# cilium statedb sysctl -w=10ms
# Name                                      Value   Status
net.ipv4.ip_forward                         1       Done (9.9m ago)
net.ipv4.conf.all.forwarding                1       Done (9.9m ago)
...
net.ipv4.conf.cilium_vxlan.accept_local     1       Refreshing (0.3ms ago)
net.ipv4.conf.cilium_vxlan.send_redirects   0       Refreshing (0.3ms ago)
net.ipv6.conf.cilium_vxlan.forwarding       1       Refreshing (0.3ms ago)
net.ipv4.conf.cilium_vxlan.forwarding       1       Refreshing (0.3ms ago)
net.ipv4.conf.cilium_vxlan.rp_filter        0       Refreshing (0.3ms ago)
net.ipv4.conf.cilium_vxlan.send_redirects   0       Done (10.7ms ago)
net.ipv6.conf.cilium_vxlan.forwarding       1       Done (10.7ms ago)
net.ipv4.conf.cilium_vxlan.forwarding       1       Done (10.7ms ago)
...
```