### PR TITLE
fix: abort failed script mutations

### DIFF
--- a/script.go
+++ b/script.go
@@ -578,7 +578,7 @@ func insertOrDelete(insert bool, db *DB, s *script.State, args ...string) (scrip
 	}
 
 	wtxn := db.WriteTxn(tbl.Meta)
-	defer wtxn.Commit()
+	defer wtxn.Abort()
 
 	for _, arg := range args[1:] {
 		data, err := os.ReadFile(s.Path(arg))
@@ -605,6 +605,7 @@ func insertOrDelete(insert bool, db *DB, s *script.State, args ...string) (scrip
 			}
 		}
 	}
+	wtxn.Commit()
 	return nil, nil
 }
 

--- a/testdata/db.txtar
+++ b/testdata/db.txtar
@@ -20,10 +20,18 @@ db/show test2
 # Assert empty
 db/empty test1 test2
 
+# Failed insert does not commit preceding files
+! db/insert test1 obj1.yaml missing.yaml
+db/empty test1
+
 # Insert
 db/insert test1 obj1.yaml
 db/insert test1 obj2.yaml
 db/insert test2 obj2.yaml
+
+# Failed delete does not commit preceding files
+! db/delete test1 obj1.yaml missing.yaml
+db/cmp --timeout=10ms test1 objs.table
 
 # Assert not empty
 ! db/empty test1 test2


### PR DESCRIPTION
`db/insert` and `db/delete` commit earlier files when a later path fails. 
The command returns an error, but the table is already partially changed

Repro:

```text
hive start
db/empty test1
! db/insert test1 obj1.yaml missing.yaml
db/empty test1
```

The last command fails because `obj1.yaml` was committed.

This aborts on errors and commits only after every input succeeds.
Tests cover insert and delete, thats it