### PR TITLE
statedb/table: allow multiple initialized transitions

### DIFF
--- a/table.go
+++ b/table.go
@@ -147,7 +147,12 @@ func (t *genTable[Obj]) tableEntry() tableEntry {
 	var entry tableEntry
 	entry.meta = t
 	entry.deleteTrackers = part.New[anyDeleteTracker]()
+
+	// A new table is initialized, as no initializers are registered.
+	entry.initialized = true
 	entry.initWatchChan = make(chan struct{})
+	close(entry.initWatchChan)
+
 	entry.indexes = make([]indexEntry, len(t.indexPositions))
 	entry.indexes[t.indexPositions[t.primaryIndexer.indexName()]] = indexEntry{part.New[object](), nil, nil, true}
 
@@ -223,10 +228,7 @@ func (t *genTable[Obj]) ToTable() Table[Obj] {
 
 func (t *genTable[Obj]) Initialized(txn ReadTxn) (bool, <-chan struct{}) {
 	table := txn.getTableEntry(t)
-	if len(table.pendingInitializers) == 0 {
-		return true, closedWatchChannel
-	}
-	return false, table.initWatchChan
+	return len(table.pendingInitializers) == 0, table.initWatchChan
 }
 
 func (t *genTable[Obj]) PendingInitializers(txn ReadTxn) []string {
@@ -239,6 +241,12 @@ func (t *genTable[Obj]) RegisterInitializer(txn WriteTxn, name string) func(Writ
 		if slices.Contains(table.pendingInitializers, name) {
 			panic(fmt.Sprintf("RegisterInitializer: %q already registered", name))
 		}
+
+		if len(table.pendingInitializers) == 0 {
+			table.initialized = false
+			table.initWatchChan = make(chan struct{})
+		}
+
 		table.pendingInitializers =
 			append(slices.Clone(table.pendingInitializers), name)
 		var once sync.Once

--- a/table.go
+++ b/table.go
@@ -257,6 +257,8 @@ func (t *genTable[Obj]) RegisterInitializer(txn WriteTxn, name string) func(Writ
 						slices.Clone(table.pendingInitializers),
 						func(n string) bool { return n == name },
 					)
+				} else {
+					panic(fmt.Sprintf("RegisterInitializer/MarkDone: Table %q not locked for writing", t.table))
 				}
 			})
 		}


### PR DESCRIPTION
Currently, [Table.Initialized] is affected by a potential pitfall, as it can return false (i.e., not initialized) and a closed watch channel if any write transaction (e.g., to populate an initial state, or register a changes iterator) completed before the first initializer is registered. Similarly, the same can happen if a new initializer is registered after that the previous ones have already been marked as done. In turn, this can cause consumers to misbehave, e.g., entering a busy loop, or incorrectly thinking that the table is initialized, if relying on the channel only.

Let's get this fixed by slightly reworking the internal handling of initialized, so that we correctly support multiple transitions for the same table between initialized and not initialized. The initializations status (and wait channel) returned by the [Table.Initialized] method is always consistent considering the snapshot referred to by the given [ReadTxn], and the presence of any initializer not marked done at that point.

In other words, every table starts in initialized state (as no initializers are initially present), and [Table.Initialized] returns true (i.e., initialized) and a closed channel. Once one or more initializers are registered, subsequent calls to [Table.Initialized] invoked with a [ReadTxn] referring to that snapshot return false and a wait channel, that gets closed once all initializers (also considering ones potentially added afterwards) get marked as done. If a new initializer is registered again, [Table.Initialized] would return false and a new watch channel, closed again once all initializers are marked done, and so on.

Additionally, let's also panic if initializer is marked done while the target table is not included in the write transaction, to make the failure explicit, instead of silently skipping the operation and not marking the table as initialized.