### PR TITLE
index: String() can just cast to index.Key

### DIFF
--- a/index/string.go
+++ b/index/string.go
@@ -6,10 +6,12 @@ package index
 import (
 	"fmt"
 	"iter"
+	"unsafe"
 )
 
 func String(s string) Key {
-	return []byte(s)
+	// Key is never mutated, so it's safe to just cast.
+	return unsafe.Slice(unsafe.StringData(s), len(s))
 }
 
 func FromString(s string) (Key, error) {


### PR DESCRIPTION
Since index.Key is never mutated and the Go string is immutable we can safely just cast the string into index.Key and avoid a copy.