### PR TITLE
reconciler: Add revision to Update and Delete ops

### DIFF
--- a/reconciler/benchmark/main.go
+++ b/reconciler/benchmark/main.go
@@ -60,7 +60,7 @@ type mockOps struct {
 }
 
 // Delete implements reconciler.Operations.
-func (mt *mockOps) Delete(ctx context.Context, txn statedb.ReadTxn, obj *testObject) error {
+func (mt *mockOps) Delete(ctx context.Context, txn statedb.ReadTxn, rev statedb.Revision, obj *testObject) error {
 	return nil
 }
 
@@ -70,7 +70,7 @@ func (mt *mockOps) Prune(ctx context.Context, txn statedb.ReadTxn, objects iter.
 }
 
 // Update implements reconciler.Operations.
-func (mt *mockOps) Update(ctx context.Context, txn statedb.ReadTxn, obj *testObject) error {
+func (mt *mockOps) Update(ctx context.Context, txn statedb.ReadTxn, rev statedb.Revision, obj *testObject) error {
 	mt.numUpdates.Add(1)
 	return nil
 }

--- a/reconciler/example/ops.go
+++ b/reconciler/example/ops.go
@@ -35,7 +35,7 @@ func NewMemoOps(lc cell.Lifecycle, log *slog.Logger, cfg Config) reconciler.Oper
 }
 
 // Delete a memo.
-func (ops *MemoOps) Delete(ctx context.Context, txn statedb.ReadTxn, memo *Memo) error {
+func (ops *MemoOps) Delete(ctx context.Context, txn statedb.ReadTxn, rev statedb.Revision, memo *Memo) error {
 	filename := path.Join(ops.directory, memo.Name)
 	err := os.Remove(filename)
 	ops.log.Info("Delete", "filename", filename, "error", err)
@@ -76,7 +76,7 @@ func (ops *MemoOps) Prune(ctx context.Context, txn statedb.ReadTxn, objects iter
 }
 
 // Update a memo.
-func (ops *MemoOps) Update(ctx context.Context, txn statedb.ReadTxn, memo *Memo) error {
+func (ops *MemoOps) Update(ctx context.Context, txn statedb.ReadTxn, rev statedb.Revision, memo *Memo) error {
 	filename := path.Join(ops.directory, memo.Name)
 	err := os.WriteFile(filename, []byte(memo.Content), 0644)
 	ops.log.Info("Update", "filename", filename, "error", err)

--- a/reconciler/incremental.go
+++ b/reconciler/incremental.go
@@ -201,7 +201,7 @@ func (round *incrementalRound[Obj]) processSingle(obj Obj, rev statedb.Revision,
 	)
 	if delete {
 		op = OpDelete
-		err = round.config.Operations.Delete(round.ctx, round.txn, obj)
+		err = round.config.Operations.Delete(round.ctx, round.txn, rev, obj)
 		if err != nil {
 			// Deletion failed. Retry again later.
 			round.retries.Add(obj, rev, true, err)
@@ -211,7 +211,7 @@ func (round *incrementalRound[Obj]) processSingle(obj Obj, rev statedb.Revision,
 		orig := obj
 		obj = round.config.CloneObject(obj)
 		op = OpUpdate
-		err = round.config.Operations.Update(round.ctx, round.txn, obj)
+		err = round.config.Operations.Update(round.ctx, round.txn, rev, obj)
 		status := round.config.GetObjectStatus(obj)
 		round.results[obj] = opResult{original: orig, id: status.ID, rev: rev, err: err}
 	}

--- a/reconciler/multi_test.go
+++ b/reconciler/multi_test.go
@@ -48,7 +48,7 @@ type multiMockOps struct {
 }
 
 // Delete implements reconciler.Operations.
-func (m *multiMockOps) Delete(context.Context, statedb.ReadTxn, *multiStatusObject) error {
+func (m *multiMockOps) Delete(context.Context, statedb.ReadTxn, statedb.Revision, *multiStatusObject) error {
 	return nil
 }
 
@@ -58,7 +58,7 @@ func (m *multiMockOps) Prune(context.Context, statedb.ReadTxn, iter.Seq2[*multiS
 }
 
 // Update implements reconciler.Operations.
-func (m *multiMockOps) Update(ctx context.Context, txn statedb.ReadTxn, obj *multiStatusObject) error {
+func (m *multiMockOps) Update(ctx context.Context, txn statedb.ReadTxn, rev statedb.Revision, obj *multiStatusObject) error {
 	m.numUpdates++
 	if m.faulty.Load() {
 		return errors.New("fail")

--- a/reconciler/types.go
+++ b/reconciler/types.go
@@ -65,11 +65,11 @@ type Operations[Obj any] interface {
 	// The object handed to Update is a clone produced by Config.CloneObject
 	// and thus Update can mutate the object. The mutations are only guaranteed
 	// to be retained if the object has a single reconciler (one Status).
-	Update(ctx context.Context, txn statedb.ReadTxn, obj Obj) error
+	Update(ctx context.Context, txn statedb.ReadTxn, revision statedb.Revision, obj Obj) error
 
 	// Delete the object in the target. Same semantics as with Update.
 	// Deleting a non-existing object is not an error and returns nil.
-	Delete(context.Context, statedb.ReadTxn, Obj) error
+	Delete(context.Context, statedb.ReadTxn, statedb.Revision, Obj) error
 
 	// Prune undesired state. It is given an iterator for the full set of
 	// desired objects. The implementation should diff the desired state against


### PR DESCRIPTION
For symmetry with BatchOperations add the object revision to the [Operations.Update] and [Operations.Delete].

Fixes: #56