### PR TITLE
statedb: Add TableWritable as constraint on NewTable, add NewTableAny

### DIFF
--- a/any_table.go
+++ b/any_table.go
@@ -137,13 +137,9 @@ func (t AnyTable) Changes(txn WriteTxn) (anyChangeIterator, error) {
 }
 
 func (t AnyTable) TableHeader() []string {
-	zero := t.Meta.proto()
-	if tw, ok := zero.(TableWritable); ok {
-		return tw.TableHeader()
-	}
-	return nil
+	return t.Meta.tableHeader()
 }
 
-func (t AnyTable) Proto() any {
-	return t.Meta.proto()
+func (t AnyTable) TableRow(obj any) []string {
+	return t.Meta.tableRowAny(obj)
 }

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -503,7 +503,7 @@ func BenchmarkDB_FullIteration_ReadTxnGet(b *testing.B) {
 	b.ReportMetric(float64(numObjectsIteration*b.N)/b.Elapsed().Seconds(), "objects/sec")
 }
 
-type testObject2 testObject
+type testObject2 struct{ testObject }
 
 var (
 	id2Index = Index[testObject2, uint64]{
@@ -577,7 +577,7 @@ func BenchmarkDB_PropagationDelay(b *testing.B) {
 		seq, watch1 = table1.LowerBoundWatch(txn, ByRevision[testObject](revision))
 		wtxn = db.WriteTxn(table2)
 		for obj := range seq {
-			table2.Insert(wtxn, testObject2(obj))
+			table2.Insert(wtxn, testObject2{obj})
 		}
 		wtxn.Commit()
 		revision = table1.Revision(txn)

--- a/derive_test.go
+++ b/derive_test.go
@@ -5,6 +5,7 @@ package statedb
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"slices"
 	"testing"
@@ -24,6 +25,21 @@ type derived struct {
 	ID      uint64
 	Deleted bool
 }
+
+// TableHeader implements TableWritable.
+func (d derived) TableHeader() []string {
+	return []string{"ID", "Deleted"}
+}
+
+// TableRow implements TableWritable.
+func (d derived) TableRow() []string {
+	return []string{
+		fmt.Sprintf("%d", d.ID),
+		fmt.Sprintf("%v", d.Deleted),
+	}
+}
+
+var _ TableWritable = derived{}
 
 var derivedIdIndex = Index[derived, uint64]{
 	Name: "id",

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -55,6 +55,24 @@ type fuzzObj struct {
 	value uint64
 }
 
+// TableHeader implements statedb.TableWritable.
+func (f fuzzObj) TableHeader() []string {
+	return []string{
+		"id",
+		"value",
+	}
+}
+
+// TableRow implements statedb.TableWritable.
+func (f fuzzObj) TableRow() []string {
+	return []string{
+		f.id,
+		fmt.Sprintf("%d", f.value),
+	}
+}
+
+var _ statedb.TableWritable = fuzzObj{}
+
 func mkID() string {
 	// We use a string hex presentation instead of the raw uint64 so we get
 	// a wide range of different length keys and different prefixes.

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -25,7 +25,12 @@ func TestCollectFilterMapToSeq(t *testing.T) {
 		FromKey: index.Int,
 		Unique:  true,
 	}
-	table, err := NewTable(db, "test", idIndex)
+	table, err := NewTableAny(
+		db,
+		"test",
+		func() []string { return nil },
+		func(*testObject) []string { return nil },
+		idIndex)
 	require.NoError(t, err)
 	db.Start()
 	defer db.Stop()

--- a/quick_test.go
+++ b/quick_test.go
@@ -39,9 +39,21 @@ type quickObj struct {
 	A, B string
 }
 
+// TableHeader implements TableWritable.
+func (q quickObj) TableHeader() []string {
+	return []string{"A", "B"}
+}
+
+// TableRow implements TableWritable.
+func (q quickObj) TableRow() []string {
+	return []string{q.A, q.B}
+}
+
 func (q quickObj) String() string {
 	return fmt.Sprintf("%x %x", []byte(q.A), []byte(q.B))
 }
+
+var _ TableWritable = quickObj{}
 
 var (
 	aIndex = Index[quickObj, string]{

--- a/reconciler/benchmark/main.go
+++ b/reconciler/benchmark/main.go
@@ -41,6 +41,21 @@ type testObject struct {
 	status reconciler.Status
 }
 
+// TableHeader implements statedb.TableWritable.
+func (t testObject) TableHeader() []string {
+	return []string{"id", "status"}
+}
+
+// TableRow implements statedb.TableWritable.
+func (t testObject) TableRow() []string {
+	return []string{
+		fmt.Sprintf("%d", t.id),
+		t.status.String(),
+	}
+}
+
+var _ statedb.TableWritable = testObject{}
+
 func (t *testObject) GetStatus() reconciler.Status {
 	return t.status
 }

--- a/reconciler/example/types.go
+++ b/reconciler/example/types.go
@@ -29,6 +29,18 @@ type Memo struct {
 	Status  reconciler.Status // reconciliation status
 }
 
+// TableHeader implements statedb.TableWritable.
+func (memo Memo) TableHeader() []string {
+	return []string{"Name", "Content", "Status"}
+}
+
+// TableRow implements statedb.TableWritable.
+func (memo Memo) TableRow() []string {
+	return []string{memo.Name, memo.Content, memo.Status.String()}
+}
+
+var _ statedb.TableWritable = Memo{}
+
 // GetStatus returns the reconciliation status. Used to provide the
 // reconciler access to it.
 func (memo *Memo) GetStatus() reconciler.Status {

--- a/reconciler/multi_test.go
+++ b/reconciler/multi_test.go
@@ -6,6 +6,7 @@ package reconciler_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"iter"
 	"log/slog"
 	"sync/atomic"
@@ -27,6 +28,21 @@ type multiStatusObject struct {
 	ID       uint64
 	Statuses reconciler.StatusSet
 }
+
+// TableHeader implements statedb.TableWritable.
+func (m multiStatusObject) TableHeader() []string {
+	return []string{"ID", "Statuses"}
+}
+
+// TableRow implements statedb.TableWritable.
+func (m multiStatusObject) TableRow() []string {
+	return []string{
+		fmt.Sprintf("%d", m.ID),
+		m.Statuses.String(),
+	}
+}
+
+var _ statedb.TableWritable = multiStatusObject{}
 
 func (m *multiStatusObject) Clone() *multiStatusObject {
 	m2 := *m

--- a/regression_test.go
+++ b/regression_test.go
@@ -39,7 +39,13 @@ func Test_Regression_29324(t *testing.T) {
 	}
 
 	db, _, _ := newTestDB(t)
-	table, err := NewTable(db, "objects", idIndex, tagIndex)
+	table, err := NewTableAny(
+		db,
+		"objects",
+		func() []string { return nil },
+		func(object) []string { return nil },
+		idIndex,
+		tagIndex)
 	require.NoError(t, err)
 
 	wtxn := db.WriteTxn(table)
@@ -198,7 +204,13 @@ func Test_Regression_Prefix_NonUnique(t *testing.T) {
 	}
 
 	db, _, _ := newTestDB(t)
-	table, err := NewTable(db, "objects", idIndex, tagIndex)
+	table, err := NewTableAny(
+		db,
+		"objects",
+		func() []string { return nil },
+		func(object) []string { return nil },
+		idIndex,
+		tagIndex)
 	require.NoError(t, err)
 
 	wtxn := db.WriteTxn(table)

--- a/script.go
+++ b/script.go
@@ -82,8 +82,8 @@ func DBCmd(db *DB) script.Cmd {
 			fmt.Fprintf(w, "Name\tObject count\tZombie objects\tIndexes\tInitializers\tGo type\tLast WriteTxn\n")
 			for _, tbl := range tbls {
 				idxs := strings.Join(tbl.Indexes(), ", ")
-				fmt.Fprintf(w, "%s\t%d\t%d\t%s\t%v\t%T\t%s\n",
-					tbl.Name(), tbl.NumObjects(txn), tbl.numDeletedObjects(txn), idxs, tbl.PendingInitializers(txn), tbl.proto(), tbl.getAcquiredInfo())
+				fmt.Fprintf(w, "%s\t%d\t%d\t%s\t%v\t%s\t%s\n",
+					tbl.Name(), tbl.NumObjects(txn), tbl.numDeletedObjects(txn), idxs, tbl.PendingInitializers(txn), tbl.typeName(), tbl.getAcquiredInfo())
 			}
 			w.Flush()
 			return nil, nil
@@ -746,7 +746,7 @@ func writeObjects(tbl *AnyTable, it iter.Seq2[any, Revision], w io.Writer, colum
 		fmt.Fprintf(tw, "%s\n", strings.Join(header, "\t"))
 
 		for obj := range it {
-			row := takeColumns(obj.(TableWritable).TableRow(), idxs)
+			row := takeColumns(tbl.TableRow(obj), idxs)
 			fmt.Fprintf(tw, "%s\n", strings.Join(row, "\t"))
 		}
 		return tw.Flush()

--- a/table.go
+++ b/table.go
@@ -36,12 +36,47 @@ import (
 //		// Provide the read-only statedb.Table[*MyObject].
 //		statedb.RWTable[*MyObject].ToTable,
 //	)
-func NewTable[Obj any](
+func NewTable[Obj TableWritable](
 	db *DB,
 	tableName TableName,
 	primaryIndexer Indexer[Obj],
 	secondaryIndexers ...Indexer[Obj],
 ) (RWTable[Obj], error) {
+	var obj Obj
+	return NewTableAny[Obj](
+		db,
+		tableName,
+		obj.TableHeader,
+		Obj.TableRow,
+		primaryIndexer,
+		secondaryIndexers...,
+	)
+}
+
+// MustNewTable creates a new table with given name and indexes, and registers
+// it with the database. Panics if indexes are malformed, or a table with the
+// same name is already registered.
+func MustNewTable[Obj TableWritable](
+	db *DB,
+	tableName TableName,
+	primaryIndexer Indexer[Obj],
+	secondaryIndexers ...Indexer[Obj]) RWTable[Obj] {
+	t, err := NewTable(db, tableName, primaryIndexer, secondaryIndexers...)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+// NewTableAny creates a new table for any type object with the given table
+// header and row functions.
+func NewTableAny[Obj any](
+	db *DB,
+	tableName TableName,
+	tableHeader func() []string,
+	tableRow func(Obj) []string,
+	primaryIndexer Indexer[Obj],
+	secondaryIndexers ...Indexer[Obj]) (RWTable[Obj], error) {
 	if err := validateTableName(tableName); err != nil {
 		return nil, err
 	}
@@ -65,6 +100,8 @@ func NewTable[Obj any](
 		secondaryAnyIndexers: make(map[string]anyIndexer, len(secondaryIndexers)),
 		indexPositions:       make(map[string]int),
 		pos:                  -1,
+		tableHeaderFunc:      tableHeader,
+		tableRowFunc:         tableRow,
 	}
 
 	table.indexPositions[primaryIndexer.indexName()] = PrimaryIndexPos
@@ -106,15 +143,17 @@ func NewTable[Obj any](
 	return table, db.registerTable(table)
 }
 
-// MustNewTable creates a new table with given name and indexes, and registers
+// MustNewTableAny creates a new table with given name and indexes, and registers
 // it with the database. Panics if indexes are malformed, or a table with the
 // same name is already registered.
-func MustNewTable[Obj any](
+func MustNewTableAny[Obj any](
 	db *DB,
 	tableName TableName,
+	tableHeader func() []string,
+	tableRow func(Obj) []string,
 	primaryIndexer Indexer[Obj],
 	secondaryIndexers ...Indexer[Obj]) RWTable[Obj] {
-	t, err := NewTable(db, tableName, primaryIndexer, secondaryIndexers...)
+	t, err := NewTableAny(db, tableName, tableHeader, tableRow, primaryIndexer, secondaryIndexers...)
 	if err != nil {
 		panic(err)
 	}
@@ -139,6 +178,8 @@ type genTable[Obj any] struct {
 	secondaryAnyIndexers map[string]anyIndexer
 	indexPositions       map[string]int
 	lastWriteTxn         atomic.Pointer[writeTxn]
+	tableHeaderFunc      func() []string
+	tableRowFunc         func(Obj) []string
 }
 
 func (t *genTable[Obj]) acquired(txn *writeTxn) {
@@ -538,9 +579,17 @@ func (t *genTable[Obj]) sortableMutex() internal.SortableMutex {
 	return t.smu
 }
 
-func (t *genTable[Obj]) proto() any {
+func (t *genTable[Obj]) typeName() string {
 	var zero Obj
-	return zero
+	return fmt.Sprintf("%T", zero)
+}
+
+func (t *genTable[Obj]) tableHeader() []string {
+	return t.tableHeaderFunc()
+}
+
+func (t *genTable[Obj]) tableRowAny(obj any) []string {
+	return t.tableRowFunc(obj.(Obj))
 }
 
 func (t *genTable[Obj]) unmarshalYAML(data []byte) (any, error) {

--- a/types.go
+++ b/types.go
@@ -249,11 +249,13 @@ type tableInternal interface {
 	secondary() map[string]anyIndexer      // Secondary indexers (if any)
 	sortableMutex() internal.SortableMutex // The sortable mutex for locking the table for writing
 	anyChanges(txn WriteTxn) (anyChangeIterator, error)
-	proto() any                             // Returns the zero value of 'Obj', e.g. the prototype
+	typeName() string                       // Returns the 'Obj' type as string
 	unmarshalYAML(data []byte) (any, error) // Unmarshal the data into 'Obj'
 	numDeletedObjects(txn ReadTxn) int      // Number of objects in graveyard
 	acquired(*writeTxn)
 	getAcquiredInfo() string
+	tableHeader() []string
+	tableRowAny(any) []string
 }
 
 type ReadTxn interface {
@@ -397,7 +399,7 @@ type Indexer[Obj any] interface {
 }
 
 // TableWritable is a constraint for objects that implement tabular
-// pretty-printing. Used in "cilium-dbg statedb" sub-commands.
+// pretty-printing. Used by the "db" script commands to render a table.
 type TableWritable interface {
 	// TableHeader returns the header columns that are independent of the
 	// object.


### PR DESCRIPTION
Let's start enforcing the TableWritable on the tables so we have proper "db/show" output for all tables.

To make it possible to have StateDB tables without having to introduce a wrapper type for types we don't control add a NewTableAny constructor which takes TableHeader() and TableRow() as arguments.