### PR TITLE
part: Shrink leaf by storing key as len+ptr

### DIFF
--- a/part/iterator.go
+++ b/part/iterator.go
@@ -48,7 +48,7 @@ func (it *Iterator[T]) Next() (key []byte, value T, ok bool) {
 			it.next = append(it.next, node.children())
 		}
 		if leaf := node.getLeaf(); leaf != nil {
-			key = leaf.key
+			key = leaf.fullKey()
 			value = leaf.value
 			ok = true
 			return


### PR DESCRIPTION
We can do the same trick in leaf as we can do in the header and store the pointer and length to the full key instead of storing the key as []byte. This will require 10 bytes (2+8) instead of the 24 bytes we'd need for the slice. According to unsafe.Sizeof leaf is now 40 bytes instead of 56 (TIL: you can just do `unsafe.Sizeof(thing{})` in your IDE and gopls will show "56 of constant unused"!)

The reconciler benchmark shows the improvement nicely (~9% less):

Before:
```
1225MB total allocated, 6011196 in-use objects, 384MB bytes in use
```

After:
```
1168MB total allocated, 6011151 in-use objects, 353MB bytes in use
```