### PR TITLE
statedb: panic with an error for immutable object violations

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -197,17 +197,17 @@ func TestDB_Insert_SamePointer(t *testing.T) {
 	require.NoError(t, err, "Insert failed")
 	txn.Commit()
 
-	defer func() {
-		txn.Abort()
-		if err := recover(); err == nil {
-			t.Fatalf("Inserting the same object again didn't fatal")
-		}
-	}()
-
 	// Try to insert the same again. This will panic.
 	txn = db.WriteTxn(table)
-	_, _, err = table.Insert(txn, obj)
-	require.NoError(t, err, "Insert failed")
+	defer txn.Abort()
+	require.PanicsWithError(
+		t,
+		"Insert() of the same object (*statedb.testObject) back into the table. Is the immutable object being mutated?",
+		func() {
+			_, _, err = table.Insert(txn, obj)
+			require.NoError(t, err, "Insert failed")
+		},
+	)
 }
 
 func TestDB_InsertWatch(t *testing.T) {

--- a/write_txn.go
+++ b/write_txn.go
@@ -156,7 +156,7 @@ func (txn *writeTxnState) modify(meta TableMeta, guardRevision Revision, newData
 		if val.Kind() == reflect.Pointer {
 			oldVal := reflect.ValueOf(oldObj.data)
 			if val.UnsafePointer() == oldVal.UnsafePointer() {
-				panic(fmt.Sprintf(
+				panic(fmt.Errorf(
 					"Insert() of the same object (%T) back into the table. Is the immutable object being mutated?",
 					obj.data))
 			}


### PR DESCRIPTION
In `(*writeTxnState).modify`, panic with an error instead of a plain string so the recovered panic value implements the error interface while preserving the same diagnostic message. This makes the failure easier for recovery code to handle through the normal error path.

Also, use `require.PanicsWithError` in `TestDB_Insert_SamePointer` to assert the panic is the expected error value with the expected message. This catches unrelated panics and regressions back to string panic values.