### PR TITLE
watchset: Use a map for channels and add Merge and Has

### DIFF
--- a/watchset.go
+++ b/watchset.go
@@ -1,64 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
 package statedb
 
 import (
 	"context"
 	"slices"
 	"sync"
+
+	"golang.org/x/exp/maps"
 )
 
 const watchSetChunkSize = 16
 
+type channelSet = map[<-chan struct{}]struct{}
+
 // WatchSet is a set of watch channels that can be waited on.
 type WatchSet struct {
 	mu    sync.Mutex
-	chans []<-chan struct{}
+	chans channelSet
 }
 
 func NewWatchSet() *WatchSet {
 	return &WatchSet{
-		chans: make([]<-chan struct{}, 0, watchSetChunkSize),
+		chans: channelSet{},
 	}
 }
 
-// Add a channel to the watch set.
+// Add channel(s) to the watch set
 func (ws *WatchSet) Add(chans ...<-chan struct{}) {
 	ws.mu.Lock()
 	for _, ch := range chans {
-		ws.chans = append(ws.chans, ch)
+		ws.chans[ch] = struct{}{}
 	}
 	ws.mu.Unlock()
 }
 
+// Clear the channels from the WatchSet
 func (ws *WatchSet) Clear() {
 	ws.mu.Lock()
-	ws.chans = ws.chans[:0]
+	clear(ws.chans)
 	ws.mu.Unlock()
+}
+
+// Has returns true if the WatchSet has the channel
+func (ws *WatchSet) Has(ch <-chan struct{}) bool {
+	ws.mu.Lock()
+	_, found := ws.chans[ch]
+	ws.mu.Unlock()
+	return found
+}
+
+// Merge channels from another WatchSet
+func (ws *WatchSet) Merge(other *WatchSet) {
+	other.mu.Lock()
+	defer other.mu.Unlock()
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
+	for ch := range other.chans {
+		ws.chans[ch] = struct{}{}
+	}
 }
 
 // Wait for any channel in the watch set to close. The
 // watch set is cleared when this method returns.
