### PR TITLE
Flatten the 'db' commands, e.g. 'db prefix' to 'db/prefix'

### DIFF
--- a/reconciler/testdata/batching.txtar
+++ b/reconciler/testdata/batching.txtar
@@ -7,10 +7,10 @@ start-reconciler with-batchops
 # From here this is the same as incremental.txtar.
 
 # Step 1: Insert non-faulty objects
-db insert test-objects obj1.yaml
-db insert test-objects obj2.yaml
-db insert test-objects obj3.yaml
-db cmp test-objects step1+3.table
+db/insert test-objects obj1.yaml
+db/insert test-objects obj2.yaml
+db/insert test-objects obj3.yaml
+db/cmp test-objects step1+3.table
 expect-ops update(1) update(2) update(3)
 
 # Reconciler should be running and reporting health
@@ -18,27 +18,27 @@ health 'job-reconcile.*level=OK.*message=OK, 3 object'
 
 # Step 2: Update object '1' to be faulty and check that it fails and is being
 # retried.
-db insert test-objects obj1_faulty.yaml
+db/insert test-objects obj1_faulty.yaml
 expect-ops 'update(1) fail' 'update(1) fail' 
-db cmp test-objects step2.table
+db/cmp test-objects step2.table
 health 'job-reconcile.*level=Degraded.*1 error'
 
 # Step 3: Set object '1' back to healthy state
-db insert test-objects obj1.yaml
+db/insert test-objects obj1.yaml
 expect-ops 'update(1)'
-db cmp test-objects step1+3.table
+db/cmp test-objects step1+3.table
 health 'job-reconcile.*level=OK'
 
 # Step 4: Delete '1' and '2'
-db delete test-objects obj1.yaml
-db delete test-objects obj2.yaml
-db cmp test-objects step4.table
+db/delete test-objects obj1.yaml
+db/delete test-objects obj2.yaml
+db/cmp test-objects step4.table
 expect-ops 'delete(1)' 'delete(2)'
 
 # Step 5: Try to delete '3' with faulty target
 set-faulty true
-db delete test-objects obj3.yaml
-db cmp test-objects empty.table
+db/delete test-objects obj3.yaml
+db/cmp test-objects empty.table
 expect-ops 'delete(3) fail'
 health 'job-reconcile.*level=Degraded.*1 error'
 

--- a/reconciler/testdata/incremental.txtar
+++ b/reconciler/testdata/incremental.txtar
@@ -5,10 +5,10 @@ hive start
 start-reconciler
 
 # Step 1: Insert non-faulty objects
-db insert test-objects obj1.yaml
-db insert test-objects obj2.yaml
-db insert test-objects obj3.yaml
-db cmp test-objects step1+3.table
+db/insert test-objects obj1.yaml
+db/insert test-objects obj2.yaml
+db/insert test-objects obj3.yaml
+db/cmp test-objects step1+3.table
 expect-ops update(1) update(2) update(3)
 
 # Reconciler should be running and reporting health
@@ -16,28 +16,28 @@ health 'job-reconcile.*level=OK.*message=OK, 3 object'
 
 # Step 2: Update object '1' to be faulty and check that it fails and is being
 # retried.
-db insert test-objects obj1_faulty.yaml
-db cmp test-objects step2.table
+db/insert test-objects obj1_faulty.yaml
+db/cmp test-objects step2.table
 expect-ops 'update(1) fail' 'update(1) fail' 
 health 'job-reconcile.*level=Degraded.*1 error'
 
 # Step 3: Set object '1' back to healthy state
-db insert test-objects obj1.yaml
-db show test-objects
-db cmp test-objects step1+3.table
+db/insert test-objects obj1.yaml
+db/show test-objects
+db/cmp test-objects step1+3.table
 expect-ops 'update(1)'
 health 'job-reconcile.*level=OK'
 
 # Step 4: Delete '1' and '2'
-db delete test-objects obj1.yaml
-db delete test-objects obj2.yaml
-db cmp test-objects step4.table
+db/delete test-objects obj1.yaml
+db/delete test-objects obj2.yaml
+db/cmp test-objects step4.table
 expect-ops 'delete(1)' 'delete(2)'
 
 # Step 5: Try to delete '3' with faulty target
 set-faulty true
-db delete test-objects obj3.yaml
-db cmp test-objects empty.table
+db/delete test-objects obj3.yaml
+db/cmp test-objects empty.table
 expect-ops 'delete(3) fail'
 health 'job-reconcile.*level=Degraded.*1 error'
 

