### PR TITLE
script: introduce db/dump script command 

### DIFF
--- a/script.go
+++ b/script.go
@@ -38,6 +38,7 @@ func ScriptCommands(db *DB) hive.ScriptCmdsOut {
 		"db/lowerbound":  LowerBoundCmd(db),
 		"db/watch":       WatchCmd(db),
 		"db/initialized": InitializedCmd(db),
+		"db/dump":        DumpCmd(db),
 	})
 }
 
@@ -89,6 +90,46 @@ func DBCmd(db *DB) script.Cmd {
 			}
 			w.Flush()
 			return nil, nil
+		},
+	)
+}
+
+func DumpCmd(db *DB) script.Cmd {
+	return script.Command(
+		script.CmdUsage{
+			Summary: "Dump StateDB contents as JSON",
+			Flags: func(fs *pflag.FlagSet) {
+				fs.StringP("out", "o", "", "File to write to instead of stdout")
+			},
+			Detail: []string{
+				"The contents are written to stdout, but can be written to",
+				"a file instead with the -o flag.",
+			},
+		},
+		func(s *script.State, args ...string) (script.WaitFunc, error) {
+			file, err := s.Flags.GetString("out")
+			if err != nil {
+				return nil, err
+			}
+
+			return func(s *script.State) (stdout string, stderr string, err error) {
+				var (
+					buf strings.Builder
+					w   io.Writer = &buf
+				)
+
+				if file != "" {
+					f, err := os.OpenFile(s.Path(file), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+					if err != nil {
+						return "", "", fmt.Errorf("OpenFile(%s): %w", file, err)
+					}
+					defer f.Close()
+					w = f
+				}
+
+				err = db.ReadTxn().WriteJSON(w)
+				return buf.String(), "", err
+			}, nil
 		},
 	)
 }

--- a/script.go
+++ b/script.go
@@ -61,7 +61,7 @@ func DBCmd(db *DB) script.Cmd {
 				"",
 				"The individual tables can be manipulated and inspected with the",
 				"other commands. See 'help -v db/show' etc. for detailed help.",
-				"Here is some examples to get you statred:",
+				"Here is some examples to get you started:",
 				"",
 				"> db/show example",
 				"Name   X",

--- a/testdata/db.txtar
+++ b/testdata/db.txtar
@@ -172,6 +172,13 @@ db/cmp test1 objs.table
 db/lowerbound --index=id --delete test1 2
 db/cmp test1 obj1.table
 
+# Retrieve a full DB dump
+db/dump
+cmp stdout dump-expected.json
+
+db/dump -o dump-actual.json
+cmp dump-actual.json dump-expected.json
+
 # Tables
 db
 
@@ -236,3 +243,12 @@ ID   Key   Prefix        Tags
 2          10.1.2.3/32   baz, foo
 -- empty.table --
 ID   Key   Prefix   Tags
+-- dump-expected.json --
+{
+  "test1": [
+    {"ID":1,"Tags":["bar","foo"]}
+  ],
+  "test2": [
+    {"ID":2,"Tags":["baz","foo"]}
+  ]
+}


### PR DESCRIPTION
Introduce a `db/dump` script command that dumps the entire contents of StateDB as JSON. This command mimics the behavior of the already existing `/dump/` HTTP API, and is intended to be used to retrieve a snapshot of the DB (for instance during sysdump collection), without having to register the HTTP API, and implement a custom client.

I'd additionally nominate this PR for backport to the v0.5 series, which is still used by Cilium v1.19, given that it has no regression risks being only a script command, but it will help with possible troubleshooting, given that it is the first Cilium version in which the operator also includes some statedb usage.  

Related: cilium/cilium#46503