### PR TITLE
script: fix `db/cmp` update header indentation

### DIFF
--- a/script.go
+++ b/script.go
@@ -383,7 +383,7 @@ func CompareCmd(db *DB) script.Cmd {
 				joined := joinByPositions(columnNames, columnPositions, false)
 				fmt.Fprintf(w, "  %s\n", joined)
 				var actual strings.Builder
-				fmt.Fprintf(&actual, "  %s\n", joined)
+				fmt.Fprintf(&actual, "%s\n", joined)
 
 				objs, watch := tbl.AllWatch(db.ReadTxn())
 				for obj := range objs {


### PR DESCRIPTION
`db/cmp` prefixes context lines in its diff output with two spaces. When support for `-scripttest.update` was added to `db/cmp` in commit e2a88e6931c ("script: support -scripttest.update in db/cmp"), it accidentally reused that diff-prefixed header for the replacement content when writing the new golden file. This was causing updated table files to gain two leading spaces before the first header column.

Fix this by keeping the diff prefix only in the diff output and write the replacement header without indentation.

Fixes: 1e2a88e6931c ("script: support -scripttest.update in db/cmp")
Reported-by: @joamaki