### PR TITLE
statedb: merge table creation and registration into a single API

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,14 +72,11 @@ var IDIndex = statedb.Index[*MyObject, uint32]{
 func example() {
   db := statedb.New()
   myObjects, err := statedb.NewTable(
+    db,
     "my-objects",
     IDIndex,
   )
   if err != nil { ... }
-
-  if err := db.RegisterTable(myObjects); err != nil {
-    ...
-  }
 
   wtxn := db.WriteTxn(myObjects)
   
@@ -227,8 +224,9 @@ With the indexes now defined, we can construct a table.
 ### Setting up a table
 
 ```go
-func NewMyObjectTable() (statedb.RWTable[*MyObject], error) {
+func NewMyObjectTable(db *statedb.DB) (statedb.RWTable[*MyObject], error) {
   return statedb.NewTable[*MyObject](
+    db,
     "my-objects",
 
     IDIndex,   // IDIndex is the primary index
@@ -238,9 +236,9 @@ func NewMyObjectTable() (statedb.RWTable[*MyObject], error) {
 }
 ```
 
-The `NewTable` function takes the name of the table, a primary index and zero or
-more secondary indexes. The table name must match the regular expression
-"^[a-z][a-z0-9_\\-]{0,30}$".
+The `NewTable` function takes the database, the name of the table, a primary
+index and zero or more secondary indexes. The table name must match the regular
+expression "^[a-z][a-z0-9_\\-]{0,30}$".
 
 `NewTable` returns a `RWTable`, which is an interface for both reading and
 writing to a table.  An `RWTable` is a superset of `Table`, an interface
@@ -248,6 +246,8 @@ that contains methods just for reading. This provides a simple form of
 type-level access control to the table. `NewTable` may return an error if
 the name or indexers are malformed, for example if `IDIndex` is not unique
 (primary index has to be), or if the indexers have overlapping names.
+Additionally, it may return an error if another table with the same name
+is already registered with the database.
 
 ### Inserting
 
@@ -257,15 +257,8 @@ to the table.
 ```go
 db := statedb.New()
 
-myObjects, err := NewMyObjectTable()
+myObjects, err := NewMyObjectTable(db)
 if err != nil { return err }
-
-// Register the table with the database.
-err := db.RegisterTable(myObjects)
-if err != nil { 
-  // May fail if the table with the same name is already registered.
-  return err
-}
 ```
 
 To insert objects into a table, we'll need to create a `WriteTxn`. This locks

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -523,15 +523,17 @@ func BenchmarkDB_PropagationDelay(b *testing.B) {
 
 	var (
 		db     *DB
-		table1 = MustNewTable("test", idIndex)
-		table2 = MustNewTable("test2", id2Index)
+		table1 RWTable[testObject]
+		table2 RWTable[testObject2]
 	)
 
 	h := hive.New(
 		Cell, // DB
 		cell.Invoke(func(db_ *DB) error {
 			db = db_
-			return db.RegisterTable(table1, table2)
+			table1 = MustNewTable(db, "test", idIndex)
+			table2 = MustNewTable(db, "test2", id2Index)
+			return nil
 		}),
 	)
 

--- a/db_test.go
+++ b/db_test.go
@@ -97,8 +97,9 @@ var (
 	}
 )
 
-func newTestObjectTable(t testing.TB, name string, secondaryIndexers ...Indexer[testObject]) RWTable[testObject] {
+func newTestObjectTable(t testing.TB, db *DB, name string, secondaryIndexers ...Indexer[testObject]) RWTable[testObject] {
 	table, err := NewTable(
+		db,
 		name,
 		idIndex,
 		secondaryIndexers...,
@@ -120,16 +121,15 @@ func newTestDB(t testing.TB, secondaryIndexers ...Indexer[testObject]) (*DB, RWT
 
 func newTestDBWithMetrics(t testing.TB, metrics Metrics, secondaryIndexers ...Indexer[testObject]) (*DB, RWTable[testObject]) {
 	var (
-		db *DB
+		db    *DB
+		table RWTable[testObject]
 	)
-	table := newTestObjectTable(t, "test", secondaryIndexers...)
 
 	h := hive.New(
 		cell.Provide(func() Metrics { return metrics }),
 		Cell, // DB
 		cell.Invoke(func(db_ *DB) {
-			err := db_.RegisterTable(table)
-			require.NoError(t, err, "RegisterTable failed")
+			table = newTestObjectTable(t, db_, "test", secondaryIndexers...)
 
 			// Use a short GC interval.
 			db_.setGCRateLimitInterval(50 * time.Millisecond)
@@ -159,12 +159,12 @@ func TestDB_Insert_SamePointer(t *testing.T) {
 		FromKey: index.Uint64,
 		Unique:  true,
 	}
-	table, _ := NewTable("test", idIndex)
-	require.NoError(t, db.RegisterTable(table), "RegisterTable")
+	table, err := NewTable(db, "test", idIndex)
+	require.NoError(t, err, "NewTable")
 
 	txn := db.WriteTxn(table)
 	obj := &testObject{ID: 1}
-	_, _, err := table.Insert(txn, obj)
+	_, _, err = table.Insert(txn, obj)
 	require.NoError(t, err, "Insert failed")
 	txn.Commit()
 
@@ -1173,6 +1173,8 @@ func Test_nonUniqueKey(t *testing.T) {
 }
 
 func Test_validateTableName(t *testing.T) {
+	db := New()
+
 	validNames := []string{
 		"a",
 		"abc123",
@@ -1188,12 +1190,12 @@ func Test_validateTableName(t *testing.T) {
 	}
 
 	for _, name := range validNames {
-		_, err := NewTable(name, idIndex)
+		_, err := NewTable(db, name, idIndex)
 		require.NoError(t, err, "NewTable(%s)", name)
 	}
 
 	for _, name := range invalidNames {
-		_, err := NewTable(name, idIndex)
+		_, err := NewTable(db, name, idIndex)
 		require.Error(t, err, "NewTable(%s)", name)
 	}
 }

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -25,8 +25,8 @@ func TestCollectFilterMapToSeq(t *testing.T) {
 		FromKey: index.Int,
 		Unique:  true,
 	}
-	table, _ := NewTable("test", idIndex)
-	require.NoError(t, db.RegisterTable(table))
+	table, err := NewTable(db, "test", idIndex)
+	require.NoError(t, err)
 	db.Start()
 	defer db.Stop()
 

--- a/quick_test.go
+++ b/quick_test.go
@@ -100,10 +100,9 @@ func seqLen[A, B any](it iter.Seq2[A, B]) int {
 }
 
 func TestDB_Quick(t *testing.T) {
-	table, err := NewTable("test", aIndex, bIndex)
-	require.NoError(t, err, "NewTable")
 	db := New()
-	require.NoError(t, db.RegisterTable(table), "RegisterTable")
+	table, err := NewTable(db, "test", aIndex, bIndex)
+	require.NoError(t, err, "NewTable")
 
 	anyTable := AnyTable{table}
 

--- a/reconciler/benchmark/main.go
+++ b/reconciler/benchmark/main.go
@@ -104,14 +104,10 @@ func main() {
 	}
 
 	var (
-		mt = &mockOps{}
-		db *statedb.DB
+		mt          = &mockOps{}
+		db          *statedb.DB
+		testObjects statedb.RWTable[*testObject]
 	)
-
-	testObjects, err := statedb.NewTable("test-objects", idIndex)
-	if err != nil {
-		panic(err)
-	}
 
 	hive := hive.New(
 		cell.SimpleHealthCell,
@@ -122,9 +118,10 @@ func main() {
 			"test",
 			"Test",
 
-			cell.Invoke(func(db_ *statedb.DB) error {
+			cell.Invoke(func(db_ *statedb.DB) (err error) {
 				db = db_
-				return db.RegisterTable(testObjects)
+				testObjects, err = statedb.NewTable(db, "test-objects", idIndex)
+				return err
 			}),
 			cell.Provide(
 				func() (*mockOps, reconciler.Operations[*testObject]) {
@@ -152,7 +149,7 @@ func main() {
 		),
 	)
 
-	err = hive.Start(logger, context.TODO())
+	err := hive.Start(logger, context.TODO())
 	if err != nil {
 		panic(err)
 	}

--- a/reconciler/example/types.go
+++ b/reconciler/example/types.go
@@ -66,12 +66,10 @@ var MemoStatusIndex = reconciler.NewStatusIndex((*Memo).GetStatus)
 // NewMemoTable creates and registers the memos table.
 func NewMemoTable(db *statedb.DB) (statedb.RWTable[*Memo], statedb.Index[*Memo, reconciler.StatusKind], error) {
 	tbl, err := statedb.NewTable(
+		db,
 		"memos",
 		MemoNameIndex,
 		MemoStatusIndex,
 	)
-	if err == nil {
-		err = db.RegisterTable(tbl)
-	}
 	return tbl, MemoStatusIndex, err
 }

--- a/reconciler/multi_test.go
+++ b/reconciler/multi_test.go
@@ -71,8 +71,7 @@ var _ reconciler.Operations[*multiStatusObject] = &multiMockOps{}
 // TestMultipleReconcilers tests use of multiple reconcilers against
 // a single object.
 func TestMultipleReconcilers(t *testing.T) {
-	table, err := statedb.NewTable("objects", multiStatusIndex)
-	require.NoError(t, err, "NewTable")
+	var table statedb.RWTable[*multiStatusObject]
 
 	var ops1, ops2 multiMockOps
 	var db *statedb.DB
@@ -87,9 +86,10 @@ func TestMultipleReconcilers(t *testing.T) {
 				return r.NewGroup(h, lc)
 			},
 		),
-		cell.Invoke(func(db_ *statedb.DB) error {
+		cell.Invoke(func(db_ *statedb.DB) (err error) {
 			db = db_
-			return db.RegisterTable(table)
+			table, err = statedb.NewTable(db, "objects", multiStatusIndex)
+			return err
 		}),
 
 		cell.Module("test1", "First reconciler",

--- a/reconciler/script_test.go
+++ b/reconciler/script_test.go
@@ -40,12 +40,10 @@ func newEngine(t testing.TB, args []string) *script.Engine {
 		reconcilerParams    reconciler.Params
 		reconcilerLifecycle = &cell.DefaultLifecycle{}
 		markInit            func()
+		testObjects         statedb.RWTable[*testObject]
 	)
 
 	expVarMetrics := reconciler.NewUnpublishedExpVarMetrics()
-
-	testObjects, err := statedb.NewTable("test-objects", idIndex)
-	require.NoError(t, err, "NewTable")
 
 	hive := hive.New(
 		statedb.Cell,
@@ -70,10 +68,11 @@ func newEngine(t testing.TB, args []string) *script.Engine {
 				}),
 
 			cell.Invoke(
-				func(db_ *statedb.DB, p_ reconciler.Params) error {
+				func(db_ *statedb.DB, p_ reconciler.Params) (err error) {
 					db = db_
 					reconcilerParams = p_
-					return db.RegisterTable(testObjects)
+					testObjects, err = statedb.NewTable(db, "test-objects", idIndex)
+					return err
 				},
 
 				func(lc cell.Lifecycle) {

--- a/regression_test.go
+++ b/regression_test.go
@@ -39,9 +39,8 @@ func Test_Regression_29324(t *testing.T) {
 	}
 
 	db, _, _ := newTestDB(t)
-	table, err := NewTable("objects", idIndex, tagIndex)
+	table, err := NewTable(db, "objects", idIndex, tagIndex)
 	require.NoError(t, err)
-	require.NoError(t, db.RegisterTable(table))
 
 	wtxn := db.WriteTxn(table)
 	table.Insert(wtxn, object{"foo", "aa"})
@@ -199,9 +198,8 @@ func Test_Regression_Prefix_NonUnique(t *testing.T) {
 	}
 
 	db, _, _ := newTestDB(t)
-	table, err := NewTable("objects", idIndex, tagIndex)
+	table, err := NewTable(db, "objects", idIndex, tagIndex)
 	require.NoError(t, err)
-	require.NoError(t, db.RegisterTable(table))
 
 	wtxn := db.WriteTxn(table)
 	table.Insert(wtxn, object{"aa", "a"})

--- a/script_test.go
+++ b/script_test.go
@@ -24,10 +24,8 @@ func TestScript(t *testing.T) {
 	h := hive.New(
 		Cell, // DB
 		cell.Invoke(func(db *DB) {
-			t1 := newTestObjectTable(t, "test1", tagsIndex)
-			require.NoError(t, db.RegisterTable(t1), "RegisterTable")
-			t2 := newTestObjectTable(t, "test2", tagsIndex)
-			require.NoError(t, db.RegisterTable(t2), "RegisterTable")
+			_ = newTestObjectTable(t, db, "test1", tagsIndex)
+			_ = newTestObjectTable(t, db, "test2", tagsIndex)
 		}),
 	)
 	t.Cleanup(func() {


### PR DESCRIPTION
Currently, table creation and registration with the database are two separate operations, respectively performed by [NewTable] and [RegisterTable]. However, it is not actually possible to use a table before it has been registered, and it is easy to either forget to register the table altogether, or perform that too late (e.g., when using dependency injection systems such as Hive/Cell, and registration is performed via [cell.Invoke]).

This commit unifies the two APIs into one, letting [NewTable] take a database as parameter, and internally performing the registration automatically. [RegisterTable] is then unexported, as no longer required to be explicitly called by consumers.

This new approach additionally prevents the possibility of registering the same table with two different databases, which would have led to a broken configuration anyhow.

(Leaving as draft for now, until a new version with the other fixes is tagged)