### PR TITLE
http: /changes API for streaming changes

### DIFF
--- a/db.go
+++ b/db.go
@@ -93,7 +93,7 @@ type DB struct {
 	defaultHandle       Handle
 }
 
-type dbRoot = []tableEntry
+type dbRoot []tableEntry
 
 type Option func(*opts)
 

--- a/iterator.go
+++ b/iterator.go
@@ -232,6 +232,19 @@ func (it *changeIterator[Obj]) Next() (ev Change[Obj], revision uint64, ok bool)
 	return
 }
 
+// nextAny is for implementing the /changes HTTP API where the concrete object
+// type is not known.
+func (it *changeIterator[Obj]) nextAny() (ev Change[any], revision uint64, ok bool) {
+	var evTyped Change[Obj]
+	evTyped, revision, ok = it.Next()
+	ev = Change[any]{
+		Object:   evTyped.Object,
+		Revision: evTyped.Revision,
+		Deleted:  evTyped.Deleted,
+	}
+	return
+}
+
 func (it *changeIterator[Obj]) Watch(txn ReadTxn) <-chan struct{} {
 	if it.iter == nil {
 		// Iterator has been exhausted, check if we need to requery
@@ -266,4 +279,10 @@ func (it *changeIterator[Obj]) Close() {
 		it.dt.close()
 	}
 	*it = changeIterator[Obj]{}
+}
+
+type anyChangeIterator interface {
+	nextAny() (ev Change[any], revision uint64, ok bool)
+	Watch(ReadTxn) <-chan struct{}
+	Close()
 }

--- a/table.go
+++ b/table.go
@@ -422,6 +422,17 @@ func (t *genTable[Obj]) Changes(txn WriteTxn) (ChangeIterator[Obj], error) {
 	return iter, nil
 }
 
+// anyChanges returns the anyChangeIterator. Used for implementing the /changes HTTP
+// API where we can't work with concrete object types as they're not known and thus
+// uninstantiatable.
+func (t *genTable[Obj]) anyChanges(txn WriteTxn) (anyChangeIterator, error) {
+	iter, err := t.Changes(txn)
+	if err != nil {
+		return nil, err
+	}
+	return iter.(*changeIterator[Obj]), err
+}
+
 func (t *genTable[Obj]) sortableMutex() internal.SortableMutex {
 	return t.smu
 }

--- a/types.go
+++ b/types.go
@@ -96,9 +96,9 @@ type Table[Obj any] interface {
 // Change is either an update or a delete of an object. Used by Changes() and
 // the Observable().
 type Change[Obj any] struct {
-	Object   Obj
-	Revision Revision
-	Deleted  bool
+	Object   Obj      `json:"obj"`
+	Revision Revision `json:"rev"`
+	Deleted  bool     `json:"deleted,omitempty"`
 }
 
 type ChangeIterator[Obj any] interface {
@@ -210,6 +210,7 @@ type RWTable[Obj any] interface {
 // the object type (the 'Obj' constraint).
 type TableMeta interface {
 	Name() TableName // The name of the table
+
 	tableEntry() tableEntry
 	tablePos() int
 	setTablePos(int)
@@ -218,6 +219,7 @@ type TableMeta interface {
 	primary() anyIndexer                   // The untyped primary indexer for the table
 	secondary() map[string]anyIndexer      // Secondary indexers (if any)
 	sortableMutex() internal.SortableMutex // The sortable mutex for locking the table for writing
+	anyChanges(txn WriteTxn) (anyChangeIterator, error)
 }
 
 // Iterator for iterating objects returned from queries.


### PR DESCRIPTION
This allows streaming changes (upserts and deletes) over the HTTP API.

Example usage:
```
  examples := statedb.NewRemoteTable[*Example](url, "examples")

  // Stream changes until [ctx] is cancelled.
  changes, errChan := examples.Changes(ctx)
  for change, rev, ok := changes.Next(); ok; change, rev, ok = changes.Next() {
    example := change.Object
    if change.Deleted {
      // deleted
    } else {
      // upserted
    }
  }
  err := <-errChan
```