### PR TITLE
treewide: modernize for 1.24

### DIFF
--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -510,7 +510,6 @@ func TestDB_Fuzz(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(numWorkers)
 	for i := range numWorkers {
-		i := i
 		go func() {
 			fuzzWorker(actionLog, i, numIterations)
 			wg.Done()
@@ -522,7 +521,6 @@ func TestDB_Fuzz(t *testing.T) {
 	var wg2 sync.WaitGroup
 	wg2.Add(numTrackers)
 	for i := range numTrackers {
-		i := i
 		go func() {
 			trackerWorker(i, stop)
 			wg2.Done()

--- a/part/map_test.go
+++ b/part/map_test.go
@@ -221,7 +221,7 @@ func Benchmark_Uint64Map_Random(b *testing.B) {
 		k := uint64(rand.Int64())
 		keys[k] = int(k)
 	}
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		var m part.Map[uint64, int]
 		for k, v := range keys {
 			m = m.Set(k, v)
@@ -237,7 +237,7 @@ func Benchmark_Uint64Map_Random(b *testing.B) {
 func Benchmark_Uint64Map_Sequential(b *testing.B) {
 	numItems := 1000
 
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		var m part.Map[uint64, int]
 		for i := range numItems {
 			k := uint64(i)

--- a/part/part_test.go
+++ b/part/part_test.go
@@ -1012,7 +1012,7 @@ func Benchmark_Insert(b *testing.B) {
 }
 
 func benchmark_Insert(b *testing.B, opts ...Option) {
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		tree := New[int](opts...)
 		txn := tree.Txn()
 		for i := range numObjectsToInsert {
@@ -1033,8 +1033,8 @@ func benchmark_Modify_vs_GetInsert(b *testing.B, doGetInsert bool) {
 		_, _, tree = tree.Insert(key, numObjectsToInsert+i)
 		keys = append(keys, key)
 	}
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
+
+	for b.Loop() {
 		txn := tree.Txn()
 		for _, key := range keys {
 			if doGetInsert {
@@ -1077,9 +1077,8 @@ func benchmark_Replace(b *testing.B, watching bool) {
 		txn.Insert(key, numObjectsToInsert+i)
 	}
 
-	b.ResetTimer()
 	key := binary.BigEndian.AppendUint32(nil, uint32(0))
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		txn.Insert(key, 0)
 	}
 	b.StopTimer()
@@ -1164,9 +1163,9 @@ func Benchmark_Get(b *testing.B) {
 	for j := range uint64(numObjectsToInsert) {
 		_, _, tree = tree.Insert(uint64Key(j), j)
 	}
-	b.ResetTimer()
+
 	var key [8]byte // to avoid the allocation
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		for j := range uint64(numObjectsToInsert) {
 			binary.BigEndian.PutUint64(key[:], j)
 			v, _, ok := tree.Get(key[:])
@@ -1184,8 +1183,8 @@ func Benchmark_Iterate(b *testing.B) {
 	for j := uint64(1); j <= numObjectsToInsert; j++ {
 		_, _, tree = tree.Insert(uint64Key(j), j)
 	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		iter := tree.Iterator()
 		for _, j, ok := iter.Next(); ok; _, j, ok = iter.Next() {
 			if j < 1 || j > numObjectsToInsert+1 {
@@ -1197,7 +1196,7 @@ func Benchmark_Iterate(b *testing.B) {
 }
 
 func Benchmark_Hashmap_Insert(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		m := map[uint64]uint64{}
 		for j := range uint64(numObjectsToInsert) {
 			m[j] = j
@@ -1214,8 +1213,8 @@ func Benchmark_Hashmap_Get_Uint64(b *testing.B) {
 	for j := range uint64(numObjectsToInsert) {
 		m[j] = j
 	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		for j := range uint64(numObjectsToInsert) {
 			if m[j] != j {
 				b.Fatalf("impossible: %d != %d", m[j], j)
@@ -1232,8 +1231,8 @@ func Benchmark_Hashmap_Get_Bytes(b *testing.B) {
 		binary.BigEndian.PutUint64(k[:], j)
 		m[k] = j
 	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		for j := range uint64(numObjectsToInsert) {
 			binary.BigEndian.PutUint64(k[:], j)
 			if m[k] != j {

--- a/script.go
+++ b/script.go
@@ -435,8 +435,8 @@ func insertOrDelete(insert bool, db *DB, s *script.State, args ...string) (scrip
 		if err != nil {
 			return nil, fmt.Errorf("ReadFile(%s): %w", arg, err)
 		}
-		parts := strings.Split(string(data), "---")
-		for _, part := range parts {
+		parts := strings.SplitSeq(string(data), "---")
+		for part := range parts {
 			obj, err := tbl.UnmarshalYAML([]byte(part))
 			if err != nil {
 				return nil, fmt.Errorf("Unmarshal(%s): %w", arg, err)

--- a/watchset_test.go
+++ b/watchset_test.go
@@ -128,8 +128,7 @@ func benchmarkWatchSet(b *testing.B, numChans int) {
 		ws.Add(make(chan struct{}))
 	}
 
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		ws.Add(closedWatchChannel)
 		ws.Wait(context.TODO(), 0)
 	}


### PR DESCRIPTION
Diff generated by:

go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test ./...

Mostly due to the bump to 1.24 :)