--- a/reconciler/testdata/pruning.txtar
+++ b/reconciler/testdata/pruning.txtar
@@ -2,10 +2,10 @@ hive start
 start-reconciler with-prune
 
 # Pruning without table being initialized does nothing.
-db insert test-objects obj1.yaml
+db/insert test-objects obj1.yaml
 expect-ops update(1)
 prune
-db insert test-objects obj2.yaml 
+db/insert test-objects obj2.yaml 
 expect-ops update(2) update(1)
 health 'job-reconcile.*level=OK'
 
@@ -33,12 +33,12 @@ expvar
 grep 'prune_current_errors.test: 0'
 
 # Delete an object and check pruning happens without it
-db delete test-objects obj1.yaml
+db/delete test-objects obj1.yaml
 prune
 expect-ops 'prune(n=1)' delete(1)
 
 # Prune without objects
-db delete test-objects obj2.yaml
+db/delete test-objects obj2.yaml
 prune
 expect-ops prune(n=0) delete(2) prune(n=1)
 

--- a/reconciler/testdata/refresh.txtar
+++ b/reconciler/testdata/refresh.txtar
@@ -2,27 +2,27 @@ hive start
 start-reconciler with-refresh
 
 # Step 1: Add a test object.
-db insert test-objects obj1.yaml
+db/insert test-objects obj1.yaml
 expect-ops 'update(1)'
-db cmp test-objects step1.table
+db/cmp test-objects step1.table
 
 # Step 2: Set the object as updated in the past to force refresh
-db insert test-objects obj1_old.yaml
+db/insert test-objects obj1_old.yaml
 expect-ops 'update-refresh(1)'
 
 # Step 3: Refresh with faulty target, should see fail & retries
 set-faulty true
-db insert test-objects obj1_old.yaml
+db/insert test-objects obj1_old.yaml
 expect-ops 'update-refresh(1) fail' 'update-refresh(1) fail'
-db cmp test-objects step3.table
+db/cmp test-objects step3.table
 health
 health 'job-reconcile.*Degraded'
 
 # Step 4: Back to health
 set-faulty false
-db insert test-objects obj1_old.yaml
+db/insert test-objects obj1_old.yaml
 expect-ops 'update-refresh(1)'
-db cmp test-objects step4.table
+db/cmp test-objects step4.table
 health 'job-reconcile.*OK, 1 object'
 
 # -----

--- a/testdata/db.txtar
+++ b/testdata/db.txtar
@@ -6,78 +6,78 @@
 hive start
 
 # Show the registered tables
-db tables
+db
 
 # Initialized
-db initialized
-db initialized test1
-db initialized test1 test2
+db/initialized
+db/initialized test1
+db/initialized test1 test2
 
 # Show (empty)
-db show test1
-db show test2
+db/show test1
+db/show test2
 
 # Insert
-db insert test1 obj1.yaml
-db insert test1 obj2.yaml
-db insert test2 obj2.yaml
+db/insert test1 obj1.yaml
+db/insert test1 obj2.yaml
+db/insert test2 obj2.yaml
 
 # Show (non-empty)
-db show test1
+db/show test1
 grep ^ID.*Tags
 grep 1.*bar
 grep 2.*baz
-db show test2
+db/show test2
 
-db show -format=table test1
+db/show -format=table test1
 grep ^ID.*Tags
 grep 1.*bar
 grep 2.*baz
 
-db show -format=table -columns=Tags test1
+db/show -format=table -columns=Tags test1
 grep ^Tags$
 grep '^bar, foo$'
 grep '^baz, foo$'
 
-db show -format=table -o=test1_show.table test1
+db/show -format=table -o=test1_show.table test1
 cmp test1.table test1_show.table
 
-db show -format=yaml -o=test1_show.yaml test1
+db/show -format=yaml -o=test1_show.yaml test1
 cmp test1.yaml test1_show.yaml
 
-db show -format=json -o=test1_show.json test1
+db/show -format=json -o=test1_show.json test1
 cmp test1.json test1_show.json
 
 # Get
-db get test2 2
-db get -format=table test2 2
+db/get test2 2
+db/get -format=table test2 2
 grep '^ID.*Tags$'
 grep ^2.*baz
-db get -format=table -columns=Tags test2 2
+db/get -format=table -columns=Tags test2 2
 grep ^Tags$
 grep '^baz, foo$'
