### PR TITLE
part: Improve node4 find speed by ~2%

### DIFF
--- a/part/node.go
+++ b/part/node.go
@@ -332,13 +332,16 @@ func (n *header[T]) find(key byte) *header[T] {
 		return nil
 	case nodeKind4:
 		n4 := n.node4()
-		size := n4.size()
-		for i := 0; i < int(size); i++ {
-			if n4.keys[i] == key {
-				return n4.children[i]
-			} else if n4.keys[i] > key {
-				return nil
-			}
+		keys := n4.keys
+		switch key {
+		case keys[0]:
+			return n4.children[0]
+		case keys[1]:
+			return n4.children[1]
+		case keys[2]:
+			return n4.children[2]
+		case keys[3]:
+			return n4.children[3]
 		}
 		return nil
 	case nodeKind16:


### PR DESCRIPTION
Change the loop into a switch. We don't need to check the size as all operations make sure to nil out the child.

Before:
BenchmarkDB_RandomLookup-6                         27901             42534 ns/op          23510630 objects/sec
BenchmarkDB_SequentialLookup-6                     35810             33500 ns/op          29851094 objects/sec

After:
BenchmarkDB_RandomLookup-6                         28411             41583 ns/op          24048128 objects/sec
BenchmarkDB_SequentialLookup-6                     36318             32940 ns/op          30358678 objects/sec

41583/42534 = 0.977
32940/32940 = 0.98i3