-func (ws *WatchSet) Wait(ctx context.Context) error {
+func (ws *WatchSet) Wait(ctx context.Context) (<-chan struct{}, error) {
 	ws.mu.Lock()
 	defer func() {
-		ws.chans = ws.chans[:0]
+		clear(ws.chans)
 		ws.mu.Unlock()
 	}()
 
 	// No channels to watch? Just watch the context.
 	if len(ws.chans) == 0 {
 		<-ctx.Done()
-		return ctx.Err()
+		return nil, ctx.Err()
 	}
 
 	// Collect the channels into a slice. The slice length is rounded to a full
 	// chunk size.
+	chans := maps.Keys(ws.chans)
 	chunkSize := 16
-	roundedSize := len(ws.chans) + (chunkSize - len(ws.chans)%chunkSize)
-	ws.chans = slices.Grow(ws.chans, roundedSize)[:roundedSize]
+	roundedSize := len(chans) + (chunkSize - len(chans)%chunkSize)
+	chans = slices.Grow(chans, roundedSize)[:roundedSize]
 
 	if len(ws.chans) <= chunkSize {
-		watch16(ctx.Done(), ws.chans)
-		return ctx.Err()
+		ch := watch16(ctx.Done(), chans)
+		return ch, ctx.Err()
 	}
 
 	// More than one chunk. Fork goroutines to watch each chunk. The first chunk
@@ -66,38 +94,68 @@ func (ws *WatchSet) Wait(ctx context.Context) error {
 	innerCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	closedChan := make(chan (<-chan struct{}), 1)
+	defer close(closedChan)
 	var wg sync.WaitGroup
-	for chunk := range slices.Chunk(ws.chans, chunkSize) {
+
+	for chunk := range slices.Chunk(chans, chunkSize) {
 		wg.Add(1)
 		go func() {
 			defer cancel()
 			defer wg.Done()
 			chunk = slices.Clone(chunk)
-			watch16(innerCtx.Done(), chunk)
+			if ch := watch16(innerCtx.Done(), chunk); ch != nil {
+				select {
+				case closedChan <- ch:
+				default:
+				}
+			}
 		}()
 	}
 	wg.Wait()
-	return ctx.Err()
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case ch := <-closedChan:
+		return ch, nil
+	}
 }
 
-func watch16(stop <-chan struct{}, chans []<-chan struct{}) {
+func watch16(stop <-chan struct{}, chans []<-chan struct{}) <-chan struct{} {
 	select {
 	case <-stop:
+		return nil
 	case <-chans[0]:
+		return chans[0]
 	case <-chans[1]:
+		return chans[1]
 	case <-chans[2]:
+		return chans[2]
 	case <-chans[3]:
+		return chans[3]
 	case <-chans[4]:
+		return chans[4]
 	case <-chans[5]:
+		return chans[5]
 	case <-chans[6]:
+		return chans[6]
 	case <-chans[7]:
+		return chans[7]
 	case <-chans[8]:
+		return chans[8]
 	case <-chans[9]:
+		return chans[9]
 	case <-chans[10]:
+		return chans[10]
 	case <-chans[11]:
+		return chans[11]
 	case <-chans[12]:
+		return chans[12]
 	case <-chans[13]:
+		return chans[13]
 	case <-chans[14]:
+		return chans[14]
 	case <-chans[15]:
+		return chans[15]
 	}
 }

--- a/watchset_test.go
+++ b/watchset_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
 package statedb
 
 import (
@@ -18,8 +21,9 @@ func TestWatchSet(t *testing.T) {
 	// Empty watch set, cancelled context.
 	ctx, cancel := context.WithCancel(context.Background())
 	go cancel()
-	err := ws.Wait(ctx)
+	ch, err := ws.Wait(ctx)
 	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, ch)
 
 	// Few channels, cancelled context.
 	ch1 := make(chan struct{})
@@ -28,8 +32,9 @@ func TestWatchSet(t *testing.T) {
 	ws.Add(ch1, ch2, ch3)
 	ctx, cancel = context.WithCancel(context.Background())
 	go cancel()
-	err = ws.Wait(ctx)
+	ch, err = ws.Wait(ctx)
 	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, ch)
 
 	// Many channels
 	for _, numChans := range []int{0, 1, 8, 12, 16, 31, 32, 61, 64, 121} {
@@ -45,8 +50,9 @@ func TestWatchSet(t *testing.T) {
 
 			close(chans[i])
 			ctx, cancel = context.WithCancel(context.Background())
-			err = ws.Wait(ctx)
+			ch, err := ws.Wait(ctx)
 			require.NoError(t, err)
+			require.True(t, ch == chans[i])
 			cancel()
 		}
 	}
@@ -63,8 +69,9 @@ func TestWatchSetInQueries(t *testing.T) {
 	// Should timeout as watches should not have closed yet.
 	ws.Add(watchAll)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
-	err := ws.Wait(ctx)
+	ch, err := ws.Wait(ctx)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Nil(t, ch)
 	cancel()
 
 	// Insert some objects
@@ -76,24 +83,39 @@ func TestWatchSetInQueries(t *testing.T) {
 
 	// The 'watchAll' channel should now have closed and Wait() returns.
 	ws.Add(watchAll)
-	err = ws.Wait(context.Background())
+	ch, err = ws.Wait(context.Background())
 	require.NoError(t, err)
+	require.Equal(t, ch, watchAll)
 
 	// Try watching specific objects for changes.
 	_, _, watch1, _ := table.GetWatch(txn, idIndex.Query(1))
 	_, _, watch2, _ := table.GetWatch(txn, idIndex.Query(2))
 	_, _, watch3, _ := table.GetWatch(txn, idIndex.Query(3))
-	ws.Add(watch3, watch2, watch1)
+
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Millisecond)
-	err = ws.Wait(ctx)
+	ch, err = ws.Wait(ctx)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Nil(t, ch)
 	cancel()
 
 	wtxn = db.WriteTxn(table)
 	table.Insert(wtxn, testObject{ID: 1, Tags: part.NewSet("foo")})
 	wtxn.Commit()
 
-	ws.Add(watch3, watch2, watch1)
-	err = ws.Wait(context.Background())
+	// Use a new WatchSet and merge it. This allows having "subsets" that we
+	// can then use to check whether the closed channel affected the subset.
+	ws2 := NewWatchSet()
+	ws2.Add(watch3, watch2, watch1)
+
+	// Merge into the larger WatchSet. This still leaves all the channels
+	// in ws2.
+	ws.Merge(ws2)
+
+	ch, err = ws.Wait(context.Background())
 	require.NoError(t, err)
+	require.True(t, ch == watch1)
+	require.True(t, ws2.Has(ch))
+
+	ws2.Clear()
+	require.False(t, ws2.Has(ch))
 }


### PR DESCRIPTION
It is not very uncommon that we'd add duplicate channels to the watch set, so better deduplicate.

Add Merge() and Has() methods. These are useful when we need to know whether a closed channel affected a particular subset of work.