### PR TITLE
fix: close HTTP change iterator on disconnect

### DIFF
--- a/http.go
+++ b/http.go
@@ -170,6 +170,7 @@ func (h dbHandler) changes(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	defer changeIter.Close()
 
 	w.WriteHeader(http.StatusOK)
 

--- a/http_test.go
+++ b/http_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -284,6 +285,10 @@ func Test_http_RemoteTable_Changes(t *testing.T) {
 
 	err = <-errs
 	require.ErrorIs(t, err, context.Canceled)
+
+	require.Eventually(t, func() bool {
+		return db.ReadTxn().root()[table.tablePos()].deleteTrackers.Len() == 0
+	}, time.Second, 10*time.Millisecond, "HTTP change iterator should be closed after disconnect")
 }
 
 func Test_http_RemoteTable_Changes_missing_table_returns_error(t *testing.T) {

--- a/iterator.go
+++ b/iterator.go
@@ -261,4 +261,5 @@ func (it *changeIterator[Obj]) Close() {
 
 type anyChangeIterator interface {
 	nextAny(ReadTxn) (iter.Seq2[Change[any], Revision], <-chan struct{})
+	Close()
 }


### PR DESCRIPTION
A disconnected `/changes/{table}` client leaves its deletion tracker registered until a later runtime cleanup. 
Deleted objects can stay in the graveyard after the stream is gone

The handler now closes its iterator on exit. 
The existing end to end test checks the tracker goes away, no API changes

Repro:
1. Apply only the test hunk
2. Run `go test ./ -run Test_http_RemoteTable_Changes -count=1`
3. It times out waiting for zero trackers. Apply the fix and it passes

Tested with `make test` and `make test-race`