### PR TITLE
Add Modify() method

### DIFF
--- a/part/tree.go
+++ b/part/tree.go
@@ -95,6 +95,17 @@ func (t *Tree[T]) Insert(key []byte, value T) (old T, hadOld bool, tree *Tree[T]
 	return
 }
 
+// Modify a value in the tree. If the key does not exist the modify
+// function is called with the zero value for T. It is up to the
+// caller to not mutate the value in-place and to return a clone.
+// Returns the old value if it exists.
+func (t *Tree[T]) Modify(key []byte, mod func(T) T) (old T, hadOld bool, tree *Tree[T]) {
+	txn := t.Txn()
+	old, hadOld = txn.Modify(key, mod)
+	tree = txn.Commit()
+	return
+}
+
 // Delete the given key from the tree.
 // Returns the old value if it exists and the new tree.
 func (t *Tree[T]) Delete(key []byte) (old T, hadOld bool, tree *Tree[T]) {

--- a/table.go
+++ b/table.go
@@ -215,11 +215,32 @@ func (t *genTable[Obj]) Get(txn ReadTxn, q Query[Obj]) (obj Obj, revision uint64
 }
 
 func (t *genTable[Obj]) GetWatch(txn ReadTxn, q Query[Obj]) (obj Obj, revision uint64, watch <-chan struct{}, ok bool) {
-	indexTxn := txn.getTxn().mustIndexReadTxn(t, t.indexPos(q.index))
+	// Since we're not returning an iterator here we can optimize and not use
+	// indexReadTxn which clones if this is a WriteTxn (to avoid invalidating iterators).
+	indexPos := t.indexPos(q.index)
+	itxn := txn.getTxn()
+	var (
+		ops    part.Ops[object]
+		unique bool
+	)
+	if itxn.modifiedTables != nil && itxn.modifiedTables[t.tablePos()] != nil {
+		var err error
+		iwtxn, err := itxn.indexWriteTxn(t, indexPos)
+		if err != nil {
+			panic(err)
+		}
+		ops = iwtxn.Txn
+		unique = iwtxn.unique
+	} else {
+		entry := itxn.root[t.tablePos()].indexes[indexPos]
+		ops = entry.tree
+		unique = entry.unique
+	}
+
 	var iobj object
-	if indexTxn.unique {
+	if unique {
 		// On a unique index we can do a direct get rather than a prefix search.
-		iobj, watch, ok = indexTxn.Get(q.key)
+		iobj, watch, ok = ops.Get(q.key)
 		if !ok {
 			return
 		}
@@ -229,7 +250,7 @@ func (t *genTable[Obj]) GetWatch(txn ReadTxn, q Query[Obj]) (obj Obj, revision u
 	}
 
 	// For a non-unique index we need to do a prefix search.
-	iter, watch := indexTxn.Prefix(q.key)
+	iter, watch := ops.Prefix(q.key)
 	for {
 		var key []byte
 		key, iobj, ok = iter.Next()

--- a/table.go
+++ b/table.go
@@ -311,6 +311,18 @@ func (t *genTable[Obj]) Insert(txn WriteTxn, obj Obj) (oldObj Obj, hadOld bool, 
 	return
 }
 
+func (t *genTable[Obj]) Modify(txn WriteTxn, obj Obj, merge func(old, new Obj) Obj) (oldObj Obj, hadOld bool, err error) {
+	var old object
+	old, hadOld, err = txn.getTxn().modify(t, Revision(0), obj,
+		func(old any) any {
+			return merge(old.(Obj), obj)
+		})
+	if hadOld {
+		oldObj = old.data.(Obj)
+	}
+	return
+}
+
 func (t *genTable[Obj]) CompareAndSwap(txn WriteTxn, rev Revision, obj Obj) (oldObj Obj, hadOld bool, err error) {
 	var old object
 	old, hadOld, err = txn.getTxn().insert(t, rev, obj)

--- a/types.go
+++ b/types.go
@@ -151,6 +151,17 @@ type RWTable[Obj any] interface {
 	// revision.
 	Insert(WriteTxn, Obj) (oldObj Obj, hadOld bool, err error)
 
+	// Modify an existing object or insert a new object into the table. If an old object
+	// exists the [merge] function is called with the old and new objects.
+	//
+	// Modify is semantically equal to Get + Insert, but avoids extra lookups making
+	// it significantly more efficient.
+	//
+	// Possible errors:
+	// - ErrTableNotLockedForWriting: table was not locked for writing
+	// - ErrTransactionClosed: the write transaction already committed or aborted
+	Modify(txn WriteTxn, new Obj, merge func(old, new Obj) Obj) (oldObj Obj, hadOld bool, err error)
+
 	// CompareAndSwap compares the existing object's revision against the
 	// given revision and if equal it replaces the object.
 	//


### PR DESCRIPTION
This adds Modify() to `part` and to `RWTable[T]`. 

Modify() can be used in Cilium to efficiently implement merging of external data into internal objects
that carry state that we want to merge with rather than replace. A follow-up PR in cilium/cilium will
add the merging support to `pkg/k8s/statedb.go`.