### PR TITLE
statedb: improve handling of initializers

### DIFF
--- a/http_test.go
+++ b/http_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func httpFixture(t *testing.T) (*DB, RWTable[testObject], *httptest.Server) {
-	db, table, _ := newTestDB(t, tagsIndex)
+	db, table := newTestDB(t, withSecondaryIndexers(tagsIndex))
 
 	ts := httptest.NewServer(db.HTTPHandler())
 	t.Cleanup(ts.Close)

--- a/regression_test.go
+++ b/regression_test.go
@@ -38,7 +38,7 @@ func Test_Regression_29324(t *testing.T) {
 		Unique:  false,
 	}
 
-	db, _, _ := newTestDB(t)
+	db, _ := newTestDB(t)
 	table, err := NewTable("objects", idIndex, tagIndex)
 	require.NoError(t, err)
 	require.NoError(t, db.RegisterTable(table))
@@ -80,7 +80,7 @@ func Test_Regression_29324(t *testing.T) {
 // wait on a watch channel that reflects the changes of a full iteration
 // and we might be stuck waiting even when there's unprocessed changes.
 func Test_Regression_Changes_Watch(t *testing.T) {
-	db, table, _ := newTestDB(t)
+	db, table := newTestDB(t)
 
 	wtxn := db.WriteTxn(table)
 	changeIter, err := table.Changes(wtxn)
@@ -198,7 +198,7 @@ func Test_Regression_Prefix_NonUnique(t *testing.T) {
 		Unique:  false,
 	}
 
-	db, _, _ := newTestDB(t)
+	db, _ := newTestDB(t)
 	table, err := NewTable("objects", idIndex, tagIndex)
 	require.NoError(t, err)
 	require.NoError(t, db.RegisterTable(table))

--- a/table.go
+++ b/table.go
@@ -239,6 +239,9 @@ func (t *genTable[Obj]) RegisterInitializer(txn WriteTxn, name string) func(Writ
 		if slices.Contains(table.pendingInitializers, name) {
 			panic(fmt.Sprintf("RegisterInitializer: %q already registered", name))
 		}
+		if !slices.Contains(table.pendingInitializers, dbStartedInitializer) {
+			panic(fmt.Sprintf("RegisterInitializer: cannot register %q once the DB has started", name))
+		}
 		table.pendingInitializers =
 			append(slices.Clone(table.pendingInitializers), name)
 		var once sync.Once

--- a/table.go
+++ b/table.go
@@ -252,6 +252,8 @@ func (t *genTable[Obj]) RegisterInitializer(txn WriteTxn, name string) func(Writ
 						slices.Clone(table.pendingInitializers),
 						func(n string) bool { return n == name },
 					)
+				} else {
+					panic(fmt.Sprintf("RegisterInitializer/MarkDone: Table %q not locked for writing", t.table))
 				}
 			})
 		}

--- a/types.go
+++ b/types.go
@@ -116,7 +116,7 @@ type RWTable[Obj any] interface {
 	// RegisterInitializer registers an initializer to the table. Returns
 	// a function to mark the initializer done. Once all initializers are
 	// done, Table[*].Initialized() will return true.
-	// This should only be used before the application has started.
+	// RegisterInitializer cannot be invoked after that the DB has started.
 	RegisterInitializer(txn WriteTxn, name string) func(WriteTxn)
 
 	// ToTable returns the Table[Obj] interface. Useful with cell.Provide
@@ -423,6 +423,8 @@ const (
 	GraveyardRevisionIndexPos = 3
 
 	SecondaryIndexStartPos = 4
+
+	dbStartedInitializer = "__db_started__"
 )
 
 // object is the format in which data is stored in the tables.

--- a/watchset_test.go
+++ b/watchset_test.go
@@ -64,7 +64,7 @@ func TestWatchSet(t *testing.T) {
 
 func TestWatchSetInQueries(t *testing.T) {
 	t.Parallel()
-	db, table := newTestDBWithMetrics(t, &NopMetrics{}, tagsIndex)
+	db, table := newTestDB(t, withSecondaryIndexers(tagsIndex))
 
 	ws := NewWatchSet()
 	txn := db.ReadTxn()


### PR DESCRIPTION
Currently, [Table.Initialized] is affected by a potential pitfall, as it can return false (i.e., not initialized) and a closed watch channel if any write transaction (e.g., to populate an initial state, or register a changes iterator) completed before the first initializer is registered. In turn, this can cause consumers to misbehave, e.g., entering a busy loop, or incorrectly thinking that the table is initialized, if relying on the channel only. 

This commit addresses this issue by registering an implicit initializer that gets automatically lifted once the DB starts. In other words, any table, regardless of the presence of custom initializers, is not treated as initialized until the DB starts.

This approach ensures that initializers can be safely registered before the DB start operation, guaranteeing that they can always take effect regardless of the ordering of operations (e.g., with respect to checking for initialization, or the execution of parallel write transactions).

The registration of initializers after that the DB has started is now also explicitly forbidden (i.e., triggers a panic), given that susceptible to misuse.

Additionally, let's also panic if initializer is marked done while the target table is not included in the write transaction, to make the failure explicit, instead of silently skipping the operation and not marking the table as initialized.