### PR TITLE
Use Go standard library slices package instead of x/exp/slices

### DIFF
--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"maps"
 	"math/rand"
 	"os"
 	"runtime"
@@ -18,7 +19,6 @@ import (
 	"github.com/cilium/statedb"
 	"github.com/cilium/statedb/index"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/maps"
 )
 
 // Run test with "--debug" for log output.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/goleak v1.3.0
-	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a
 	golang.org/x/time v0.5.0
 )
 
@@ -31,6 +30,7 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.uber.org/dig v1.17.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a // indirect
 	golang.org/x/sys v0.17.0 // indirect
 	golang.org/x/term v0.16.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/graveyard.go
+++ b/graveyard.go
@@ -5,9 +5,10 @@ package statedb
 
 import (
 	"context"
+	"maps"
+	"slices"
 	"time"
 
-	"golang.org/x/exp/maps"
 	"golang.org/x/time/rate"
 )
 
@@ -83,7 +84,7 @@ func graveyardWorker(db *DB, ctx context.Context, gcRateLimitInterval time.Durat
 		}
 
 		// Dead objects found, do a write transaction against all tables with dead objects in them.
-		tablesToModify := maps.Keys(toBeDeleted)
+		tablesToModify := slices.Collect(maps.Keys(toBeDeleted))
 		txn = db.WriteTxn(tablesToModify[0], tablesToModify[1:]...).getTxn()
 		for meta, deadObjs := range toBeDeleted {
 			tableName := meta.Name()

--- a/reconciler/helpers.go
+++ b/reconciler/helpers.go
@@ -6,8 +6,7 @@ package reconciler
 import (
 	"errors"
 	"fmt"
-
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 var closedWatchChannel = func() <-chan struct{} {


### PR DESCRIPTION
The former is available since Go 1.21 and the latter is merely a wrapper around it when using Go ≥ 1.21. Use the standard library package directly.

We cannot yet switch out `x/exp/maps` for the standard library `maps` package as the `maps.Keys` function used in `statedb` code base is only available in Go ≥ 1.23.