### PR TITLE
[v0.5] statedb: extend Derive to propagate initialization signal

### DIFF
--- a/derive.go
+++ b/derive.go
@@ -52,10 +52,14 @@ type DeriveParams[In, Out any] struct {
 //	)
 func Derive[In, Out any](jobName string, transform func(obj In, deleted bool) (Out, DeriveResult)) func(DeriveParams[In, Out]) {
 	return func(p DeriveParams[In, Out]) {
+		wtxn := p.DB.WriteTxn(p.OutTable)
+		markInit := p.OutTable.RegisterInitializer(wtxn, jobName)
+		wtxn.Commit()
+
 		g := p.Jobs.NewGroup(p.Health, p.Lifecycle)
 		g.Add(job.OneShot(
 			jobName,
-			derive[In, Out]{p, jobName, transform}.loop),
+			derive[In, Out]{p, jobName, transform, markInit}.loop),
 		)
 	}
 }
@@ -64,6 +68,7 @@ type derive[In, Out any] struct {
 	DeriveParams[In, Out]
 	jobName   string
 	transform func(obj In, deleted bool) (Out, DeriveResult)
+	markInit  func(WriteTxn)
 }
 
 func (d derive[In, Out]) loop(ctx context.Context, _ cell.Health) error {
@@ -75,6 +80,8 @@ func (d derive[In, Out]) loop(ctx context.Context, _ cell.Health) error {
 		return err
 	}
 	for {
+		var init <-chan struct{}
+
 		wtxn := d.DB.WriteTxn(out)
 		changes, watch := iter.Next(wtxn)
 		for change := range changes {
@@ -96,10 +103,21 @@ func (d derive[In, Out]) loop(ctx context.Context, _ cell.Health) error {
 				return err
 			}
 		}
+
+		if d.markInit != nil {
+			if ok, ch := d.InTable.Initialized(wtxn); ok {
+				d.markInit(wtxn)
+				d.markInit = nil
+			} else {
+				init = ch
+			}
+		}
+
 		wtxn.Commit()
 
 		select {
 		case <-watch:
+		case <-init:
 		case <-ctx.Done():
 			return nil
 		}

--- a/derive_test.go
+++ b/derive_test.go
@@ -86,6 +86,7 @@ func TestDerive(t *testing.T) {
 		db       *DB
 		inTable  RWTable[testObject]
 		outTable RWTable[derived]
+		markInit func(WriteTxn)
 	)
 
 	transform := func(obj testObject, deleted bool) (derived, DeriveResult) {
@@ -115,6 +116,11 @@ func TestDerive(t *testing.T) {
 				db = db_
 				inTable = MustNewTable(db, "test", idIndex)
 				outTable = MustNewTable(db, "derived", derivedIdIndex)
+
+				wtx := db.WriteTxn(inTable)
+				markInit = inTable.RegisterInitializer(wtx, "init")
+				wtx.Commit()
+
 				return inTable, outTable, nil
 			}),
 
@@ -152,6 +158,22 @@ func TestDerive(t *testing.T) {
 		10*time.Millisecond,
 		"expected 1 & 2 to be derived",
 	)
+
+	// The In table is not yet initialized; the Out one should likewise not.
+	init, _ := outTable.Initialized(db.ReadTxn())
+	require.False(t, init, "Out table should not be initialized before In one is")
+
+	// Initialize the In table, and assert that the Out one is also marked as initialized.
+	wtxn = db.WriteTxn(inTable)
+	markInit(wtxn)
+	wtxn.Commit()
+
+	_, initch := outTable.Initialized(db.ReadTxn())
+	select {
+	case <-initch:
+	case <-time.After(1 * time.Second):
+		require.FailNow(t, "Out table should be initialized once the In one is")
+	}
 
 	// Delete 2 (testing DeriveUpdate)
 	wtxn = db.WriteTxn(inTable)


### PR DESCRIPTION
Backport of https://github.com/cilium/statedb/pull/171