### PR TITLE
Refactor API to use iter.Seq2 instead of Iterator[T]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
     - main
 
 env:
-  GO_VERSION: 1.22.2
+  GO_VERSION: 1.23
 
 jobs:
   test:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,7 @@ on:
     - main
 
 env:
-  GO_VERSION: 1.22.2
+  GO_VERSION: 1.23
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -115,26 +115,31 @@ func example() {
     ...
   }
 
-  // Iterate all objects
-  iter := myObjects.All()
-  for obj, revision, ok := iter.Next(); ok; obj, revision, ok = iter.Next() {
+  // Iterate over all objects
+  for obj := range myObjects.All() {
+    ...
+  }
+
+  // Iterate with revision
+  for obj, revision := range myObjects.All() {
     ...
   }
   
   // Iterate all objects and then wait until something changes.
-  iter, watch := myObjects.AllWatch(txn)
-  for ... {}
+  objs, watch := myObjects.AllWatch(txn)
+  for obj := range objs { ... }
   <-watch
+
   // Grab a new snapshot to read the new changes.
   txn = db.ReadTxn()
   
   // Iterate objects with ID >= 2
-  iter, watch = myObjects.LowerBoundWatch(txn, IDIndex.Query(2))
-  for ... {}
+  objs, watch = myObjects.LowerBoundWatch(txn, IDIndex.Query(2))
+  for obj := range objs { ... }
   
   // Iterate objects where ID is between 0x1000_0000 and 0x1fff_ffff
-  iter, watch = myObjects.PrefixWatch(txn, IDIndex.Query(0x1000_0000))
-  for ... {}
+  objs, watch = myObjects.PrefixWatch(txn, IDIndex.Query(0x1000_0000))
+  for obj := range objs { ... }
 }
 ```
 
@@ -338,19 +343,17 @@ obj, revision, watch, found = myObjects.GetWatch(txn, IDIndex.Query(42))
 `List` can be used to iterate over all objects that match the query.
 
 ```go
