### PR TITLE
statedb: reject duplicate tables in write transactions

### DIFF
--- a/db.go
+++ b/db.go
@@ -193,12 +193,24 @@ func (db *DB) WriteTxn(tables ...TableMeta) WriteTxn {
 	txn := db.writeTxnPool.Get().(*writeTxnState)
 	txn.db = db
 
+	// Deduplicate the set of tables to avoid acquiring the same table lock
+	// more than once, which would deadlock down the line.
+	seen := make(map[int]struct{}, len(tables))
+	tables = slices.DeleteFunc(slices.Clone(tables), func(table TableMeta) bool {
+		pos := table.tablePos()
+		if pos < 0 {
+			panic(tableError(table.Name(), ErrTableNotRegistered))
+		}
+		if _, exists := seen[pos]; exists {
+			return true
+		}
+		seen[pos] = struct{}{}
+		return false
+	})
+
 	txn.smus = reuseSlice(txn.smus, len(tables))
 	for i, table := range tables {
 		txn.smus[i] = table.sortableMutex()
-		if table.tablePos() < 0 {
-			panic(tableError(table.Name(), ErrTableNotRegistered))
-		}
 	}
 
 	lockAt := time.Now()

--- a/db_test.go
+++ b/db_test.go
@@ -175,6 +175,19 @@ func newTestDBWithMetrics(t testing.TB, metrics Metrics, secondaryIndexers ...In
 	return db, table
 }
 
+func TestDB_WriteTxn_DuplicateTables(t *testing.T) {
+	t.Parallel()
+
+	db, table := newTestDBWithMetrics(t, &NopMetrics{})
+
+	txn := db.WriteTxn(table, table)
+	_, _, err := table.Insert(txn, &testObject{ID: 1})
+	require.NoError(t, err, "Insert")
+	txn.Commit()
+
+	require.Equal(t, 1, table.NumObjects(db.ReadTxn()))
+}
+
 func TestDB_Insert_SamePointer(t *testing.T) {
 	db := New()
 	require.NoError(t, db.Start(), "Start")


### PR DESCRIPTION
Passing the same table more than once to WriteTxn will currently deadlock when the transaction tries to acquire the same table lock repeatedly.

Avoid this by detecting duplicate table arguments before locking and panic'ing in that case, making the misuse immediately visible to the user.