### PR TITLE
Unify DB and Handle types into just DB

### DIFF
--- a/reconciler/example/main.go
+++ b/reconciler/example/main.go
@@ -169,6 +169,8 @@ func registerHTTPServer(
 
 	mux := http.NewServeMux()
 
+	// To dump the metrics:
+	// curl -s http://localhost:8080/expvar
 	mux.Handle("/expvar", expvar.Handler())
 
 	// For dumping the database:

--- a/reconciler/example/main.go
+++ b/reconciler/example/main.go
@@ -97,7 +97,14 @@ func main() {
 	cmd.Execute()
 }
 
-var Hive = hive.New(
+var Hive = hive.NewWithOptions(
+	hive.Options{
+		// Create a named DB handle for each module.
+		ModuleDecorator: func(db *statedb.DB, id cell.ModuleID) *statedb.DB {
+			return db.NewHandle(string(id))
+		},
+	},
+
 	statedb.Cell,
 	job.Cell,
 

--- a/reconciler/metrics.go
+++ b/reconciler/metrics.go
@@ -41,10 +41,10 @@ func (m *ExpVarMetrics) PruneDuration(moduleID cell.FullModuleID, duration time.
 
 func (m *ExpVarMetrics) PruneError(moduleID cell.FullModuleID, err error) {
 	m.PruneCountVar.Add(moduleID.String(), 1)
-	m.PruneTotalErrorsVar.Add(moduleID.String(), 1)
 
 	var intVar expvar.Int
 	if err != nil {
+		m.PruneTotalErrorsVar.Add(moduleID.String(), 1)
 		intVar.Set(1)
 	}
 	m.PruneCurrentErrorsVar.Set(moduleID.String(), &intVar)


### PR DESCRIPTION
This removes the separate `Handle` type to allow decorating `DB` with the handle name in Hive:
```
       hive.Options{
               // Create a named DB handle for each module.
               ModuleDecorator: func(db *statedb.DB, id cell.ModuleID) *statedb.DB {
                       return db.NewHandle(string(id))
               },
       },
```

With this we can get StateDB metrics accounted by module, allowing us to for example seeing which module
has long-running `WriteTxn`s etc.