### PR TITLE
Avoid repeated Clone() when doing reads with a WriteTxn

### DIFF
--- a/part/txn.go
+++ b/part/txn.go
@@ -33,17 +33,14 @@ func (txn *Txn[T]) Len() int {
 	return txn.size
 }
 
-// Clone returns a clone of the transaction. The clone is unaffected
+// Clone returns a clone of the transaction for reading. The clone is unaffected
 // by any future changes done with the original transaction.
-func (txn *Txn[T]) Clone() *Txn[T] {
+func (txn *Txn[T]) Clone() Ops[T] {
 	// Clear the mutated nodes so that the returned clone won't be changed by
 	// further modifications in this transaction.
 	txn.mutated.clear()
-	return &Txn[T]{
-		Tree:               txn.Tree,
-		watches:            map[chan struct{}]struct{}{},
-		deleteParentsCache: nil,
-	}
+	treeCopy := txn.Tree
+	return &treeCopy
 }
 
 // Insert or update the tree with the given key and value.

--- a/txn.go
+++ b/txn.go
@@ -96,13 +96,10 @@ func (txn *txn) indexReadTxn(meta TableMeta, indexPos int) (indexReadTxn, error)
 	if txn.modifiedTables != nil {
 		entry := txn.modifiedTables[meta.tablePos()]
 		if entry != nil {
-			itxn, err := txn.indexWriteTxn(meta, indexPos)
-			if err != nil {
-				return indexReadTxn{}, err
-			}
+			indexEntry := &entry.indexes[indexPos]
 			// Since iradix reuses nodes when mutating we need to return a clone
 			// so that iterators don't become invalid.
-			return indexReadTxn{itxn.Txn.Clone(), itxn.unique}, nil
+			return indexReadTxn{indexEntry.getClone(), indexEntry.unique}, nil
 		}
 	}
 	indexEntry := txn.root[meta.tablePos()].indexes[indexPos]
@@ -120,6 +117,7 @@ func (txn *txn) indexWriteTxn(meta TableMeta, indexPos int) (indexTxn, error) {
 	if indexEntry.txn == nil {
 		indexEntry.txn = indexEntry.tree.Txn()
 	}
+	indexEntry.clone = nil
 	return indexTxn{indexEntry.txn, indexEntry.unique}, nil
 }
 


### PR DESCRIPTION
This reduces allocations a bit when using `WriteTxn` to do `Prefix` or `LowerBound` queries by not repeatedly cloning the `part.Txn` of a `WriteTxn` when no writes have been made.

Benchmark before:
```
    BenchmarkDB_SequentialInsert_Prefix-32               207           5982505 ns/op            167154 objects/sec   5611786 B/op      67561 allocs/op
```

after:
```
    BenchmarkDB_SequentialInsert_Prefix-32               247           4594889 ns/op            217633 objects/sec   3795819 B/op      58560 allocs/op
```

The benchmark does an Insert followed by 5 prefix searches for the inserted object. ~15% less allocations and ~20% faster benchmark result.