### PR TITLE
CI: Fail action if make fails (pipefail oops)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,26 +17,21 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - name: test
         run: |
+          set -o pipefail
           echo '```' > results.comment
-          echo "$ make test" >> results.comment
-          make test 2>&1 | tee test.out
-          cat test.out | tail -20 >> results.comment
-          echo "-----" >> results.comment
+          echo "$ make" >> results.comment
+          make 2>&1 | tee -a results.comment
 
-      - name: test-race
+      - name: close
+        if: success() || failure()
         run: |
-          make test-race
-      - name: bench
-        run: |
-          echo "$ make bench" >> results.comment
-          make bench 2>&1 | tee bench.out
-          cat bench.out >> results.comment
           echo '```' >> results.comment
           
       - name: results
-        if: always()
+        if: success() || failure()
         uses: thollander/actions-comment-pull-request@v2
         with:
           comment_tag: results


### PR DESCRIPTION
The posting of the test run as a comment used `make | tee out` which without `pipefail` ate the exit status from `make`. Use `set -o pipefail` in the jobs to properly propagate this. While at it, simplify the workflow a bit.

In case you're wondering why post a comment at all: this is my simple way of easily keeping track of the code test coverage and the benchmark numbers (I always check the reconciler throughput for example). This will also leave a trace of which PR potentially started causing regressions (unreliable of course due to benchmarks running potentially different hardware, but it's something).