### PR TITLE
reconciler: append name to job names

### DIFF
--- a/reconciler/builder.go
+++ b/reconciler/builder.go
@@ -4,6 +4,7 @@
 package reconciler
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/cilium/hive/job"
@@ -81,9 +82,17 @@ func Register[Obj comparable](
 		progress:             newProgressTracker(),
 	}
 
-	params.JobGroup.Add(job.OneShot("reconcile", r.reconcileLoop))
+	var scoped = func(jn string) string {
+		if cfg.Name == "" {
+			return jn
+		}
+
+		return fmt.Sprintf("%s-%s", jn, cfg.Name)
+	}
+
+	params.JobGroup.Add(job.OneShot(scoped("reconcile"), r.reconcileLoop))
 	if r.config.RefreshInterval > 0 {
-		params.JobGroup.Add(job.OneShot("refresh", r.refreshLoop))
+		params.JobGroup.Add(job.OneShot(scoped("refresh"), r.refreshLoop))
 	}
 	return r, nil
 }

--- a/reconciler/multi_test.go
+++ b/reconciler/multi_test.go
@@ -214,6 +214,7 @@ func TestMultipleReconcilersPerModuleMetrics(t *testing.T) {
 
 	var ops1, ops2 multiMockOps
 	var db *statedb.DB
+	var health *cell.SimpleHealth
 	metrics := reconciler.NewUnpublishedExpVarMetrics()
 
 	hive := hive.New(
@@ -228,8 +229,8 @@ func TestMultipleReconcilersPerModuleMetrics(t *testing.T) {
 				return r.NewGroup(h)
 			},
 		),
-		cell.Invoke(func(db_ *statedb.DB) (err error) {
-			db = db_
+		cell.Invoke(func(db_ *statedb.DB, h *cell.SimpleHealth) (err error) {
+			db, health = db_, h
 			table, err = statedb.NewTable(db, "objects", multiStatusIndex)
 			return err
 		}),
@@ -305,6 +306,11 @@ func TestMultipleReconcilersPerModuleMetrics(t *testing.T) {
 	assert.Equal(t, "0", metrics.ReconciliationCurrentErrorsVar.Get("test/left").String())
 	assert.Equal(t, "0", metrics.ReconciliationCurrentErrorsVar.Get("test/right").String())
 	assert.Nil(t, metrics.ReconciliationCountVar.Get("test"))
+
+	assert.NotNil(t, health.GetChild("job-reconcile-left"))
+	assert.NotNil(t, health.GetChild("job-refresh-left"))
+	assert.NotNil(t, health.GetChild("job-reconcile-right"))
+	assert.NotNil(t, health.GetChild("job-refresh-right"))
 
 	require.NoError(t, hive.Stop(log, context.TODO()), "Stop")
 }


### PR DESCRIPTION
Respect the reconciler name configured through the [WithName] option when constructing the name of the jobs, to prevent them from conflicting (and consequently have the health scopes conflict) in case of multiple reconcilers inside the same module.