### PR TITLE
statedb: reject indexes with empty names

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -1386,6 +1386,47 @@ func TestDB_EmptyKeys(t *testing.T) {
 
 }
 
+func TestDB_EmptyIndexName(t *testing.T) {
+	t.Parallel()
+
+	// A prefix index whose FromObject yields no prefixes, so that
+	// QueryFromObject returns a zero-value Query{} with an empty index name.
+	emptyPrefixIndex := NetIPPrefixIndex[*testObject]{
+		Name:   "empty-prefix",
+		Unique: true,
+		FromObject: func(obj *testObject) iter.Seq[netip.Prefix] {
+			return func(yield func(netip.Prefix) bool) {}
+		},
+	}
+
+	db, table := newTestDBWithMetrics(t, &NopMetrics{}, emptyPrefixIndex)
+
+	txn := db.WriteTxn(table)
+	_, _, err := table.Insert(txn, &testObject{ID: 1})
+	require.NoError(t, err, "Insert")
+	txn.Commit()
+
+	// QueryFromObject returns an empty-index query when the object yields no
+	// keys. Querying with it must fall back to the primary index instead of
+	// panicking.
+	q := emptyPrefixIndex.QueryFromObject(&testObject{ID: 1})
+	rtxn := db.ReadTxn()
+	require.NotPanics(t, func() {
+		table.Get(rtxn, q)
+		for range table.List(rtxn, q) {
+		}
+		for range table.Prefix(rtxn, q) {
+		}
+		for range table.LowerBound(rtxn, q) {
+		}
+	})
+
+	// An explicitly empty-index query resolves to the primary index.
+	obj, _, ok := table.Get(rtxn, Query[*testObject]{key: index.Uint64(1)})
+	require.True(t, ok, "Get")
+	require.Equal(t, uint64(1), obj.ID)
+}
+
 func TestWriteJSON(t *testing.T) {
 	t.Parallel()
 

--- a/db_test.go
+++ b/db_test.go
@@ -1491,6 +1491,15 @@ func Test_validateTableName(t *testing.T) {
 	}
 }
 
+func Test_validateSecondaryIndexName(t *testing.T) {
+	db := New()
+	emptyNameIndex := tagsIndex
+	emptyNameIndex.Name = ""
+
+	_, err := NewTable(db, "test", idIndex, emptyNameIndex)
+	require.ErrorIs(t, err, ErrEmptySecondaryIndexName)
+}
+
 func Test_getAcquiredInfo(t *testing.T) {
 	t.Parallel()
 	db, table, _ := newTestDB(t)

--- a/db_test.go
+++ b/db_test.go
@@ -1491,6 +1491,37 @@ func Test_validateTableName(t *testing.T) {
 	}
 }
 