-db get -format=json test2 2
-db get -format=yaml test2 2
-db get -format=yaml -o=obj2_get.yaml test2 2
+db/get -format=json test2 2
+db/get -format=yaml test2 2
+db/get -format=yaml -o=obj2_get.yaml test2 2
 cmp obj2.yaml obj2_get.yaml
 
-db get -index=tags -format=yaml -o=obj1_get.yaml test1 bar
+db/get -index=tags -format=yaml -o=obj1_get.yaml test1 bar
 cmp obj1.yaml obj1_get.yaml
 
 # List
-db list -o=list.table test1 1
+db/list -o=list.table test1 1
 cmp obj1.table list.table
-db list -o=list.table test1 2
+db/list -o=list.table test1 2
 cmp obj2.table list.table
 
-db list -o=list.table -index=tags test1 bar
+db/list -o=list.table -index=tags test1 bar
 cmp obj1.table list.table
-db list -o=list.table -index=tags test1 baz
+db/list -o=list.table -index=tags test1 baz
 cmp obj2.table list.table
-db list -o=list.table -index=tags test1 foo
+db/list -o=list.table -index=tags test1 foo
 cmp objs.table list.table
 
-db list -format=table -index=tags -columns=Tags test1 foo
+db/list -format=table -index=tags -columns=Tags test1 foo
 grep ^Tags$
 grep '^bar, foo$'
 grep '^baz, foo$'
@@ -85,56 +85,56 @@ grep '^baz, foo$'
 # Prefix
 # uint64 so can't really prefix search meaningfully, unless
 # FromString() accomodates partial keys.
-db prefix test1 1
+db/prefix test1 1
 
-db prefix -o=prefix.table -index=tags test1 ba
+db/prefix -o=prefix.table -index=tags test1 ba
 cmp objs.table prefix.table
 
 # LowerBound
-db lowerbound -o=lb.table test1 0
+db/lowerbound -o=lb.table test1 0
 cmp objs.table lb.table
-db lowerbound -o=lb.table test1 1
+db/lowerbound -o=lb.table test1 1
 cmp objs.table lb.table
-db lowerbound -o=lb.table test1 2
+db/lowerbound -o=lb.table test1 2
 cmp obj2.table lb.table
-db lowerbound -o=lb.table test1 3
+db/lowerbound -o=lb.table test1 3
 cmp empty.table lb.table
 
 # Compare
-db cmp test1 objs.table
-db cmp test1 objs_ids.table
-db cmp -grep=bar test1 obj1.table
-db cmp -grep=baz test1 obj2.table
+db/cmp test1 objs.table
+db/cmp test1 objs_ids.table
+db/cmp -grep=bar test1 obj1.table
+db/cmp -grep=baz test1 obj2.table
 
 # Delete
-db delete test1 obj1.yaml
-db cmp test1 obj2.table
+db/delete test1 obj1.yaml
+db/cmp test1 obj2.table
 
-db delete test1 obj2.yaml
-db cmp test1 empty.table
+db/delete test1 obj2.yaml
+db/cmp test1 empty.table
 
 # Delete with get
-db insert test1 obj1.yaml
-db cmp test1 obj1.table
-db get -delete test1 1
-db cmp test1 empty.table
+db/insert test1 obj1.yaml
+db/cmp test1 obj1.table
+db/get -delete test1 1
+db/cmp test1 empty.table
 
 # Delete with prefix
-db insert test1 obj1.yaml
-db insert test1 obj2.yaml
-db cmp test1 objs.table
-db prefix -index=tags -delete test1 fo
-db cmp test1 empty.table
+db/insert test1 obj1.yaml
+db/insert test1 obj2.yaml
+db/cmp test1 objs.table
+db/prefix -index=tags -delete test1 fo
+db/cmp test1 empty.table
 
 # Delete with lowerbound
-db insert test1 obj1.yaml
-db insert test1 obj2.yaml
-db cmp test1 objs.table
-db lowerbound -index=id -delete test1 2
-db cmp test1 obj1.table
+db/insert test1 obj1.yaml
+db/insert test1 obj2.yaml
+db/cmp test1 objs.table
+db/lowerbound -index=id -delete test1 2
+db/cmp test1 obj1.table
 
 # Tables
-db tables
+db
 
 # ---------------------
 


### PR DESCRIPTION
The user experience with commands that have sub-commands is not great and it makes it harder to implement completion in 'cilium-dbg shell' if we so choose. There isn't really any good rational for nesting the commands like this, so let's go with Plan 9 style command names (https://9p.io/magic/man2html/8/auth), e.g. "db prefix" becomes "db/prefix".