### PR TITLE
Fix ChangeIterator watch channel on partial iteration

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -256,7 +256,9 @@ func (it *changeIterator[Obj]) Watch(txn ReadTxn) <-chan struct{} {
 		// Return a closed watch channel to immediately trigger iteration.
 		return closedWatchChannel
 	}
-	return it.watch
+
+	// Iterator not consumed yet, return a closed channel to trigger iteration.
+	return closedWatchChannel
 }
 
 func (it *changeIterator[Obj]) Close() {

--- a/regression_test.go
+++ b/regression_test.go
@@ -5,6 +5,7 @@ package statedb
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -72,5 +73,79 @@ func Test_Regression_29324(t *testing.T) {
 	iter = table.List(txn, idIndex.Query("a"))
 	items = Collect(iter)
 	assert.Len(t, items, 0, "Get(\"a\") should return nothing")
+}
+
+// The watch channel returned by Changes() must be a closed one if there
+// is anything left to iterate over. Otherwise on partial iteration we'll
+// wait on a watch channel that reflects the changes of a full iteration
+// and we might be stuck waiting even when there's unprocessed changes.
+func Test_Regression_Changes_Watch(t *testing.T) {
+	db, table, _ := newTestDB(t)
+
+	wtxn := db.WriteTxn(table)
+	changes, err := table.Changes(wtxn)
+	require.NoError(t, err, "Changes")
+	wtxn.Commit()
+
+	n := 0
+	_, _, ok := changes.Next()
+	require.False(t, ok, "expected no changes")
+
+	// On first call to Watch() the iterator is refreshed and a closed watch channel
+	// is returned.
+	watch := changes.Watch(db.ReadTxn())
+	select {
+	case <-watch:
+		t.Fatalf("Changes() watch channel closed, expected it to block until commit")
+	default:
+	}
+
+	wtxn = db.WriteTxn(table)
+	table.Insert(wtxn, testObject{ID: 1})
+	table.Insert(wtxn, testObject{ID: 2})
+	table.Insert(wtxn, testObject{ID: 3})
+	wtxn.Commit()
+
+	// Observe the objects.
+	select {
+	case <-watch:
+	case <-time.After(time.Second):
+		t.Fatalf("Changes() watch channel not closed after inserts")
+	}
+	watch = changes.Watch(db.ReadTxn())
+	n = 0
+	for change, _, ok := changes.Next(); ok; change, _, ok = changes.Next() {
+		require.False(t, change.Deleted, "not deleted")
+		n++
+	}
+	require.Equal(t, 3, n, "expected 3 objects")
+
+	// Delete the objects
+	wtxn = db.WriteTxn(table)
+	require.NoError(t, table.DeleteAll(wtxn), "DeleteAll")
+	wtxn.Commit()
+
+	// Partially observe the changes
+	<-watch
+	changes.Watch(db.ReadTxn())
+	change, _, ok := changes.Next()
+	require.True(t, ok)
+	require.True(t, change.Deleted, "expected Deleted")
+
+	// Calling Watch again after partially consuming the iterator
+	// should return a closed watch channel.
+	select {
+	case <-changes.Watch(db.ReadTxn()):
+	case <-time.After(time.Second):
+		t.Fatalf("Changes() watch channel not closed!")
+	}
+
+	// Consume the rest of the deletions.
+	n = 1
+	for change, _, ok := changes.Next(); ok; change, _, ok = changes.Next() {
+		require.True(t, change.Deleted, "expected Deleted")
+		n++
+	}
+	require.Equal(t, 3, n, "expected 3 deletions")
 
 }

--- a/table.go
+++ b/table.go
@@ -414,10 +414,10 @@ func (t *genTable[Obj]) Changes(txn WriteTxn) (ChangeIterator[Obj], error) {
 	}
 
 	// Prepare the iterator
-	updateIter := t.LowerBound(txn, ByRevision[Obj](0))       // observe all current objects
-	deleteIter := iter.dt.deleted(txn, iter.dt.getRevision()) // only observe new deletions
+	updateIter, watch := t.LowerBoundWatch(txn, ByRevision[Obj](0)) // observe all current objects
+	deleteIter := iter.dt.deleted(txn, iter.dt.getRevision())       // only observe new deletions
 	iter.iter = NewDualIterator(deleteIter, updateIter)
-	iter.watch = closedWatchChannel
+	iter.watch = watch
 
 	return iter, nil
 }


### PR DESCRIPTION
Add a regression test for Changes() API to show the issues and fix the issues:

1) If the ChangeIterator is not exhausted always return a closed watch channel to trigger the iteration.

2) The initial "iter.watch" channel does not need to be closed, but should rather be a watch channel against the revision index to avoid unnecessary refresh.