### PR TITLE
Add InsertWatch operation

### DIFF
--- a/any_table.go
+++ b/any_table.go
@@ -31,7 +31,7 @@ func (t AnyTable) UnmarshalYAML(data []byte) (any, error) {
 
 func (t AnyTable) Insert(txn WriteTxn, obj any) (old any, hadOld bool, err error) {
 	var iobj object
-	iobj, hadOld, err = txn.getTxn().insert(t.Meta, Revision(0), obj)
+	iobj, hadOld, _, err = txn.getTxn().insert(t.Meta, Revision(0), obj)
 	if hadOld {
 		old = iobj.data
 	}

--- a/part/part_test.go
+++ b/part/part_test.go
@@ -45,9 +45,10 @@ func Test_insertion_and_watches(t *testing.T) {
 
 		txn := tree.Txn()
 		txn.Insert([]byte("abc"), 1)
-		txn.Insert([]byte("ab"), 2)
+		_, _, watch_ab := txn.InsertWatch([]byte("ab"), 2)
 		txn.Insert([]byte("abd"), 3)
 		tree = txn.Commit()
+		assertOpen(t, watch_ab)
 
 		_, w, f := tree.Get([]byte("ab"))
 		assert.True(t, f)
@@ -63,6 +64,7 @@ func Test_insertion_and_watches(t *testing.T) {
 		_, _, tree = tree.Insert([]byte("ab"), 42)
 		assertClosed(t, w)
 		assertClosed(t, w2)
+		assertClosed(t, watch_ab)
 
 		assertOpen(t, w3)
 

--- a/types.go
+++ b/types.go
@@ -143,6 +143,18 @@ type RWTable[Obj any] interface {
 	// revision.
 	Insert(WriteTxn, Obj) (oldObj Obj, hadOld bool, err error)
 
+	// InsertWatch an object into the table. Returns the object that was
+	// replaced if there was one and a watch channel that closes when the
+	// object is modified again.
+	//
+	// Possible errors:
+	// - ErrTableNotLockedForWriting: table was not locked for writing
+	// - ErrTransactionClosed: the write transaction already committed or aborted
+	//
+	// Each inserted or updated object will be assigned a new unique
+	// revision.
+	InsertWatch(WriteTxn, Obj) (oldObj Obj, hadOld bool, watch <-chan struct{}, err error)
+
 	// Modify an existing object or insert a new object into the table. If an old object
 	// exists the [merge] function is called with the old and new objects.
 	//


### PR DESCRIPTION
The InsertWatch returns the new watch channel for the inserted objects allowing waiting for subsequent changes without having to do a separate query to retrieve the watch channel.

Example:
```
  txn := db.WriteTxn(table)
  old, hadOld, watch, err := table.InsertWatch(txn, myObject{ID: 1})
  txn.Commit()

  txn = db.WriteTxn(table)
  table.Insert(txn, myObject{ID: 1})
  txn.Commit()

  <-watch // this is now closed
```