### PR TITLE
script: Fix comparison of non-ordered columns

### DIFF
--- a/script.go
+++ b/script.go
@@ -649,12 +649,11 @@ func writeObjects(tbl *AnyTable, it iter.Seq2[any, Revision], w io.Writer, colum
 	return fmt.Errorf("unknown format %q, expected table, yaml or json", format)
 }
 
-func takeColumns[T any](xs []T, idxs []int) []T {
-	// Invariant: idxs is sorted so can set in-place.
-	for i, idx := range idxs {
-		xs[i] = xs[idx]
+func takeColumns[T any](xs []T, idxs []int) (out []T) {
+	for _, idx := range idxs {
+		out = append(out, xs[idx])
 	}
-	return xs[:len(idxs)]
+	return
 }
 
 func getColumnIndexes(names []string, header []string) ([]int, error) {

--- a/script_test.go
+++ b/script_test.go
@@ -3,6 +3,8 @@ package statedb
 import (
 	"context"
 	"maps"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/cilium/hive"
@@ -38,5 +40,68 @@ func TestScript(t *testing.T) {
 		context.Background(), func() *script.Engine {
 			return engine
 		}, []string{}, "testdata/*.txtar")
+}
 
+func TestHeaderLine(t *testing.T) {
+	type retrieval struct {
+		header string
+		idxs   []int
+	}
+	testCases := []struct {
+		line  string
+		names []string
+		pos   []int
+		get   []retrieval
+	}{
+		{
+			"Foo   Bar   ",
+			[]string{"Foo", "Bar"},
+			[]int{0, 6},
+			[]retrieval{
+				{"Foo", []int{0}},
+				{"Bar", []int{1}},
+				{"Bar Foo Bar", []int{1, 0, 1}},
+			},
+		},
+		{
+			"Foo Bar   Quux",
+			[]string{"Foo", "Bar", "Quux"},
+			[]int{0, 4, 10},
+			[]retrieval{
+				{"Foo", []int{0}},
+				{"Bar", []int{1}},
+				{"Bar  Foo", []int{1, 0}},
+				{"Quux", []int{2}},
+				{"Quux   Foo", []int{2, 0}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		// Parse header line into names and positions
+		names, pos := splitHeaderLine(tc.line)
+		require.Equal(t, tc.names, names)
+		require.Equal(t, tc.pos, pos)
+
+		// Split the header line with the parsed positions.
+		header := splitByPositions(tc.line, pos)
+		require.Equal(t, tc.names, header)
+
+		// Join the headers with the positions.
+		line := joinByPositions(header, pos)
+		require.Equal(t, strings.TrimRight(tc.line, " \t"), line)
+
+		// Test retrievals
+		for _, r := range tc.get {
+			names, pos = splitHeaderLine(r.header)
+			idxs, err := getColumnIndexes(names, header)
+			require.NoError(t, err)
+			require.Equal(t, r.idxs, idxs)
+
+			row := slices.Clone(header)
+			cols := takeColumns(row, idxs)
+			line := joinByPositions(cols, pos)
+			require.Equal(t, line, r.header)
+		}
+	}
 }


### PR DESCRIPTION
The takeColumns function assumed that the column indexes were ordered, e.g. if the table header was "Foo Bar Baz", then it'd always be referenced in order: "Foo" or "Foo Baz" but never "Baz Foo". There's no reason to assume that, so fix this and add tests.