### PR TITLE
Fix JSON formatting in db show command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cilium/statedb
 go 1.23
 
 require (
-	github.com/cilium/hive v0.0.0-20241011093954-8df06c41a157
+	github.com/cilium/hive v0.0.0-20241025140746-d66ad09f4384
 	github.com/cilium/stream v0.0.0-20240209152734-a0792b51812d
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/cilium/hive v0.0.0-20241011093954-8df06c41a157 h1:8UuDJ7JPPoCaDfZ/WkU/aP3FtNCwdNQe+7fbzP+lZrk=
 github.com/cilium/hive v0.0.0-20241011093954-8df06c41a157/go.mod h1:pI2GJ1n3SLKIQVFrKF7W6A6gb6BQkZ+3Hp4PAEo5SuI=
+github.com/cilium/hive v0.0.0-20241025140746-d66ad09f4384 h1:MAkG2lk4v0Z8J2X4+fFnhuCEsIJGPdCCrWzL41S2Z/I=
+github.com/cilium/hive v0.0.0-20241025140746-d66ad09f4384/go.mod h1:pI2GJ1n3SLKIQVFrKF7W6A6gb6BQkZ+3Hp4PAEo5SuI=
 github.com/cilium/stream v0.0.0-20240209152734-a0792b51812d h1:p6MgATaKEB9o7iAsk9rlzXNDMNCeKPAkx4Y8f+Zq8X8=
 github.com/cilium/stream v0.0.0-20240209152734-a0792b51812d/go.mod h1:3VLiLgs8wfjirkuYqos4t0IBPQ+sXtf3tFkChLm6ARM=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=

--- a/reconciler/script_test.go
+++ b/reconciler/script_test.go
@@ -30,7 +30,7 @@ import (
 	"golang.org/x/time/rate"
 )
 
-func newScriptTest(t *testing.T) *script.Engine {
+func newEngine(t testing.TB, args []string) *script.Engine {
 	log := hivetest.Logger(t)
 
 	var (
@@ -225,9 +225,9 @@ func TestScript(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)
 	scripttest.Test(t,
-		ctx, func() *script.Engine {
-			return newScriptTest(t)
-		}, []string{}, "testdata/*.txtar")
+		ctx, newEngine,
+		[]string{},
+		"testdata/*.txtar")
 }
 
 type testObject struct {

--- a/script.go
+++ b/script.go
@@ -604,20 +604,15 @@ func writeObjects(tbl *AnyTable, it iter.Seq2[any, Revision], w io.Writer, colum
 		return nil
 	case "json":
 		sep := []byte("\n")
-		first := true
 		for obj := range it {
-			if !first {
-				w.Write(sep)
-			}
-			first = false
-
-			out, err := json.Marshal(obj)
+			out, err := json.MarshalIndent(obj, "", "  ")
 			if err != nil {
 				return fmt.Errorf("json.Marshal: %w", err)
 			}
 			if _, err := w.Write(out); err != nil {
 				return err
 			}
+			w.Write(sep)
 		}
 		return nil
 	case "table":

--- a/script_test.go
+++ b/script_test.go
@@ -37,9 +37,13 @@ func TestScript(t *testing.T) {
 		Cmds: cmds,
 	}
 	scripttest.Test(t,
-		context.Background(), func() *script.Engine {
+		context.Background(),
+		func(t testing.TB, args []string) *script.Engine {
 			return engine
-		}, []string{}, "testdata/*.txtar")
+		},
+		[]string{},
+		"testdata/*.txtar",
+	)
 }
 
 func TestHeaderLine(t *testing.T) {

--- a/testdata/db.txtar
+++ b/testdata/db.txtar
@@ -39,16 +39,14 @@ grep ^Tags$
 grep '^bar, foo$'
 grep '^baz, foo$'
 
-db show  -format=json test1
-grep ID.:1.*bar
-grep ID.:2.*baz
+db show -format=table -o=test1_show.table test1
+cmp test1.table test1_show.table
 
-db show  -format=yaml test1
-grep 'id: 1'
-grep 'id: 2'
+db show -format=yaml -o=test1_show.yaml test1
+cmp test1.yaml test1_show.yaml
 
-db show -format=yaml -o=test1_export.yaml test1
-cmp test1.yaml test1_export.yaml
+db show -format=json -o=test1_show.json test1
+cmp test1.json test1_show.json
 
 # Get
 db get test2 2
@@ -160,6 +158,25 @@ id: 2
 tags:
     - baz
     - foo
+-- test1.json --
+{
+  "ID": 1,
+  "Tags": [
+    "bar",
+    "foo"
+  ]
+}
+{
+  "ID": 2,
+  "Tags": [
+    "baz",
+    "foo"
+  ]
+}
+-- test1.table --
+ID   Tags
+1    bar, foo
+2    baz, foo
 -- objs.table --
 ID   Tags
 1    bar, foo


### PR DESCRIPTION
The "db show -format=json" was missing newline at the end. While at it, switch to MarshalIndent for nicer output and extend the tests.

Hive dependency is bumped to add the -scripttest.update support.