### PR TITLE
part: RootOnlyWatch fixes

### DIFF
--- a/part/txn.go
+++ b/part/txn.go
@@ -217,7 +217,7 @@ func (txn *Txn[T]) modify(root *header[T], key []byte, mod func(T) T) (oldValue 
 				if this.watch != nil {
 					txn.watches[this.watch] = struct{}{}
 				}
-				this = this.promote(!txn.opts.rootOnlyWatch || this == newRoot)
+				this = this.promote(!txn.opts.rootOnlyWatch || this == root)
 				txn.mutated.put(this)
 			} else {
 				// Node is big enough, clone it so we can mutate it

--- a/part/txn.go
+++ b/part/txn.go
@@ -58,6 +58,9 @@ func (txn *Txn[T]) InsertWatch(key []byte, value T) (old T, hadOld bool, watch <
 	if !hadOld {
 		txn.size++
 	}
+	if txn.opts.rootOnlyWatch {
+		watch = txn.root.watch
+	}
 	return
 }
 
@@ -79,6 +82,9 @@ func (txn *Txn[T]) ModifyWatch(key []byte, mod func(T) T) (old T, hadOld bool, w
 	old, hadOld, watch, txn.root = txn.modify(txn.root, key, mod)
 	if !hadOld {
 		txn.size++
+	}
+	if txn.opts.rootOnlyWatch {
+		watch = txn.root.watch
 	}
 	return
 }


### PR DESCRIPTION
The InsertWatch/ModifyWatch returned nil channel with RootOnlyWatch. Should always return the root channel.

The root node watch channel was not replaced on promotion with RootOnlyWatch. This potentially impacts StateDB as it uses RootOnlyWatch for the revision index so when revision `2^58` (6th most significant bit changes) is hit the root node will need to split from node4 to node16 hitting the bug.