+func Test_validateIndexName(t *testing.T) {
+	t.Parallel()
+
+	db := New()
+
+	emptyNamePrimaryIndex := Index[*testObject, uint64]{
+		Name: "",
+		FromObject: func(t *testObject) index.KeySet {
+			return index.NewKeySet(index.Uint64(t.ID))
+		},
+		FromKey: index.Uint64,
+		Unique:  true,
+	}
+
+	_, err := NewTable(db, "test", idIndex, emptyNamePrimaryIndex)
+	require.ErrorIs(t, err, ErrEmptyIndexName)
+
+	emptyNameSecondaryIndex := Index[*testObject, string]{
+		Name: "",
+		FromObject: func(t *testObject) index.KeySet {
+			return index.Set(t.Tags)
+		},
+		FromKey:    index.String,
+		FromString: index.FromString,
+		Unique:     false,
+	}
+
+	_, err = NewTable(db, "test", idIndex, idIndex, emptyNameSecondaryIndex)
+	require.ErrorIs(t, err, ErrEmptyIndexName)
+}
+
 func Test_getAcquiredInfo(t *testing.T) {
 	t.Parallel()
 	db, table, _ := newTestDB(t)

--- a/errors.go
+++ b/errors.go
@@ -20,6 +20,9 @@ var (
 	// ErrPrimaryIndexNotUnique indicates that the primary index for the table is not marked unique.
 	ErrPrimaryIndexNotUnique = errors.New("primary index not unique")
 
+	// ErrEmptySecondaryIndexName indicates that a secondary index for the table has an empty name.
+	ErrEmptySecondaryIndexName = errors.New("secondary index name is empty")
+
 	// ErrDuplicateIndex indicates that the table has two or more indexers that share the same name.
 	ErrDuplicateIndex = errors.New("index name already in use")
 

--- a/errors.go
+++ b/errors.go
@@ -20,6 +20,9 @@ var (
 	// ErrPrimaryIndexNotUnique indicates that the primary index for the table is not marked unique.
 	ErrPrimaryIndexNotUnique = errors.New("primary index not unique")
 
+	// ErrEmptyIndexName indicates that a table index has an empty name.
+	ErrEmptyIndexName = errors.New("index name is empty")
+
 	// ErrDuplicateIndex indicates that the table has two or more indexers that share the same name.
 	ErrDuplicateIndex = errors.New("index name already in use")
 

--- a/table.go
+++ b/table.go
@@ -116,6 +116,9 @@ func NewTableAny[Obj any](
 	indexPos := SecondaryIndexStartPos
 	for _, indexer := range secondaryIndexers {
 		name := indexer.indexName()
+		if name == "" {
+			return nil, tableError(tableName, ErrEmptySecondaryIndexName)
+		}
 		anyIndexer := toAnyIndexer(indexer, indexPos)
 		table.secondaryAnyIndexers = append(table.secondaryAnyIndexers, anyIndexer)
 		table.indexPositions[indexPos] = name

--- a/table.go
+++ b/table.go
@@ -202,6 +202,11 @@ func (t *genTable[Obj]) released() {
 }
 
 func (t *genTable[Obj]) indexPos(name string) int {
+	// An empty index name refers to the primary index, matching getIndexer.
+	if name == "" {
+		return PrimaryIndexPos
+	}
+
 	// By default don't consider the internal indexes.
 	start := PrimaryIndexPos
 

--- a/table.go
+++ b/table.go
@@ -80,6 +80,11 @@ func NewTableAny[Obj any](
 		return nil, err
 	}
 
+	// Primary index must always be unique
+	if !primaryIndexer.isUnique() {
+		return nil, tableError(tableName, ErrPrimaryIndexNotUnique)
+	}
+
 	toAnyIndexer := func(idx Indexer[Obj], pos int) anyIndexer {
 		return anyIndexer{
 			name:          idx.indexName(),
@@ -115,11 +120,6 @@ func NewTableAny[Obj any](
 		table.secondaryAnyIndexers = append(table.secondaryAnyIndexers, anyIndexer)
 		table.indexPositions[indexPos] = name
 		indexPos++
-	}
-
-	// Primary index must always be unique
-	if !primaryIndexer.isUnique() {
-		return nil, tableError(tableName, ErrPrimaryIndexNotUnique)
 	}
 
 	// Validate that indexes have unique ids.

--- a/table.go
+++ b/table.go
@@ -80,6 +80,16 @@ func NewTableAny[Obj any](
 		return nil, err
 	}
 
+	// Index name must be non-empty
+	if primaryIndexer.indexName() == "" {
+		return nil, tableError(tableName, ErrEmptyIndexName)
+	}
+
+	// Primary index must always be unique
+	if !primaryIndexer.isUnique() {
+		return nil, tableError(tableName, ErrPrimaryIndexNotUnique)
+	}
+
 	toAnyIndexer := func(idx Indexer[Obj], pos int) anyIndexer {
 		return anyIndexer{
 			name:          idx.indexName(),
@@ -111,15 +121,14 @@ func NewTableAny[Obj any](
 	indexPos := SecondaryIndexStartPos
 	for _, indexer := range secondaryIndexers {
 		name := indexer.indexName()
+		// Index name must be non-empty
+		if name == "" {
+			return nil, tableError(tableName, ErrEmptyIndexName)
+		}
 		anyIndexer := toAnyIndexer(indexer, indexPos)
 		table.secondaryAnyIndexers = append(table.secondaryAnyIndexers, anyIndexer)
 		table.indexPositions[indexPos] = name
 		indexPos++
-	}
-
-	// Primary index must always be unique
-	if !primaryIndexer.isUnique() {
-		return nil, tableError(tableName, ErrPrimaryIndexNotUnique)
 	}
 
 	// Validate that indexes have unique ids.


### PR DESCRIPTION
Querying a table with an empty index name currently falls back to the primary index. Change the semantics so that `NewTableAny` validates that the index name is non-empty.
