### PR TITLE
statedb: fix RemoteTable HTTP error handling

### DIFF
--- a/http_client.go
+++ b/http_client.go
@@ -49,6 +49,7 @@ func (t *RemoteTable[Obj]) query(ctx context.Context, lowerBound bool, q Query[O
 	// Use a channel to return errors so we can use the same Iterator[Obj] interface as StateDB does.
 	errChanSend := make(chan error, 1)
 	errChan = errChanSend
+	seq = emptySeq2[Obj, Revision]()
 
 	key := base64.StdEncoding.EncodeToString(q.key)
 	queryReq := QueryRequest{
@@ -60,6 +61,7 @@ func (t *RemoteTable[Obj]) query(ctx context.Context, lowerBound bool, q Query[O
 	bs, err := json.Marshal(&queryReq)
 	if err != nil {
 		errChanSend <- err
+		close(errChanSend)
 		return
 	}
 
@@ -67,6 +69,7 @@ func (t *RemoteTable[Obj]) query(ctx context.Context, lowerBound bool, q Query[O
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), bytes.NewBuffer(bs))
 	if err != nil {
 		errChanSend <- err
+		close(errChanSend)
 		return
 	}
 	req.Header.Add("Content-Type", "application/json")
@@ -75,9 +78,15 @@ func (t *RemoteTable[Obj]) query(ctx context.Context, lowerBound bool, q Query[O
 	resp, err := t.client.Do(req)
 	if err != nil {
 		errChanSend <- err
+		close(errChanSend)
 		return
 	}
-	return remoteGetSeq[Obj](json.NewDecoder(resp.Body), errChanSend), errChan
+	if resp.StatusCode != http.StatusOK {
+		errChanSend <- decodeHTTPError(resp)
+		close(errChanSend)
+		return
+	}
+	return remoteGetSeq[Obj](resp.Body, json.NewDecoder(resp.Body), errChanSend), errChan
 }
 
 func (t *RemoteTable[Obj]) Get(ctx context.Context, q Query[Obj]) (iter.Seq2[Obj, Revision], <-chan error) {
@@ -92,30 +101,23 @@ func (t *RemoteTable[Obj]) LowerBound(ctx context.Context, q Query[Obj]) (iter.S
 type responseObject[Obj any] struct {
 	Rev uint64 `json:"rev"`
 	Obj Obj    `json:"obj"`
-	Err string `json:"err,omitempty"`
 }
 
-func remoteGetSeq[Obj any](dec *json.Decoder, errChan chan error) iter.Seq2[Obj, Revision] {
+func remoteGetSeq[Obj any](body io.ReadCloser, dec *json.Decoder, errChan chan error) iter.Seq2[Obj, Revision] {
 	return func(yield func(Obj, Revision) bool) {
+		defer body.Close()
+		defer close(errChan)
 		for {
 			var resp responseObject[Obj]
-			err := dec.Decode(&resp)
-			errString := ""
-			if err != nil {
+			if err := dec.Decode(&resp); err != nil {
 				if errors.Is(err, io.EOF) {
-					close(errChan)
-					break
+					return
 				}
-				errString = "Decode error: " + err.Error()
-			} else {
-				errString = resp.Err
-			}
-			if errString != "" {
-				errChan <- errors.New(errString)
-				break
+				errChan <- fmt.Errorf("decode error: %w", err)
+				return
 			}
 			if !yield(resp.Obj, resp.Rev) {
-				break
+				return
 			}
 		}
 	}
@@ -125,6 +127,7 @@ func (t *RemoteTable[Obj]) Changes(ctx context.Context) (seq iter.Seq2[Change[Ob
 	// Use a channel to return errors so we can use the same Iterator[Obj] interface as StateDB does.
 	errChanSend := make(chan error, 1)
 	errChan = errChanSend
+	seq = emptySeq2[Change[Obj], Revision]()
 
 	url := t.base.JoinPath("/changes", t.tableName)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
@@ -143,11 +146,17 @@ func (t *RemoteTable[Obj]) Changes(ctx context.Context) (seq iter.Seq2[Change[Ob
 		close(errChanSend)
 		return
 	}
-	return remoteChangeSeq[Obj](json.NewDecoder(resp.Body), errChanSend), errChan
+	if resp.StatusCode != http.StatusOK {
+		errChanSend <- decodeHTTPError(resp)
+		close(errChanSend)
+		return
+	}
+	return remoteChangeSeq[Obj](resp.Body, json.NewDecoder(resp.Body), errChanSend), errChan
 }
 
-func remoteChangeSeq[Obj any](dec *json.Decoder, errChan chan error) iter.Seq2[Change[Obj], Revision] {
+func remoteChangeSeq[Obj any](body io.ReadCloser, dec *json.Decoder, errChan chan error) iter.Seq2[Change[Obj], Revision] {
 	return func(yield func(Change[Obj], Revision) bool) {
+		defer body.Close()
 		defer close(errChan)
 		for {
 			var change Change[Obj]
@@ -169,4 +178,19 @@ func remoteChangeSeq[Obj any](dec *json.Decoder, errChan chan error) iter.Seq2[C
 			}
 		}
 	}
+}
+
+func emptySeq2[A, B any]() iter.Seq2[A, B] {
+	return func(func(A, B) bool) {}
+}
+
+func decodeHTTPError(resp *http.Response) error {
+	defer resp.Body.Close()
+
+	var queryErr QueryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&queryErr); err == nil && queryErr.Err != "" {
+		return fmt.Errorf("HTTP %s: %s", resp.Status, queryErr.Err)
+	}
+
+	return fmt.Errorf("HTTP %s", resp.Status)
 }

--- a/http_test.go
+++ b/http_test.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -194,4 +196,77 @@ func Test_http_RemoteTable_Changes(t *testing.T) {
 
 	err = <-errs
 	require.ErrorIs(t, err, context.Canceled)
+}
+
+func Test_http_RemoteTable_Changes_missing_table_returns_error(t *testing.T) {
+	_, _, ts := httpFixture(t)
+
+	base, err := url.Parse(ts.URL)
+	require.NoError(t, err, "ParseURL")
+
+	remoteTable := NewRemoteTable[*testObject](base, "missing")
+
+	changes, errs := remoteTable.Changes(t.Context())
+	var got []Change[*testObject]
+	for change := range changes {
+		got = append(got, change)
+	}
+
+	require.Empty(t, got)
+	err = <-errs
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `Table "missing" not found`)
+}
+
+func Test_http_RemoteTable_Get_closes_body_when_stopped_early(t *testing.T) {
+	base, err := url.Parse("http://example.com")
+	require.NoError(t, err, "ParseURL")
+
+	remoteTable := NewRemoteTable[*testObject](base, "test")
+	body := &trackingReadCloser{
+		ReadCloser: io.NopCloser(strings.NewReader(
+			`{"rev":1,"obj":{"ID":1}}` + "\n" +
+				`{"rev":2,"obj":{"ID":2}}` + "\n",
+		)),
+	}
+	remoteTable.client.Transport = roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body:       body,
+			Header:     make(http.Header),
+		}, nil
+	})
+
+	seq, errs := remoteTable.Get(t.Context(), idIndex.Query(1))
+	seq(func(obj *testObject, rev Revision) bool {
+		require.EqualValues(t, 1, obj.ID)
+		require.EqualValues(t, 1, rev)
+		return false
+	})
+
+	require.True(t, body.closed.Load(), "response body should be closed when iteration stops early")
+	select {
+	case err, ok := <-errs:
+		require.False(t, ok)
+		require.Nil(t, err)
+	default:
+		t.Fatal("error channel should be closed when iteration stops early")
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+type trackingReadCloser struct {
+	io.ReadCloser
+	closed atomic.Bool
+}
+
+func (trc *trackingReadCloser) Close() error {
+	trc.closed.Store(true)
+	return trc.ReadCloser.Close()
 }


### PR DESCRIPTION
`RemoteTable` had 2 small footguns.

What broke
- `Changes()` on a missing table could return an empty stream and no error. The 404 JSON body got treated like a keepalive, kinda sneaky.
- `Get()` and `LowerBound()` could leave `resp.Body` open if the caller stops after the first item.

What changed
- check non-200 responses before streaming and return the server error
- close response bodies when iteration ends, even if iteration stops early

How to repro
1. Run `Test_http_RemoteTable_Changes_missing_table_returns_error`.
2. Before this patch, `NewRemoteTable[*testObject](base, "missing").Changes(ctx)` yields an empty stream and `nil` error.
3. After this patch, it returns `HTTP 404 Not Found: Table "missing" not found`.

1. Run `Test_http_RemoteTable_Get_closes_body_when_stopped_early`.
2. Before this patch, stopping after the first `Get()` result leaves the response body open.
3. After this patch, the body is closed right away.

Checked with `go test ./...`.
