### PR TITLE
reconciler: Shrink Status type

### DIFF
--- a/reconciler/script_test.go
+++ b/reconciler/script_test.go
@@ -273,7 +273,7 @@ func (t *testObject) TableRow() []string {
 		strconv.FormatUint(t.ID, 10),
 		strconv.FormatBool(t.Faulty),
 		string(t.Status.Kind),
-		t.Status.Error,
+		t.Status.GetError(),
 	}
 }
 

--- a/reconciler/script_test.go
+++ b/reconciler/script_test.go
@@ -272,7 +272,7 @@ func (t *testObject) TableRow() []string {
 	return []string{
 		strconv.FormatUint(t.ID, 10),
 		strconv.FormatBool(t.Faulty),
-		string(t.Status.Kind),
+		t.Status.Kind.String(),
 		t.Status.GetError(),
 	}
 }

--- a/reconciler/status_test.go
+++ b/reconciler/status_test.go
@@ -50,7 +50,7 @@ func TestStatusJSON(t *testing.T) {
 				UpdatedAt: time.Unix(1, 0).UTC(),
 				Error:     nil,
 			},
-			`{"kind":"Done","updated-at":"1970-01-01T00:00:01Z"}`,
+			`{"updated-at":"1970-01-01T00:00:01Z","kind":"Done"}`,
 		},
 		{
 			Status{
@@ -58,7 +58,7 @@ func TestStatusJSON(t *testing.T) {
 				UpdatedAt: time.Unix(2, 0).UTC(),
 				Error:     nil,
 			},
-			`{"kind":"Pending","updated-at":"1970-01-01T00:00:02Z"}`,
+			`{"updated-at":"1970-01-01T00:00:02Z","kind":"Pending"}`,
 		},
 		{
 			Status{
@@ -66,7 +66,7 @@ func TestStatusJSON(t *testing.T) {
 				UpdatedAt: time.Unix(3, 0).UTC(),
 				Error:     errp("some-error"),
 			},
-			`{"kind":"Error","updated-at":"1970-01-01T00:00:03Z","error":"some-error"}`,
+			`{"updated-at":"1970-01-01T00:00:03Z","error":"some-error","kind":"Error"}`,
 		},
 		{
 			Status{
@@ -74,7 +74,7 @@ func TestStatusJSON(t *testing.T) {
 				UpdatedAt: time.Unix(4, 0).UTC(),
 				Error:     nil,
 			},
-			`{"kind":"Refreshing","updated-at":"1970-01-01T00:00:04Z"}`,
+			`{"updated-at":"1970-01-01T00:00:04Z","kind":"Refreshing"}`,
 		},
 	}
 

--- a/reconciler/testdata/refresh.txtar
+++ b/reconciler/testdata/refresh.txtar
@@ -44,7 +44,7 @@ faulty: false
 updates: 1
 status:
     kind: Pending
-    updatedat: 2024-01-01T10:10:10.0+02:00
+    updated-at: 2024-01-01T10:10:10.0+02:00
     error: ""
     id: 2
 
@@ -54,7 +54,7 @@ faulty: false
 updates: 1
 status:
     kind: Done
-    updatedat: 2000-01-01T10:10:10.0+02:00
+    updated-at: 2000-01-01T10:10:10.0+02:00
     error: ""
     id: 1
 

--- a/reconciler/types.go
+++ b/reconciler/types.go
@@ -7,6 +7,7 @@ import (
 	"cmp"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"iter"
 	"log/slog"
@@ -20,6 +21,7 @@ import (
 	"github.com/cilium/statedb"
 	"github.com/cilium/statedb/index"
 	"github.com/cilium/statedb/internal"
+	"go.yaml.in/yaml/v3"
 )
 
 type Reconciler[Obj any] interface {
@@ -94,14 +96,64 @@ type BatchOperations[Obj any] interface {
 	DeleteBatch(context.Context, statedb.ReadTxn, []BatchEntry[Obj])
 }
 
-type StatusKind string
+// StatusKind marks the state of status.
+//
+// This is a struct for legacy reasons. This used to string, but to save on space
+// this is now a uint8. By wrapping it into a struct we force the use-sites to
+// use StatusKind.String() and makes it impossible to do string(foo.Status.Kind).
+type StatusKind struct {
+	kind uint8
+}
 
-const (
-	StatusKindPending    StatusKind = "Pending"
-	StatusKindRefreshing StatusKind = "Refreshing"
-	StatusKindDone       StatusKind = "Done"
-	StatusKindError      StatusKind = "Error"
+var (
+	StatusKindUnset      = StatusKind{0}
+	StatusKindPending    = StatusKind{1}
+	StatusKindRefreshing = StatusKind{2}
+	StatusKindDone       = StatusKind{3}
+	StatusKindError      = StatusKind{4}
 )
+
+var stringToStatusKind = map[string]StatusKind{
+	"":           StatusKindUnset,
+	"Done":       StatusKindDone,
+	"Pending":    StatusKindPending,
+	"Refreshing": StatusKindRefreshing,
+	"Error":      StatusKindError,
+}
+
+var statusKindToString = map[StatusKind]string{
+	StatusKindUnset:      "",
+	StatusKindPending:    "Pending",
+	StatusKindRefreshing: "Refreshing",
+	StatusKindDone:       "Done",
+	StatusKindError:      "Error",
+}
+
+func (s StatusKind) String() string {
+	return statusKindToString[s]
+}
+
+func (s *StatusKind) UnmarshalJSON(b []byte) error {
+	if len(b) < 2 && b[0] != '"' && b[len(b)-1] != '"' {
+		return errors.New("expected quoted string")
+	}
+	b = b[1 : len(b)-1]
+	*s = stringToStatusKind[string(b)]
+	return nil
+}
+
+func (s StatusKind) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + s.String() + `"`), nil
+}
+
+func (s *StatusKind) UnmarshalYAML(value *yaml.Node) error {
+	*s = stringToStatusKind[value.Value]
+	return nil
+}
+
+func (s StatusKind) MarshalYAML() (any, error) {
+	return s.String(), nil
+}
 
 var (
 	pendingKey    = index.Key("P")
@@ -122,8 +174,9 @@ func (s StatusKind) Key() index.Key {
 		return doneKey
 	case StatusKindError:
 		return errorKey
+	default:
+		return index.Key("?")
 	}
-	panic("BUG: unmatched StatusKind")
 }
 
 // Status is embedded into the reconcilable object. It allows
@@ -131,16 +184,16 @@ func (s StatusKind) Key() index.Key {
 // the reconciler. Object may have multiple reconcilers and
 // multiple reconciliation statuses.
 type Status struct {
-	Kind      StatusKind `json:"kind" yaml:"kind"`
-	UpdatedAt time.Time  `json:"updated-at" yaml:"updated-at"`
-	Error     *string    `json:"error,omitempty" yaml:"error,omitempty"`
+	UpdatedAt time.Time `json:"updated-at" yaml:"updated-at"`
+	Error     *string   `json:"error,omitempty" yaml:"error,omitempty"`
 
 	// id is a unique identifier for a pending object.
 	// The reconciler uses this to compare whether the object
 	// has really changed when committing the resulting status.
 	// This allows multiple reconcilers to exist for a single
 	// object without repeating work when status is updated.
-	ID uint64 `json:"id,omitempty" yaml:"id,omitempty"`
+	ID   uint64     `json:"id,omitempty" yaml:"id,omitempty"`
+	Kind StatusKind `json:"kind" yaml:"kind"`
 }
 
 func (s Status) IsPendingOrRefreshing() bool {


### PR DESCRIPTION
1. Change `Error` from `string` to `*string` as it's rarely set (64 => 56 bytes)
2. Change `StatusKind` from `string` to `uint8` (56 => 48 bytes)

The `StatusKind` is `struct { uint8 }` to make sure code that used to do `string(foo.Status.Kind)` won't compile and is forced to change to `foo.Status.Kind.String()`. Note that we're going to release v0.5.0 with few other breaking API changes in addition to this one and tooling in cilium/cilium only bumps StateDB on patch version changes.