### PR TITLE
Fix comment posting on failed CI run and cleanup benchmarks

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,6 +36,7 @@ jobs:
           echo '```' >> results.comment
           
       - name: results
+        if: always()
         uses: thollander/actions-comment-pull-request@v2
         with:
           comment_tag: results

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -48,10 +48,6 @@ func BenchmarkDB_WriteTxn_1000(b *testing.B) {
 	benchmarkDB_WriteTxn_batch(b, 1000)
 }
 
-func BenchmarkDB_WriteTxn_10000(b *testing.B) {
-	benchmarkDB_WriteTxn_batch(b, 10000)
-}
-
 func benchmarkDB_WriteTxn_batch(b *testing.B, batchSize int) {
 	db, table := newTestDBWithMetrics(b, &NopMetrics{})
 	n := b.N

--- a/part/part_test.go
+++ b/part/part_test.go
@@ -1095,14 +1095,6 @@ func Benchmark_txn_1000(b *testing.B) {
 	benchmark_txn_batch(b, 1000)
 }
 
-func Benchmark_txn_10000(b *testing.B) {
-	benchmark_txn_batch(b, 10000)
-}
-
-func Benchmark_txn_100000(b *testing.B) {
-	benchmark_txn_batch(b, 100000)
-}
-
 func benchmark_txn_batch(b *testing.B, batchSize int) {
 	tree := New[int](RootOnlyWatch)
 	n := b.N
@@ -1136,14 +1128,6 @@ func Benchmark_txn_delete_100(b *testing.B) {
 
 func Benchmark_txn_delete_1000(b *testing.B) {
 	benchmark_txn_delete_batch(b, 1000)
-}
-
-func Benchmark_txn_delete_10000(b *testing.B) {
-	benchmark_txn_delete_batch(b, 10000)
-}
-
-func Benchmark_txn_delete_100000(b *testing.B) {
-	benchmark_txn_delete_batch(b, 100000)
 }
 
 func benchmark_txn_delete_batch(b *testing.B, batchSize int) {


### PR DESCRIPTION
If a PR fails the failed "make test" output wasn't posted. Add a "if: always()" to the comment posting to always post it.
This was manually tested.

Fix the secondary index benchmark not to recreate the tags set on each insert as that's not what is important for the benchmark.
Additionally drop the very large batch sizes from benchmarks as those use up fair bit of memory and don't provide a useful signal.