-var iter statedb.Iterator[*MyObject]
-// List returns all matching objects as an iterator. The iterator is lazy
-// and one can stop reading at any time without worrying about the rest.
-iter := myObjects.List(txn, TagsIndex.Query("hello"))
-for obj, revision, ok := iter.Next(); ok; obj, revision, ok = iter.Next() {
-  // ...
+// List returns all matching objects as an iter.Seq2[Obj, Revision].
+objs := myObjects.List(txn, TagsIndex.Query("hello"))
+for obj, revision := range objs {
+  ...
 }
 
 // ListWatch is like List, but also returns a watch channel.
-iter, watch := myObjects.ListWatch(txn, TagsIndex.Query("hello"))
-for obj, revision, ok := iter.Next(); ok; obj, revision, ok = iter.Next() { ... }
+objs, watch := myObjects.ListWatch(txn, TagsIndex.Query("hello"))
+for obj, revision := range objs { ... }
 
-// closes when an object with tag "hello" is inserted or deleted
+// closes when an object with tag "hello" is inserted or deleted.
 <-watch
 ```
 
@@ -359,10 +362,11 @@ for obj, revision, ok := iter.Next(); ok; obj, revision, ok = iter.Next() { ... 
 ```go
 // Prefix does a prefix search on an index. Here it returns an iterator
 // for all objects that have a tag that starts with "h".
-iter, watch = myObjects.Prefix(txn, TagsIndex.Query("h"))
-for obj, revision, ok := iter.Next(); ok; obj, revision, ok = iter.Next() {
-  // ...
-}
+objs, watch = myObjects.Prefix(txn, TagsIndex.Query("h"))
+for obj := range objs {
+  ...
+} 
+
 // closes when an object with a tag starting with "h" is inserted or deleted
 <-watch
 ```
@@ -376,8 +380,8 @@ have a key equal to or higher than given key.
 // For example index.Uint32 returns the big-endian or most significant byte
 // first form of the integer, in other words the number 3 is the key
 // []byte{0, 0, 0, 3}, which allows doing a meaningful LowerBound search on it.
-iter, watch = myObjects.LowerBoundWatch(txn, IDIndex.Query(3))
-for obj, revision, ok := iter.Next(); ok; obj, revision, ok = iter.Next() {
+objs, watch = myObjects.LowerBoundWatch(txn, IDIndex.Query(3))
+for obj, revision := range objs {
   // obj.ID >= 3
 }
 
@@ -402,8 +406,9 @@ with `ByRevision`.
 // we can use this to wait for new changes!
 lastRevision := statedb.Revision(0)
 for {
-  iter, watch = myObjects.LowerBoundWatch(txn, statedb.ByRevision(lastRevision+1))
-  for obj, revision, ok := iter.Next(); ok; obj, revision, ok = iter.Next() {
+  objs, watch = myObjects.LowerBoundWatch(txn, statedb.ByRevision(lastRevision+1))
+  for obj, revision := range objs {
+    // do something with obj
     lastRevision = revision
   }
 
@@ -428,10 +433,10 @@ been observed. Using `Changes` one can iterate over insertions and deletions.
 ```go
 // Let's iterate over both inserts and deletes. We need to use
 // a write transaction to create the change iterator as this needs to
-// register with the table to track the deleted objects.
+// register with the table to track the deleted objects. 
 
 wtxn := statedb.WriteTxn(myObjects)
-changes, err := myObjects.Changes(wtxn)
+changeIter, err := myObjects.Changes(wtxn)
 wtxn.Commit()
 if err != nil {
   // This can fail due to same reasons as e.g. Insert()
@@ -440,24 +445,23 @@ if err != nil {
   return err
 }
 
-// We need to remember to Close() it so that StateDB does not hold onto
-// deleted objects for us. No worries though, a finalizer will close it
-// for us if we do not do this.
-defer changes.Close()
-
 // Now very similar to the LowerBound revision iteration above, we will
 // iterate over the changes.
 for {
-  for change, revision, ok := iter.Next(); ok; change, revision, ok = iter.Next() {
+  changes, watch := changeIter.Next(db.ReadTxn())
+  for change := range changes {
     if change.Deleted {
       fmt.Printf("Object %#v was deleted!\n", change.Object)
     } else {
       fmt.Printf("Object %#v was inserted!\n", change.Object)
     }
   }
-  // To observe more changes, we create a new ReadTxn and pass it to Watch() that
-  // refreshes the iterator. Once the returned channel closes we can iterate again.
-  <-changes.Watch(db.ReadTxn())
+  // Wait for more changes.
+  select {
+  case <-ctx.Done():
+    return
+  case <-watch:
+  }
 }
 ```
 
@@ -527,6 +531,33 @@ if errors.Is(err, statedb.ErrRevisionNotEqual) {
 wtxn.Commit()
 ```
 
+### Utilities
+
+StateDB includes few utility functions for operating on the iterators returned
+by the query methods.
+
+```go
+  // objs is an iterator for (object, revision) pairs. It can be consumed
+  // multiple times.
+  var objs iter.Seq2[*MyObject, statedb.Revision]
+  objs = myObjects.All(db.ReadTxn())
+
+  // The values can be collected into a slice.
+  var objsSlice []*MyObject
+  objsSlice = statedb.Collect(objs)
+
+  // The sequence can be mapped to another value.
+  var ids iter.Seq2[ID, Revision]
+  ids = statedb.Map(objs, func(o *MyObject) ID { return o.ID })
+
+  // The sequence can be filtered.
+  ids = statedb.Filter(ids, func(id ID) bool { return id > 0 })
+
+  // The revisions can be dropped by converting iter.Seq2 into iter.Seq
+  var onlyIds iter.Seq[ID]
+  onlyIds = statedb.ToSeq(ids)
+```
+
 ### Performance considerations
 
 Needless to say, one should keep the duration of the write transactions
@@ -541,6 +572,10 @@ on a watch channel to close. The `ReadTxn` holds a pointer to the database
 root and thus holding it will prevent old objects from being garbage collected
 by the Go runtime. Considering grabbing the `ReadTxn` in a function and returning
 the watch channel to the function doing the for-select loop.
+
+It is fine to hold onto the `iter.Seq2[Obj, Revision]` returned by the queries
+and since it may be iterated over multiple times, it may be preferable to pass
+and hold the `iter.Seq2` instead of collecting the objects into a slice.
 
 ## Persistent Map and Set
 
@@ -573,12 +608,12 @@ m = mNew
 m = m.Set("two")
 
 // All key-value pairs can be iterated over.
-iter := m.All()
+kvs := m.All()
 // Maps can be prefix and lowerbound searched, just like StateDB tables
-iter = m.Prefix("a")  // Iterator for anything starting with 'a'
-iter = m.LowerBound("b") // Iterator for anything equal to 'b' or larger, e.g. 'bb' or 'c'...
+kvs = m.Prefix("a")  // Iterator for anything starting with 'a'
+kvs = m.LowerBound("b") // Iterator for anything equal to 'b' or larger, e.g. 'bb' or 'c'...
 
-for k, v, ok := iter.Next(); ok; k, v, ok = iter.Next() {
+for k, v := range kvs {
   // ...
 }
 
@@ -619,8 +654,7 @@ s3 = s3.Union(s)
 s3.Len() == 3
 
 // Print "hello", "foo", "world"
-iter := s3.All()
-for word, ok := iter.Next(); ok; word, ok = iter.Next() {
+for word := range s3.All() {
   fmt.Println(word)
 }
 

--- a/db_test.go
+++ b/db_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"slices"
 	"testing"
 	"time"
 
@@ -763,7 +764,7 @@ func TestDB_GetList(t *testing.T) {
 	obj, rev, _, ok = table.GetWatch(txn, tagsIndex.Query("even"))
 	require.True(t, ok, "expected Get(even) to return result")
 	require.NotZero(t, rev, "expected non-zero revision")
-	require.ElementsMatch(t, obj.Tags.Slice(), []string{"even", "modified"})
+	require.ElementsMatch(t, slices.Collect(obj.Tags.All()), []string{"even", "modified"})
 	require.EqualValues(t, 2, obj.ID)
 
 	iter = table.List(txn, tagsIndex.Query("odd"))
@@ -856,7 +857,7 @@ func TestDB_CompareAndSwap_CompareAndDelete(t *testing.T) {
 	obj, _, ok = table.Get(db.ReadTxn(), idIndex.Query(1))
 	require.True(t, ok)
 	require.Equal(t, 1, obj.Tags.Len())
-	v, _ := obj.Tags.All().Next()
+	v := slices.Collect(obj.Tags.All())[0]
 	require.Equal(t, "updated", v)
 
 	// Updating an object with mismatching revision number fails
@@ -871,7 +872,7 @@ func TestDB_CompareAndSwap_CompareAndDelete(t *testing.T) {
 	obj, _, ok = table.Get(db.ReadTxn(), idIndex.Query(1))
 	require.True(t, ok)
 	require.Equal(t, 1, obj.Tags.Len())
-	v, _ = obj.Tags.All().Next()
+	v = slices.Collect(obj.Tags.All())[0]
 	require.Equal(t, "updated", v)
 
 	// Deleting an object with mismatching revision number fails
@@ -886,7 +887,7 @@ func TestDB_CompareAndSwap_CompareAndDelete(t *testing.T) {
 	obj, rev2, ok := table.Get(db.ReadTxn(), idIndex.Query(1))
 	require.True(t, ok)
 	require.Equal(t, 1, obj.Tags.Len())
-	v, _ = obj.Tags.All().Next()
+	v = slices.Collect(obj.Tags.All())[0]
 	require.Equal(t, "updated", v)
 
 	// Deleting with matching revision number works

--- a/derive.go
+++ b/derive.go
@@ -76,10 +76,10 @@ func (d derive[In, Out]) loop(ctx context.Context, _ cell.Health) error {
 	if err != nil {
 		return err
 	}
-	defer iter.Close()
 	for {
 		wtxn := d.DB.WriteTxn(out)
-		for change := range iter.Changes() {
+		changes, watch := iter.Next(wtxn)
+		for change := range changes {
 			outObj, result := d.transform(change.Object, change.Deleted)
 			switch result {
 			case DeriveInsert:
@@ -101,7 +101,7 @@ func (d derive[In, Out]) loop(ctx context.Context, _ cell.Health) error {
 		wtxn.Commit()
 
 		select {
-		case <-iter.Watch(d.DB.ReadTxn()):
+		case <-watch:
 		case <-ctx.Done():
 			return nil
 		}

--- a/derive.go
+++ b/derive.go
@@ -79,8 +79,8 @@ func (d derive[In, Out]) loop(ctx context.Context, _ cell.Health) error {
 	defer iter.Close()
 	for {
 		wtxn := d.DB.WriteTxn(out)
-		for ev, _, ok := iter.Next(); ok; ev, _, ok = iter.Next() {
-			outObj, result := d.transform(ev.Object, ev.Deleted)
+		for change := range iter.Changes() {
+			outObj, result := d.transform(change.Object, change.Deleted)
 			switch result {
 			case DeriveInsert:
 				_, _, err = out.Insert(wtxn, outObj)

--- a/derive_test.go
+++ b/derive_test.go
@@ -5,6 +5,7 @@ package statedb
 
 import (
 	"context"
+	"slices"
 	"testing"
 	"time"
 
@@ -68,12 +69,12 @@ func TestDerive(t *testing.T) {
 	transform := func(obj testObject, deleted bool) (derived, DeriveResult) {
 		t.Logf("transform(%v, %v)", obj, deleted)
 
-		tag, _ := obj.Tags.All().Next()
-		if obj.Tags.Len() > 0 && tag == "skip" {
+		tags := slices.Collect(obj.Tags.All())
+		if obj.Tags.Len() > 0 && tags[0] == "skip" {
 			return derived{}, DeriveSkip
 		}
 		if deleted {
-			if obj.Tags.Len() > 0 && tag == "delete" {
+			if obj.Tags.Len() > 0 && tags[0] == "delete" {
 				return derived{ID: obj.ID}, DeriveDelete
 			}
 			return derived{ID: obj.ID, Deleted: true}, DeriveUpdate

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cilium/statedb
 
-go 1.22.0
+go 1.23
 
 require (
 	github.com/cilium/hive v0.0.0-20240209163124-bd6ebb4ec11d

--- a/http.go
+++ b/http.go
@@ -179,7 +179,6 @@ func (h dbHandler) changes(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	defer changeIter.Close()
 
 	w.WriteHeader(http.StatusOK)
 
@@ -187,7 +186,8 @@ func (h dbHandler) changes(w http.ResponseWriter, r *http.Request) {
 	defer ticker.Stop()
 
 	for {
-		for change := range changeIter.changesAny() {
+		changes, watch := changeIter.nextAny(h.db.ReadTxn())
+		for change := range changes {
 			err := enc.Encode(change)
 			if err != nil {
 				panic(err)
@@ -202,7 +202,7 @@ func (h dbHandler) changes(w http.ResponseWriter, r *http.Request) {
 			// Send an empty keep-alive
 			enc.Encode(Change[any]{})
 
-		case <-changeIter.Watch(h.db.ReadTxn()):
+		case <-watch:
 		}
 	}
 }

--- a/http.go
+++ b/http.go
@@ -187,7 +187,7 @@ func (h dbHandler) changes(w http.ResponseWriter, r *http.Request) {
 	defer ticker.Stop()
 
 	for {
-		for change, _, ok := changeIter.nextAny(); ok; change, _, ok = changeIter.nextAny() {
+		for change := range changeIter.changesAny() {
 			err := enc.Encode(change)
 			if err != nil {
 				panic(err)

--- a/index/seq.go
+++ b/index/seq.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package index
+
+import "iter"
+
+// Seq creates a KeySet from an iter.Seq[T] with the given indexing function.
+// Example usage:
+//
+//	var strings iter.Seq[string]
+//	keys := Seq[string](index.String, strings)
+func Seq[T any](
+	toKey func(T) Key,
+	seq iter.Seq[T],
+) KeySet {
+	keys := []Key{}
+	for v := range seq {
+		keys = append(keys, toKey(v))
+	}
+	return NewKeySet(keys...)
+}
+
+// Seq2 creates a KeySet from an iter.Seq2[A,B] with the given indexing function.
+// Example usage:
+//
+//	 var seq iter.Seq2[string, int]
+//		keys := Seq2(index.String, seq)
+func Seq2[A, B any](
+	toKey func(A) Key,
+	seq iter.Seq2[A, B],
+) KeySet {
+	keys := []Key{}
+	for a := range seq {
+		keys = append(keys, toKey(a))
+	}
+	return NewKeySet(keys...)
+}

--- a/index/seq_test.go
+++ b/index/seq_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package index_test
+
+import (
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/cilium/statedb/index"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSeq(t *testing.T) {
+	tests := [][]uint64{
+		{},
+		{1},
+		{1, 2, 3},
+	}
+	for _, keys := range tests {
+		expected := []index.Key{}
+		for _, x := range keys {
+			expected = append(expected, index.Uint64(x))
+		}
+		keySet := index.Seq(index.Uint64, slices.Values(keys))
+		actual := []index.Key{}
+		keySet.Foreach(func(k index.Key) {
+			actual = append(actual, k)
+		})
+		assert.ElementsMatch(t, expected, actual)
+	}
+}
+
+func TestSeq2(t *testing.T) {
+	tests := []map[uint64]int{
+		nil,
+		map[uint64]int{},
+		map[uint64]int{1: 1},
+		map[uint64]int{1: 1, 2: 2, 3: 3},
+	}
+	for _, m := range tests {
+		expected := []index.Key{}
+		for x := range m {
+			expected = append(expected, index.Uint64(x))
+		}
+		keySet := index.Seq2(index.Uint64, maps.All(m))
+		actual := []index.Key{}
+		keySet.Foreach(func(k index.Key) {
+			actual = append(actual, k)
+		})
+		assert.ElementsMatch(t, expected, actual)
+	}
+}
+
+type testObj struct {
+	x string
+}
+
+func (t testObj) String() string {
+	return t.x
+}
+
+func TestStringerSeq(t *testing.T) {
+	tests := [][]testObj{
+		{},
+		{testObj{"foo"}},
+		{testObj{"foo"}, testObj{"bar"}},
+	}
+	for _, objs := range tests {
+		expected := []index.Key{}
+		for _, o := range objs {
+			expected = append(expected, index.String(o.x))
+		}
+		keySet := index.StringerSeq(slices.Values(objs))
+		actual := []index.Key{}
+		keySet.Foreach(func(k index.Key) {
+			actual = append(actual, k)
+		})
+		assert.ElementsMatch(t, expected, actual)
+	}
+}
+
+func TestStringerSeq2(t *testing.T) {
+	tests := []map[testObj]int{
+		{},
+		{testObj{"foo"}: 1},
+		{testObj{"foo"}: 1, testObj{"bar"}: 2},
+	}
+	for _, m := range tests {
+		expected := []index.Key{}
+		for o := range m {
+			expected = append(expected, index.String(o.x))
+		}
+		keySet := index.StringerSeq2(maps.All(m))
+		actual := []index.Key{}
+		keySet.Foreach(func(k index.Key) {
+			actual = append(actual, k)
+		})
+		assert.ElementsMatch(t, expected, actual)
+	}
+}

--- a/index/set.go
+++ b/index/set.go
@@ -7,19 +7,18 @@ import "github.com/cilium/statedb/part"
 
 // Set creates a KeySet from a part.Set.
 func Set[T any](s part.Set[T]) KeySet {
-	iter := s.All()
 	toBytes := s.ToBytesFunc()
-
 	switch s.Len() {
 	case 0:
 		return NewKeySet()
 	case 1:
-		v, _ := iter.Next()
-		return NewKeySet(toBytes(v))
-
+		for v := range s.All() {
+			return NewKeySet(toBytes(v))
+		}
+		panic("BUG: Set.Len() == 1, but ranging returned nothing")
 	default:
 		keys := make([]Key, 0, s.Len())
-		for v, ok := iter.Next(); ok; v, ok = iter.Next() {
+		for v := range s.All() {
 			keys = append(keys, toBytes(v))
 		}
 		return NewKeySet(keys...)

--- a/index/string.go
+++ b/index/string.go
@@ -3,7 +3,10 @@
 
 package index
 
-import "fmt"
+import (
+	"fmt"
+	"iter"
+)
 
 func String(s string) Key {
 	return []byte(s)
@@ -27,4 +30,12 @@ func StringerSlice[T fmt.Stringer](ss []T) KeySet {
 		keys = append(keys, Stringer(s))
 	}
 	return NewKeySet(keys...)
+}
+
+func StringerSeq[T fmt.Stringer](seq iter.Seq[T]) KeySet {
+	return Seq[T](Stringer, seq)
+}
+
+func StringerSeq2[A fmt.Stringer, B any](seq iter.Seq2[A, B]) KeySet {
+	return Seq2[A, B](Stringer, seq)
 }

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFilter(t *testing.T) {
+func TestCollectFilterMapToSeq(t *testing.T) {
 	type testObject struct {
 		ID int
 	}
@@ -54,4 +54,12 @@ func TestFilter(t *testing.T) {
 	)
 	assert.Len(t, filtered, 2)
 	assert.Equal(t, []int{2, 4}, filtered)
+
+	count := 0
+	for obj := range ToSeq(iter) {
+		assert.Greater(t, obj.ID, 0)
+		count++
+	}
+	assert.Equal(t, 5, count)
+
 }

--- a/observable.go
+++ b/observable.go
@@ -36,10 +36,12 @@ func (to *observable[Obj]) Observe(ctx context.Context, next func(Change[Obj]), 
 		defer complete(nil)
 
 		for {
-			for ev, _, ok := iter.Next(); ok; ev, _, ok = iter.Next() {
-				next(ev)
+			for change := range iter.Changes() {
+				if ctx.Err() != nil {
+					break
+				}
+				next(change)
 			}
-
 			select {
 			case <-ctx.Done():
 				return

--- a/observable.go
+++ b/observable.go
@@ -32,11 +32,11 @@ func (to *observable[Obj]) Observe(ctx context.Context, next func(Change[Obj]), 
 			complete(err)
 			return
 		}
-		defer iter.Close()
 		defer complete(nil)
 
 		for {
-			for change := range iter.Changes() {
+			changes, watch := iter.Next(to.db.ReadTxn())
+			for change := range changes {
 				if ctx.Err() != nil {
 					break
 				}
@@ -45,7 +45,7 @@ func (to *observable[Obj]) Observe(ctx context.Context, next func(Change[Obj]), 
 			select {
 			case <-ctx.Done():
 				return
-			case <-iter.Watch(to.db.ReadTxn()):
+			case <-watch:
 			}
 		}
 	}()

--- a/part/iterator.go
+++ b/part/iterator.go
@@ -5,12 +5,21 @@ package part
 
 import (
 	"bytes"
+	"slices"
 	"sort"
 )
 
 // Iterator for key and value pairs where value is of type T
 type Iterator[T any] struct {
 	next [][]*header[T] // sets of edges to explore
+}
+
+// Clone returns a copy of the iterator, allowing restarting
+// the iterator from scratch.
+func (it *Iterator[T]) Clone() *Iterator[T] {
+	// Since the iterator does not mutate the edge array elements themselves ([]*header[T])
+	// it is enough to do a shallow clone here.
+	return &Iterator[T]{slices.Clone(it.next)}
 }
 
 // Next returns the next key, value and true if the value exists,

--- a/part/part_test.go
+++ b/part/part_test.go
@@ -597,6 +597,7 @@ func Test_prefix(t *testing.T) {
 	ins("ab")
 	ins("abc")
 	ins("abcd")
+	ins("bc")
 
 	iter, _ := tree.Prefix([]byte("ab"))
 	k, v, ok := iter.Next()

--- a/part/quick_test.go
+++ b/part/quick_test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var quickConfig = &quick.Config{
+	// Use a higher count in order to hit the Node256 cases.
+	MaxCount: 2000,
+}
+
 func TestQuick_InsertGetPrefix(t *testing.T) {
 	tree := part.New[string]()
 	insert := func(key, value string) any {
@@ -28,7 +33,7 @@ func TestQuick_InsertGetPrefix(t *testing.T) {
 	}
 
 	require.NoError(t,
-		quick.CheckEqual(insert, get, nil),
+		quick.CheckEqual(insert, get, quickConfig),
 	)
 }
 
@@ -46,7 +51,6 @@ func TestQuick_IteratorReuse(t *testing.T) {
 		iterators := []*part.Iterator[string]{
 			tree.LowerBound([]byte(key)),
 			prefixIter,
-			tree.Iterator(),
 		}
 
 		for _, iter := range iterators {
@@ -76,7 +80,7 @@ func TestQuick_IteratorReuse(t *testing.T) {
 	}
 
 	require.NoError(t,
-		quick.Check(iterate, nil),
+		quick.Check(iterate, quickConfig),
 	)
 }
 
@@ -117,7 +121,7 @@ func TestQuick_Delete(t *testing.T) {
 		return true
 	}
 
-	require.NoError(t, quick.Check(do, nil))
+	require.NoError(t, quick.Check(do, quickConfig))
 }
 
 func TestQuick_ClosedWatch(t *testing.T) {
@@ -165,5 +169,5 @@ func TestQuick_ClosedWatch(t *testing.T) {
 		return true
 	}
 
-	require.NoError(t, quick.Check(insert, nil))
+	require.NoError(t, quick.Check(insert, quickConfig))
 }

--- a/part/set_test.go
+++ b/part/set_test.go
@@ -2,6 +2,7 @@ package part_test
 
 import (
 	"encoding/json"
+	"slices"
 	"testing"
 
 	"github.com/cilium/statedb/part"
@@ -17,13 +18,12 @@ func TestStringSet(t *testing.T) {
 	s = s.Set("foo")
 	assert.True(t, s.Has("foo"), "Has foo")
 
-	iter := s.All()
-	v, ok := iter.Next()
-	assert.True(t, ok, "Next")
-	assert.Equal(t, "foo", v)
-	v, ok = iter.Next()
-	assert.False(t, ok, "Next")
-	assert.Equal(t, "", v)
+	count := 0
+	for v := range s.All() {
+		assert.Equal(t, "foo", v)
+		count++
+	}
+	assert.Equal(t, 1, count)
 
 	s2 := part.NewSet("bar")
 
@@ -32,6 +32,9 @@ func TestStringSet(t *testing.T) {
 	assert.False(t, s2.Has("foo"), "s2 has no foo")
 	assert.True(t, s3.Has("foo"), "s3 has foo")
 	assert.True(t, s3.Has("bar"), "s3 has bar")
+
+	values := slices.Collect(s3.All())
+	assert.ElementsMatch(t, []string{"foo", "bar"}, values)
 
 	s4 := s3.Difference(s2)
 	assert.False(t, s4.Has("bar"), "s4 has no bar")
@@ -49,10 +52,6 @@ func TestStringSet(t *testing.T) {
 
 	assert.Equal(t, 2, s3.Len())
 	assert.Equal(t, 1, s5.Len())
-
-	xs := s5.Slice()
-	assert.Len(t, xs, 1)
-	assert.Equal(t, "bar", xs[0])
 }
 
 func TestSetJSON(t *testing.T) {

--- a/reconciler/benchmark/main.go
+++ b/reconciler/benchmark/main.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"iter"
 	"log"
 	"log/slog"
 	"os"
@@ -64,7 +65,7 @@ func (mt *mockOps) Delete(ctx context.Context, txn statedb.ReadTxn, obj *testObj
 }
 
 // Prune implements reconciler.Operations.
-func (mt *mockOps) Prune(ctx context.Context, txn statedb.ReadTxn, iter statedb.Iterator[*testObject]) error {
+func (mt *mockOps) Prune(ctx context.Context, txn statedb.ReadTxn, objects iter.Seq2[*testObject, statedb.Revision]) error {
 	return nil
 }
 
@@ -205,8 +206,7 @@ func main() {
 	}
 
 	// Check that all statuses are correctly set.
-	iter := testObjects.All(db.ReadTxn())
-	for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
+	for obj := range testObjects.All(db.ReadTxn()) {
 		if obj.status.Kind != reconciler.StatusKindDone {
 			log.Fatalf("Object with unexpected status: %#v", obj)
 		}

--- a/reconciler/example/ops.go
+++ b/reconciler/example/ops.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"errors"
+	"iter"
 	"log/slog"
 	"os"
 	"path"
@@ -42,9 +43,10 @@ func (ops *MemoOps) Delete(ctx context.Context, txn statedb.ReadTxn, memo *Memo)
 }
 
 // Prune unexpected memos.
-func (ops *MemoOps) Prune(ctx context.Context, txn statedb.ReadTxn, iter statedb.Iterator[*Memo]) error {
+func (ops *MemoOps) Prune(ctx context.Context, txn statedb.ReadTxn, objects iter.Seq2[*Memo, statedb.Revision]) error {
 	expected := map[string]struct{}{}
-	for memo, _, ok := iter.Next(); ok; memo, _, ok = iter.Next() {
+
+	for memo := range objects {
 		expected[memo.Name] = struct{}{}
 	}
 

--- a/reconciler/multi_test.go
+++ b/reconciler/multi_test.go
@@ -6,6 +6,7 @@ package reconciler_test
 import (
 	"context"
 	"errors"
+	"iter"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -50,7 +51,7 @@ func (m *multiMockOps) Delete(context.Context, statedb.ReadTxn, *multiStatusObje
 }
 
 // Prune implements reconciler.Operations.
-func (m *multiMockOps) Prune(context.Context, statedb.ReadTxn, statedb.Iterator[*multiStatusObject]) error {
+func (m *multiMockOps) Prune(context.Context, statedb.ReadTxn, iter.Seq2[*multiStatusObject, statedb.Revision]) error {
 	return nil
 }
 

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"expvar"
 	"fmt"
+	"iter"
 	"slices"
 	"sort"
 	"strings"
@@ -492,11 +493,11 @@ func (mt *mockOps) Delete(ctx context.Context, txn statedb.ReadTxn, obj *testObj
 }
 
 // Prune implements reconciler.Operations.
-func (mt *mockOps) Prune(ctx context.Context, txn statedb.ReadTxn, iter statedb.Iterator[*testObject]) error {
+func (mt *mockOps) Prune(ctx context.Context, txn statedb.ReadTxn, objects iter.Seq2[*testObject, statedb.Revision]) error {
 	if mt.faulty.Load() {
 		return errors.New("prune fail")
 	}
-	objs := statedb.Collect(iter)
+	objs := statedb.Collect(objects)
 	mt.history.add(opPrune(len(objs)))
 	return nil
 }

--- a/reconciler/types.go
+++ b/reconciler/types.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"iter"
 	"log/slog"
 	"slices"
 	"strings"
@@ -76,7 +77,7 @@ type Operations[Obj any] interface {
 	//
 	// Unlike failed Update()'s a failed Prune() operation is not retried until
 	// the next full reconciliation round.
-	Prune(context.Context, statedb.ReadTxn, statedb.Iterator[Obj]) error
+	Prune(ctx context.Context, txn statedb.ReadTxn, objects iter.Seq2[Obj, statedb.Revision]) error
 }
 
 type BatchEntry[Obj any] struct {

--- a/txn.go
+++ b/txn.go
@@ -265,9 +265,6 @@ func (txn *txn) addDeleteTracker(meta TableMeta, trackerName string, dt anyDelet
 	_, _, table.deleteTrackers = table.deleteTrackers.Insert([]byte(trackerName), dt)
 	txn.db.metrics.DeleteTrackerCount(meta.Name(), table.deleteTrackers.Len())
 
-	// Add a finalizer to make sure delete trackers are always closed.
-	runtime.SetFinalizer(dt, func(dt anyDeleteTracker) { dt.close() })
-
 	return nil
 }
 


### PR DESCRIPTION
Add support for range-funcs by switching the custom iterator types in StateDB and part.Map and part.Set to iter.Seq/Seq2.

This allows iterating over the query results using normal for loops:
```
  // StateDB:
  for obj := range myTable.All(db.ReadTxn()) { 
    ... 
  }

  var ByName = nameIndex.Query
  for obj, rev := range myTable.Prefix(db.ReadTxn(), ByName("foo")) {
    // obj.Name starts with "foo"
   ...
  }

  // part.Map and part.Set:
  var m part.Map[string, int]
  for s, i := range m.All() {
    ...
  }

  for s, i := range m.Prefix("foo") {
    // HasPrefix(s, "foo") == true
    ...
  }

  var s part.Set[string]
  for x := range s.All() {
    ...
  }
```

This PR also reworks the Changes() API to be easier to use in combination with a WriteTxn:

```
  // Old version:
  changeIter, err := tbl.Changes(wtxn)
  ...


  wtxn := db.WriteTxn(tbl)
  for change := range changeIter.Changes() {
    // Iterates with the "old" snapshot passed to Watch()
  }
  wtxn.Commit()
  
  // Wait for changes
  <-changeIter.Watch(db.ReadTxn())
 
  // New version:

  changeIter, err := tbl.Changes(wtxn)
  ...

  wtxn = db.WriteTxn(tbl)
  tbl.Insert(wtxn, ...) // This won't be seen by the change iterator as it's not yet committed.
  changes, watch := changeIter.Next(wtxn)
  for change := range changes {
     obj := change.Object.Clone()
     // process outside change to change.Object ...
     // update the object.
     tbl.Insert(wtxn, obj)
  }
  wtxn.Commit()
  <-watch
```

This is now easier to use in a consistent way when combined with a WriteTxn and making sure we're using the latest
version of the object.  Additionally the implementation was changed to specifically use the snapshot of the committed
data and ignore the changes made in the WriteTxn (otherwise we might mark a revision to graveyard that might be reverted
when Abort()'d).