### PR TITLE
reconciler: Add WithName option

### DIFF
--- a/reconciler/builder.go
+++ b/reconciler/builder.go
@@ -91,6 +91,14 @@ func Register[Obj comparable](
 // Option for the reconciler
 type Option func(opts *options)
 
+// WithName sets the name of this reconciler instance.
+// This name is passed to the configured [Metrics] implementation.
+func WithName(name string) Option {
+	return func(opts *options) {
+		opts.Name = name
+	}
+}
+
 // WithMetrics sets the [Metrics] instance to use with this reconciler.
 // The metrics capture the duration of operations during incremental and
 // full reconcilation and the errors that occur during either.

--- a/reconciler/config.go
+++ b/reconciler/config.go
@@ -10,6 +10,7 @@ import (
 
 func defaultOptions() options {
 	return options{
+		Name:    "",
 		Metrics: nil, // use DefaultMetrics
 
 		// Refresh objects every 30 minutes at a rate of 100 per second.
@@ -31,6 +32,11 @@ func defaultOptions() options {
 }
 
 type options struct {
+	// Name identifies this reconciler instance within the hive module.
+	// This is passed to the configured metrics implementation and is useful
+	// when a single module registers multiple reconcilers.
+	Name string
+
 	// Metrics to use with this reconciler. The metrics capture the duration
 	// of operations during incremental and full reconcilation and the errors
 	// that occur during either.

--- a/reconciler/incremental.go
+++ b/reconciler/incremental.go
@@ -17,6 +17,7 @@ import (
 type incremental[Obj comparable] struct {
 	metrics        Metrics
 	moduleID       cell.FullModuleID
+	name           string
 	config         *config[Obj]
 	retries        *retries
 	primaryIndexer statedb.Indexer[Obj]
@@ -68,7 +69,7 @@ func (incr *incremental[Obj]) run(ctx context.Context, txn statedb.ReadTxn, chan
 	// queue which includes both errors occurred in this round and the old
 	// errors.
 	errs = incr.retries.errors()
-	incr.metrics.ReconciliationErrors(incr.moduleID, newErrors, len(errs))
+	incr.metrics.ReconciliationErrors(incr.moduleID, incr.name, newErrors, len(errs))
 
 	// Prepare for next round.
 	incr.numReconciled = 0
@@ -148,6 +149,7 @@ func (incr *incremental[Obj]) batch(ctx context.Context, txn statedb.ReadTxn, ch
 		ops.DeleteBatch(ctx, txn, deleteBatch)
 		incr.metrics.ReconciliationDuration(
 			incr.moduleID,
+			incr.name,
 			OpDelete,
 			time.Since(start),
 		)
@@ -165,6 +167,7 @@ func (incr *incremental[Obj]) batch(ctx context.Context, txn statedb.ReadTxn, ch
 		ops.UpdateBatch(ctx, txn, updateBatch)
 		incr.metrics.ReconciliationDuration(
 			incr.moduleID,
+			incr.name,
 			OpUpdate,
 			time.Since(start),
 		)
@@ -218,7 +221,7 @@ func (incr *incremental[Obj]) processSingle(ctx context.Context, txn statedb.Rea
 		status := incr.config.GetObjectStatus(obj)
 		incr.results[obj] = opResult{original: orig, id: status.ID, rev: rev, err: err}
 	}
-	incr.metrics.ReconciliationDuration(incr.moduleID, op, time.Since(start))
+	incr.metrics.ReconciliationDuration(incr.moduleID, incr.name, op, time.Since(start))
 
 	if err == nil {
 		incr.retries.Clear(obj)

--- a/reconciler/metrics.go
+++ b/reconciler/metrics.go
@@ -11,11 +11,11 @@ import (
 )
 
 type Metrics interface {
-	ReconciliationDuration(moduleID cell.FullModuleID, operation string, duration time.Duration)
-	ReconciliationErrors(moduleID cell.FullModuleID, new, current int)
+	ReconciliationDuration(moduleID cell.FullModuleID, name, operation string, duration time.Duration)
+	ReconciliationErrors(moduleID cell.FullModuleID, name string, new, current int)
 
-	PruneError(moduleID cell.FullModuleID, err error)
-	PruneDuration(moduleID cell.FullModuleID, duration time.Duration)
+	PruneError(moduleID cell.FullModuleID, name string, err error)
+	PruneDuration(moduleID cell.FullModuleID, name string, duration time.Duration)
 }
 
 const (
@@ -37,32 +37,41 @@ type ExpVarMetrics struct {
 	PruneCurrentErrorsVar *expvar.Map
 }
 
-func (m *ExpVarMetrics) PruneDuration(moduleID cell.FullModuleID, duration time.Duration) {
-	m.PruneDurationVar.AddFloat(moduleID.String(), duration.Seconds())
+func metricKey(moduleID cell.FullModuleID, name string) string {
+	if name == "" {
+		return moduleID.String()
+	}
+	return moduleID.String() + "/" + name
 }
 
-func (m *ExpVarMetrics) PruneError(moduleID cell.FullModuleID, err error) {
-	m.PruneCountVar.Add(moduleID.String(), 1)
+func (m *ExpVarMetrics) PruneDuration(moduleID cell.FullModuleID, name string, duration time.Duration) {
+	m.PruneDurationVar.AddFloat(metricKey(moduleID, name), duration.Seconds())
+}
+
+func (m *ExpVarMetrics) PruneError(moduleID cell.FullModuleID, name string, err error) {
+	key := metricKey(moduleID, name)
+	m.PruneCountVar.Add(key, 1)
 
 	var intVar expvar.Int
 	if err != nil {
-		m.PruneTotalErrorsVar.Add(moduleID.String(), 1)
+		m.PruneTotalErrorsVar.Add(key, 1)
 		intVar.Set(1)
 	}
-	m.PruneCurrentErrorsVar.Set(moduleID.String(), &intVar)
+	m.PruneCurrentErrorsVar.Set(key, &intVar)
 }
 
-func (m *ExpVarMetrics) ReconciliationDuration(moduleID cell.FullModuleID, operation string, duration time.Duration) {
-	m.ReconciliationDurationVar.AddFloat(moduleID.String()+"/"+operation, duration.Seconds())
+func (m *ExpVarMetrics) ReconciliationDuration(moduleID cell.FullModuleID, name, operation string, duration time.Duration) {
+	m.ReconciliationDurationVar.AddFloat(metricKey(moduleID, name)+"/"+operation, duration.Seconds())
 }
 
-func (m *ExpVarMetrics) ReconciliationErrors(moduleID cell.FullModuleID, new, current int) {
-	m.ReconciliationCountVar.Add(moduleID.String(), 1)
-	m.ReconciliationTotalErrorsVar.Add(moduleID.String(), int64(new))
+func (m *ExpVarMetrics) ReconciliationErrors(moduleID cell.FullModuleID, name string, new, current int) {
+	key := metricKey(moduleID, name)
+	m.ReconciliationCountVar.Add(key, 1)
+	m.ReconciliationTotalErrorsVar.Add(key, int64(new))
 
 	var intVar expvar.Int
 	intVar.Set(int64(current))
-	m.ReconciliationCurrentErrorsVar.Set(moduleID.String(), &intVar)
+	m.ReconciliationCurrentErrorsVar.Set(key, &intVar)
 }
 
 var _ Metrics = &ExpVarMetrics{}

--- a/reconciler/multi_test.go
+++ b/reconciler/multi_test.go
@@ -208,3 +208,103 @@ func TestMultipleReconcilers(t *testing.T) {
 
 	require.NoError(t, hive.Stop(log, context.TODO()), "Stop")
 }
+
+func TestMultipleReconcilersPerModuleMetrics(t *testing.T) {
+	var table statedb.RWTable[*multiStatusObject]
+
+	var ops1, ops2 multiMockOps
+	var db *statedb.DB
+	metrics := reconciler.NewUnpublishedExpVarMetrics()
+
+	hive := hive.New(
+		statedb.Cell,
+		job.Cell,
+		cell.Provide(
+			cell.NewSimpleHealth,
+			func() reconciler.Metrics {
+				return metrics
+			},
+			func(r job.Registry, h cell.Health) job.Group {
+				return r.NewGroup(h)
+			},
+		),
+		cell.Invoke(func(db_ *statedb.DB) (err error) {
+			db = db_
+			table, err = statedb.NewTable(db, "objects", multiStatusIndex)
+			return err
+		}),
+		cell.Module("test", "Reconcilers in one module",
+			cell.Invoke(func(params reconciler.Params) error {
+				_, err := reconciler.Register(
+					params,
+					table,
+					(*multiStatusObject).Clone,
+					func(obj *multiStatusObject, s reconciler.Status) *multiStatusObject {
+						obj.Statuses = obj.Statuses.Set("left", s)
+						return obj
+					},
+					func(obj *multiStatusObject) reconciler.Status {
+						return obj.Statuses.Get("left")
+					},
+					&ops1,
+					nil,
+					reconciler.WithName("left"),
+					reconciler.WithRetry(time.Hour, time.Hour),
+				)
+				return err
+			}),
+			cell.Invoke(func(params reconciler.Params) error {
+				_, err := reconciler.Register(
+					params,
+					table,
+					(*multiStatusObject).Clone,
+					func(obj *multiStatusObject, s reconciler.Status) *multiStatusObject {
+						obj.Statuses = obj.Statuses.Set("right", s)
+						return obj
+					},
+					func(obj *multiStatusObject) reconciler.Status {
+						return obj.Statuses.Get("right")
+					},
+					&ops2,
+					nil,
+					reconciler.WithName("right"),
+					reconciler.WithRetry(time.Hour, time.Hour),
+				)
+				return err
+			}),
+		),
+	)
+
+	log := hivetest.Logger(t, hivetest.LogLevel(slog.LevelError))
+	require.NoError(t, hive.Start(log, context.TODO()), "Start")
+
+	wtxn := db.WriteTxn(table)
+	table.Insert(wtxn, &multiStatusObject{
+		ID:       1,
+		Statuses: reconciler.NewStatusSet(),
+	})
+	wtxn.Commit()
+
+	for {
+		obj, _, watch, found := table.GetWatch(db.ReadTxn(), multiStatusIndex.Query(1))
+		if found &&
+			obj.Statuses.Get("left").Kind == reconciler.StatusKindDone &&
+			obj.Statuses.Get("right").Kind == reconciler.StatusKindDone {
+
+			break
+		}
+		<-watch
+	}
+
+	require.NotNil(t, metrics.ReconciliationCountVar.Get("test/left"))
+	require.NotNil(t, metrics.ReconciliationCountVar.Get("test/right"))
+	require.NotNil(t, metrics.ReconciliationCurrentErrorsVar.Get("test/left"))
+	require.NotNil(t, metrics.ReconciliationCurrentErrorsVar.Get("test/right"))
+	assert.NotEqual(t, "0", metrics.ReconciliationCountVar.Get("test/left").String())
+	assert.NotEqual(t, "0", metrics.ReconciliationCountVar.Get("test/right").String())
+	assert.Equal(t, "0", metrics.ReconciliationCurrentErrorsVar.Get("test/left").String())
+	assert.Equal(t, "0", metrics.ReconciliationCurrentErrorsVar.Get("test/right").String())
+	assert.Nil(t, metrics.ReconciliationCountVar.Get("test"))
+
+	require.NoError(t, hive.Stop(log, context.TODO()), "Stop")
+}

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -59,6 +59,7 @@ func (r *reconciler[Obj]) reconcileLoop(ctx context.Context, health cell.Health)
 
 	incremental := incremental[Obj]{
 		moduleID:       r.ModuleID,
+		name:           r.config.Name,
 		metrics:        r.config.Metrics,
 		config:         &r.config,
 		retries:        r.retries,
@@ -136,8 +137,8 @@ func (r *reconciler[Obj]) prune(ctx context.Context, txn statedb.ReadTxn) error 
 		r.Log.Warn("Reconciler: failed to prune objects", "error", err, "pruneInterval", r.config.PruneInterval)
 		err = fmt.Errorf("prune: %w", err)
 	}
-	r.config.Metrics.PruneDuration(r.ModuleID, time.Since(start))
-	r.config.Metrics.PruneError(r.ModuleID, err)
+	r.config.Metrics.PruneDuration(r.ModuleID, r.config.Name, time.Since(start))
+	r.config.Metrics.PruneError(r.ModuleID, r.config.Name, err)
 	return err
 }
 


### PR DESCRIPTION
The reconciler metrics only had the Hive module ID to identify the reconciler instance.

Extend the [reconciler.Metrics] to pass an additional reconciler name to the metrics and add WithName() option to set the name to allow multiple reconcilers in a module with separate metrics.