### PR TITLE
Fix NumObjects and Initialized with WriteTxn

### DIFF
--- a/table.go
+++ b/table.go
@@ -173,7 +173,7 @@ func (t *genTable[Obj]) Initialized(txn ReadTxn) bool {
 	return len(t.PendingInitializers(txn)) == 0
 }
 func (t *genTable[Obj]) PendingInitializers(txn ReadTxn) []string {
-	return txn.getTxn().root[t.pos].pendingInitializers
+	return txn.getTxn().getTableEntry(t).pendingInitializers
 }
 
 func (t *genTable[Obj]) RegisterInitializer(txn WriteTxn, name string) func(WriteTxn) {
@@ -201,12 +201,12 @@ func (t *genTable[Obj]) RegisterInitializer(txn WriteTxn, name string) func(Writ
 }
 
 func (t *genTable[Obj]) Revision(txn ReadTxn) Revision {
-	return txn.getTxn().getRevision(t)
+	return txn.getTxn().getTableEntry(t).revision
 }
 
 func (t *genTable[Obj]) NumObjects(txn ReadTxn) int {
-	table := &txn.getTxn().root[t.tablePos()]
-	return table.indexes[PrimaryIndexPos].tree.Len()
+	table := txn.getTxn().getTableEntry(t)
+	return table.numObjects()
 }
 
 func (t *genTable[Obj]) Get(txn ReadTxn, q Query[Obj]) (obj Obj, revision uint64, ok bool) {

--- a/txn.go
+++ b/txn.go
@@ -55,14 +55,14 @@ func txnFinalizer(txn *txn) {
 	}
 }
 
-func (txn *txn) getRevision(meta TableMeta) Revision {
+func (txn *txn) getTableEntry(meta TableMeta) *tableEntry {
 	if txn.modifiedTables != nil {
 		entry := txn.modifiedTables[meta.tablePos()]
 		if entry != nil {
-			return entry.revision
+			return entry
 		}
 	}
-	return txn.root[meta.tablePos()].revision
+	return &txn.root[meta.tablePos()]
 }
 
 // indexReadTxn returns a transaction to read from the specific index.

--- a/types.go
+++ b/types.go
@@ -390,10 +390,16 @@ type tableEntry struct {
 
 func (t *tableEntry) numObjects() int {
 	indexEntry := t.indexes[t.meta.indexPos(RevisionIndex)]
+	if indexEntry.txn != nil {
+		return indexEntry.txn.Len()
+	}
 	return indexEntry.tree.Len()
 }
 
 func (t *tableEntry) numDeletedObjects() int {
 	indexEntry := t.indexes[t.meta.indexPos(GraveyardIndex)]
+	if indexEntry.txn != nil {
+		return indexEntry.txn.Len()
+	}
 	return indexEntry.tree.Len()
 }


### PR DESCRIPTION
Both NumObjects() and Initialized() returned the committed state and not the currently modified state:

```
txn := db.WriteTxn(tbl)
tbl.NumObjects(txn) == 0
tbl.Insert(txn, Foo{})
tbl.NumObjects(txn) == 0 !!!

init := tbl.RegisterInitializer("test")
tbl.Initialized(txn) == false

init(txn)
tbl.Initialized(txn) == false !!!
```