### PR TITLE
part: Optimize map space usage with one element

### DIFF
--- a/part/map.go
+++ b/part/map.go
@@ -19,8 +19,9 @@ import (
 // Map is a typed wrapper around Tree[T] for working with
 // keys that are not []byte.
 type Map[K, V any] struct {
-	bytesFromKey func(K) []byte
-	tree         *Tree[mapKVPair[K, V]]
+	bytesFromKeyFunc func(K) []byte
+	tree             *Tree[mapKVPair[K, V]]
+	singleton        *mapKVPair[K, V]
 }
 
 type mapKVPair[K, V any] struct {
@@ -32,14 +33,23 @@ type mapKVPair[K, V any] struct {
 // This is not implemented as a method on Map[K,V] as hash maps require the
 // comparable constraint and we do not need to limit Map[K, V] to that.
 func FromMap[K comparable, V any](m Map[K, V], hm map[K]V) Map[K, V] {
-	if len(hm) == 0 {
-		return Map[K, V]{}
+	switch len(hm) {
+	case 0:
+		return m
+	case 1:
+		for key, value := range hm {
+			return m.Set(key, value)
+		}
 	}
 
 	m.ensureTree()
 	txn := m.tree.Txn()
-	for k, v := range hm {
-		txn.Insert(m.bytesFromKey(k), mapKVPair[K, V]{k, v})
+	for key, value := range hm {
+		txn.Insert(m.keyToBytes(key), mapKVPair[K, V]{key, value})
+	}
+	if m.singleton != nil {
+		txn.Insert(m.keyToBytes(m.singleton.Key), *m.singleton)
+		m.singleton = nil
 	}
 	m.tree = txn.CommitOnly()
 	return m
@@ -52,34 +62,60 @@ func (m *Map[K, V]) ensureTree() {
 	if m.tree == nil {
 		m.tree = New[mapKVPair[K, V]](RootOnlyWatch, NoCache)
 	}
-	m.bytesFromKey = lookupKeyType[K]()
 }
 
 // Get a value from the map by its key.
 func (m Map[K, V]) Get(key K) (value V, found bool) {
+	if m.singleton != nil && bytes.Equal(m.keyToBytes(m.singleton.Key), m.keyToBytes(key)) {
+		return m.singleton.Value, true
+	}
+
 	if m.tree == nil {
 		return
 	}
-	kv, _, found := m.tree.Get(m.bytesFromKey(key))
+	kv, _, found := m.tree.Get(m.keyToBytes(key))
 	return kv.Value, found
 }
 
 // Set a value. Returns a new map with the value set.
 // Original map is unchanged.
 func (m Map[K, V]) Set(key K, value V) Map[K, V] {
+	keyBytes := m.keyToBytes(key)
+	if m.tree == nil && m.singleton == nil || m.singleton != nil && bytes.Equal(keyBytes, m.keyToBytes(m.singleton.Key)) {
+		m.singleton = &mapKVPair[K, V]{key, value}
+		return m
+	}
+
 	m.ensureTree()
 	txn := m.tree.Txn()
-	txn.Insert(m.bytesFromKey(key), mapKVPair[K, V]{key, value})
+	txn.Insert(m.keyToBytes(key), mapKVPair[K, V]{key, value})
+	if m.singleton != nil {
+		txn.Insert(m.keyToBytes(m.singleton.Key), *m.singleton)
+		m.singleton = nil
+	}
 	m.tree = txn.CommitOnly()
 	return m
+}
+
+func (m *Map[K, V]) keyToBytes(key K) []byte {
+	if m.bytesFromKeyFunc == nil {
+		m.bytesFromKeyFunc = lookupKeyType[K]()
+	}
+	return m.bytesFromKeyFunc(key)
 }
 
 // Delete a value from the map. Returns a new map
 // without the element pointed to by the key (if found).
 func (m Map[K, V]) Delete(key K) Map[K, V] {
+	if m.singleton != nil {
+		if bytes.Equal(m.keyToBytes(m.singleton.Key), m.keyToBytes(key)) {
+			m.singleton = nil
+		}
+		return m
+	}
 	if m.tree != nil {
 		txn := m.tree.Txn()
-		txn.Delete(m.bytesFromKey(key))
+		txn.Delete(m.keyToBytes(key))
 		// Map is a struct passed by value, so we can modify
 		// it without changing the caller's view of it.
 		m.tree = txn.CommitOnly()
@@ -107,19 +143,37 @@ func toSeq2[K, V any](iter *Iterator[mapKVPair[K, V]]) iter.Seq2[K, V] {
 // LowerBound iterates over all keys in order with value equal
 // to or greater than [from].
 func (m Map[K, V]) LowerBound(from K) iter.Seq2[K, V] {
+	if m.singleton != nil {
+		if bytes.Compare(m.keyToBytes(m.singleton.Key), m.keyToBytes(from)) >= 0 {
+			return m.singletonIter()
+		}
+	}
 	if m.tree == nil {
 		return toSeq2[K, V](nil)
 	}
-	return toSeq2(m.tree.LowerBound(m.bytesFromKey(from)))
+	return toSeq2(m.tree.LowerBound(m.keyToBytes(from)))
+}
+
+func (m *Map[K, V]) singletonIter() iter.Seq2[K, V] {
+	return func(yield func(K, V) bool) {
+		if m.singleton != nil {
+			yield(m.singleton.Key, m.singleton.Value)
+		}
+	}
 }
 
 // Prefix iterates in order over all keys that start with
 // the given prefix.
 func (m Map[K, V]) Prefix(prefix K) iter.Seq2[K, V] {
+	if m.singleton != nil {
+		if bytes.HasPrefix(m.keyToBytes(m.singleton.Key), m.keyToBytes(prefix)) {
+			return m.singletonIter()
+		}
+	}
 	if m.tree == nil {
 		return toSeq2[K, V](nil)
 	}
-	iter, _ := m.tree.Prefix(m.bytesFromKey(prefix))
+	iter, _ := m.tree.Prefix(m.keyToBytes(prefix))
 	return toSeq2(iter)
 }
 
@@ -127,6 +181,9 @@ func (m Map[K, V]) Prefix(prefix K) iter.Seq2[K, V] {
 // The order is in bytewise order of the byte slice
 // returned by bytesFromKey.
 func (m Map[K, V]) All() iter.Seq2[K, V] {
+	if m.singleton != nil {
+		return m.singletonIter()
+	}
 	if m.tree == nil {
 		return toSeq2[K, V](nil)
 	}
@@ -136,10 +193,12 @@ func (m Map[K, V]) All() iter.Seq2[K, V] {
 // EqualKeys returns true if both maps contain the same keys.
 func (m Map[K, V]) EqualKeys(other Map[K, V]) bool {
 	switch {
-	case m.tree == nil && other.tree == nil:
-		return true
 	case m.Len() != other.Len():
 		return false
+	case m.singleton != nil && other.singleton != nil:
+		return bytes.Equal(m.keyToBytes(m.singleton.Key), other.keyToBytes(other.singleton.Key))
+	case m.tree == nil && other.tree == nil:
+		return true
 	default:
 		iter1 := m.tree.Iterator()
 		iter2 := other.tree.Iterator()
@@ -163,10 +222,13 @@ func (m Map[K, V]) EqualKeys(other Map[K, V]) bool {
 // slow and mostly useful for testing.
 func (m Map[K, V]) SlowEqual(other Map[K, V]) bool {
 	switch {
-	case m.tree == nil && other.tree == nil:
-		return true
 	case m.Len() != other.Len():
 		return false
+	case m.singleton != nil && other.singleton != nil:
+		return bytes.Equal(m.keyToBytes(m.singleton.Key), other.keyToBytes(other.singleton.Key)) &&
+			reflect.DeepEqual(m.singleton.Value, other.singleton.Value)
+	case m.tree == nil && other.tree == nil:
+		return true
 	default:
 		iter1 := m.tree.Iterator()
 		iter2 := other.tree.Iterator()
@@ -187,6 +249,9 @@ func (m Map[K, V]) SlowEqual(other Map[K, V]) bool {
 
 // Len returns the number of elements in the map.
 func (m Map[K, V]) Len() int {
+	if m.singleton != nil {
+		return 1
+	}
 	if m.tree == nil {
 		return 0
 	}
@@ -218,6 +283,8 @@ func (m Map[K, V]) MarshalJSON() ([]byte, error) {
 }
 
 func (m *Map[K, V]) UnmarshalJSON(data []byte) error {
+	*m = Map[K, V]{}
+
 	dec := json.NewDecoder(bytes.NewReader(data))
 	t, err := dec.Token()
 	if err != nil {
@@ -234,7 +301,7 @@ func (m *Map[K, V]) UnmarshalJSON(data []byte) error {
 		if err != nil {
 			return err
 		}
-		txn.Insert(m.bytesFromKey(kv.Key), mapKVPair[K, V]{kv.Key, kv.Value})
+		txn.Insert(m.keyToBytes(kv.Key), mapKVPair[K, V]{kv.Key, kv.Value})
 	}
 
 	t, err = dec.Token()
@@ -245,21 +312,26 @@ func (m *Map[K, V]) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("%T.UnmarshalJSON: expected ']' got %v", m, t)
 	}
 	m.tree = txn.CommitOnly()
+
+	if m.tree.size == 1 {
+		_, kv, _ := m.tree.Iterator().Next()
+		m.singleton = &kv
+		m.tree = nil
+	}
 	return nil
 }
 
 func (m Map[K, V]) MarshalYAML() (any, error) {
 	kvs := make([]mapKVPair[K, V], 0, m.Len())
-	if m.tree != nil {
-		iter := m.tree.Iterator()
-		for _, kv, ok := iter.Next(); ok; _, kv, ok = iter.Next() {
-			kvs = append(kvs, kv)
-		}
+	for k, v := range m.All() {
+		kvs = append(kvs, mapKVPair[K, V]{k, v})
 	}
 	return kvs, nil
 }
 
 func (m *Map[K, V]) UnmarshalYAML(value *yaml.Node) error {
+	*m = Map[K, V]{}
+
 	if value.Kind != yaml.SequenceNode {
 		return fmt.Errorf("%T.UnmarshalYAML: expected sequence", m)
 	}
@@ -273,7 +345,7 @@ func (m *Map[K, V]) UnmarshalYAML(value *yaml.Node) error {
 		if err := e.Decode(&kv); err != nil {
 			return err
 		}
-		txn.Insert(m.bytesFromKey(kv.Key), mapKVPair[K, V]{kv.Key, kv.Value})
+		txn.Insert(m.keyToBytes(kv.Key), mapKVPair[K, V]{kv.Key, kv.Value})
 	}
 	m.tree = txn.CommitOnly()
 	return nil


### PR DESCRIPTION
In cilium/cilium we're using part.Map in the Backend object to hold the instances of the backend and most of the time it only contains one element.

Specialize for this case by adding a singleton field to part.Map.

Before (map with 1 element):
```
=== RUN   TestMapMemoryUse
map_test.go:272: 320 bytes per map
```

After:
```
=== RUN   TestMapMemoryUse
map_test.go:348: 40 bytes per map
```

pkg/loadbalancer/benchmark before:
```
Memory statistics from N=10 iterations:
Min: Allocated 716852kB in total, 2068061 objects / 125960kB still reachable (per service:  41 objs, 14681B alloc,  2579B in-use) 
Avg: Allocated 731848kB in total, 2607405 objects / 180868kB still reachable (per service:  52 objs, 14988B alloc,  3704B in-use) 
Max: Allocated 775441kB in total, 3649005 objects / 317829kB still reachable (per service:  72 objs, 15881B alloc,  6509B in-use)

Insert statistics from N=10 iterations:
Min: Reconciled 50000 objects in 832.079251ms (16.641µs  per service /  60093 services per second) 
Avg: Reconciled 50000 objects in 883.983229ms (17.679µs  per service /  56564 services per second) 
Max: Reconciled 50000 objects in 988.247623ms (19.764µs  per service /  50597 services per second)
```

After:
```
Memory statistics from N=10 iterations:
Min: Allocated 669824kB in total, 2067737 objects / 124777kB still reachable (per service:  41 objs, 13718B alloc,  2555B in-use) 
Avg: Allocated 688314kB in total, 2445133 objects / 166797kB still reachable (per service:  48 objs, 14096B alloc,  3416B in-use) 
Max: Allocated 734497kB in total, 3444117 objects / 301701kB still reachable (per service:  68 objs, 15042B alloc,  6178B in-use)

Insert statistics from N=10 iterations:
Min: Reconciled 50000 objects in 798.811656ms (15.976µs  per service /  62594 services per second) 
Avg: Reconciled 50000 objects in 831.351251ms (16.627µs  per service /  60143 services per second) 
Max: Reconciled 50000 objects in 929.973547ms (18.599µs  per service /  53766 services per second)
```