### PR TITLE
Add Index[].QueryFromKey for querying with raw keys

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -838,6 +838,12 @@ func TestDB_GetList(t *testing.T) {
 	default:
 	}
 
+	// Test QueryFromKey
+	obj, rev, ok = table.Get(txn, idIndex.QueryFromKey(index.Uint64(1)))
+	require.True(t, ok, "expected Get(1) to return result")
+	require.NotZero(t, rev, "expected non-zero revision")
+	require.EqualValues(t, obj.ID, 1, "expected first obj.ID to equal 1")
+
 	// Modify the testObject(2) to trigger closing of the watch channels.
 	wtxn := db.WriteTxn(table)
 	_, hadOld, err := table.Insert(wtxn, testObject{ID: uint64(2), Tags: part.NewSet("even", "modified")})

--- a/types.go
+++ b/types.go
@@ -383,6 +383,16 @@ func (i Index[Obj, Key]) QueryFromObject(obj Obj) Query[Obj] {
 	}
 }
 
+// QueryFromKey constructs a query against the index using the given
+// user-supplied key. Be careful when using this and prefer [Index.Query]
+// over this if possible.
+func (i Index[Obj, Key]) QueryFromKey(key index.Key) Query[Obj] {
+	return Query[Obj]{
+		index: i.Name,
+		key:   key,
+	}
+}
+
 func (i Index[Obj, Key]) ObjectToKey(obj Obj) index.Key {
 	return i.encodeKey(i.FromObject(obj).First())
 }


### PR DESCRIPTION
In some cases one may want to construct the raw query key by hand instead of going via the [FromKey] method defined by the index. To allow this add Index[].QueryFromKey() that constructs a Query with the given index.Key.

Example use case: https://github.com/cilium/cilium/pull/41965/files#r2394153881