### PR TITLE
Start with closed watch channel in Changes()

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -274,7 +274,7 @@ func TestDB_Prefix(t *testing.T) {
 	require.Equal(t, Collect(Map(iter, testObject.getID)), []uint64{71, 82, 99})
 }
 
-func TestDB_EventIterator(t *testing.T) {
+func TestDB_Changes(t *testing.T) {
 	t.Parallel()
 
 	db, table, metrics := newTestDB(t, tagsIndex)
@@ -303,6 +303,9 @@ func TestDB_EventIterator(t *testing.T) {
 	wtxn.Commit()
 
 	assert.EqualValues(t, 2, expvarInt(metrics.DeleteTrackerCountVar.Get("test")), "DeleteTrackerCount")
+
+	// The initial watch channel is closed, so users can either iterate first or watch first.
+	<-iter.Watch(db.ReadTxn())
 
 	// Delete 2/3 objects
 	{

--- a/table.go
+++ b/table.go
@@ -403,10 +403,10 @@ func (t *genTable[Obj]) Changes(txn WriteTxn) (ChangeIterator[Obj], error) {
 	}
 
 	// Prepare the iterator
-	updateIter, watch := t.LowerBoundWatch(txn, ByRevision[Obj](0)) // observe all current objects
-	deleteIter := iter.dt.deleted(txn, iter.dt.getRevision())       // only observe new deletions
+	updateIter := t.LowerBound(txn, ByRevision[Obj](0))       // observe all current objects
+	deleteIter := iter.dt.deleted(txn, iter.dt.getRevision()) // only observe new deletions
 	iter.iter = NewDualIterator(deleteIter, updateIter)
-	iter.watch = watch
+	iter.watch = closedWatchChannel
 
 	return iter, nil
 }


### PR DESCRIPTION
The initial watch channel used by ChangeIterator is the one returned by the LowerBound search. This only closes when there are new changes and thus would block even if there would be changes to iterate.

To make this easier to use correctly, use a closed watch channel to start with so it doesn't matter whether the changes are iterated first and then Watch() is called or the other way around.