### PR TITLE
reconciler: Take a job.Group instead of creating one

### DIFF
--- a/reconciler/benchmark/main.go
+++ b/reconciler/benchmark/main.go
@@ -142,6 +142,7 @@ func main() {
 				func() (*mockOps, reconciler.Operations[*testObject]) {
 					return mt, mt
 				},
+				job.Registry.NewGroup,
 			),
 			cell.Invoke(func(params reconciler.Params) error {
 				_, err := reconciler.Register(

--- a/reconciler/builder.go
+++ b/reconciler/builder.go
@@ -12,7 +12,8 @@ import (
 	"golang.org/x/time/rate"
 )
 
-// Register creates a new reconciler and registers it to the application lifecycle.
+// Register creates a new reconciler and adds the reconcilation jobs to the provided
+// job group.
 //
 // The setStatus etc. functions are passed in as arguments rather than requiring
 // the object to implement them via interface as this allows constructing multiple
@@ -79,11 +80,9 @@ func Register[Obj comparable](
 		primaryIndexer:       idx,
 	}
 
-	g := params.Jobs.NewGroup(params.Health, params.Lifecycle)
-
-	g.Add(job.OneShot("reconcile", r.reconcileLoop))
+	params.JobGroup.Add(job.OneShot("reconcile", r.reconcileLoop))
 	if r.config.RefreshInterval > 0 {
-		g.Add(job.OneShot("refresh", r.refreshLoop))
+		params.JobGroup.Add(job.OneShot("refresh", r.refreshLoop))
 	}
 	return r, nil
 }

--- a/reconciler/example/main.go
+++ b/reconciler/example/main.go
@@ -121,6 +121,10 @@ var Hive = hive.NewWithOptions(
 		cell.Config(Config{}),
 
 		cell.Provide(
+			// Provide a job.Group for the reconciler's jobs. Note that in cilium/cilium
+			// this is automatically provided as part of cell.Module.
+			job.Registry.NewGroup,
+
 			// Create and register the RWTable[*Memo]
 			NewMemoTable,
 

--- a/reconciler/types.go
+++ b/reconciler/types.go
@@ -41,12 +41,10 @@ type Reconciler[Obj any] interface {
 type Params struct {
 	cell.In
 
-	Lifecycle      cell.Lifecycle
 	Log            *slog.Logger
 	DB             *statedb.DB
-	Jobs           job.Registry
+	JobGroup       job.Group
 	ModuleID       cell.FullModuleID
-	Health         cell.Health
 	DefaultMetrics Metrics `optional:"true"`
 }
 


### PR DESCRIPTION
To allow using reconciler.Register after the application has started change it to take a job.Group to which to append its jobs instead of having it create one.