### PR TITLE
WatchSet.Wait now waits even with single channel

### DIFF
--- a/watchset.go
+++ b/watchset.go
@@ -75,8 +75,9 @@ func (ws *WatchSet) Merge(other *WatchSet) {
 }
 
 // Wait for channels in the watch set to close or the context is cancelled.
-// After the first closed channel is seen Wait will wait [settleTime] for
-// more closed channels.
+// If [settleTime] is >0 the method waits for an additional [settleTime]
+// duration to collect further closed channels. The wait is performed
+// even when all channels in the set are closed.
 // If [settleTime] is 0 waits until [ctx] cancelled or any channel closes.
 // Returns the closed channels and removes them from the set.
 func (ws *WatchSet) Wait(ctx context.Context, settleTime time.Duration) ([]<-chan struct{}, error) {
@@ -118,7 +119,7 @@ func (ws *WatchSet) Wait(ctx context.Context, settleTime time.Duration) ([]<-cha
 		}
 	}()
 
-	// Wait for the first channel to close and shift it out from [cases]
+	// Wait for any channel to close and shift it out from [cases]
 	chosen, _, _ := reflect.Select(cases)
 	if chosen == 0 {
 		return nil, ctx.Err()
@@ -127,9 +128,8 @@ func (ws *WatchSet) Wait(ctx context.Context, settleTime time.Duration) ([]<-cha
 	cases[chosen] = cases[len(cases)-1]
 	cases = cases[:len(cases)-1]
 
-	// If nothing else than context channel remains or we don't want to wait for further channels
-	// to close then we're done.
-	if len(cases) == 1 || settleTime == 0 {
+	// Stop here if no additional wait requested
+	if settleTime == 0 {
 		return closedChannels, nil
 	}
 
@@ -138,7 +138,7 @@ func (ws *WatchSet) Wait(ctx context.Context, settleTime time.Duration) ([]<-cha
 	defer cancel()
 	cases[0].Chan = reflect.ValueOf(settleCtx.Done())
 
-	for len(cases) > 1 {
+	for len(cases) >= 1 {
 		chosen, _, _ := reflect.Select(cases)
 		if chosen == 0 /* settleCtx.Done() */ {
 			break

--- a/watchset_test.go
+++ b/watchset_test.go
@@ -26,8 +26,19 @@ func TestWatchSet(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 	require.Empty(t, chs)
 
-	// Few channels, cancelled context.
+	// One closed channel with non-zero settle time
 	ch1 := make(chan struct{})
+	close(ch1)
+	ws.Add(ch1)
+	t0 := time.Now()
+	duration := 50 * time.Millisecond
+	chs, err = ws.Wait(context.Background(), duration)
+	require.NoError(t, err)
+	require.ElementsMatch(t, chs, []<-chan struct{}{ch1})
+	require.Greater(t, time.Since(t0), duration, "expected to wait to settle")
+
+	// Few channels, cancelled context.
+	ch1 = make(chan struct{})
 	ch2 := make(chan struct{})
 	ch3 := make(chan struct{})
 	ws.Add(ch1, ch2, ch3)
@@ -38,8 +49,8 @@ func TestWatchSet(t *testing.T) {
 	require.Empty(t, chs)
 
 	// Few channels, timed out context.
-	duration := 10 * time.Millisecond
-	t0 := time.Now()
+	duration = 10 * time.Millisecond
+	t0 = time.Now()
 	ctx, cancel = context.WithTimeout(context.Background(), duration)
 
 	// Wait with a settle time of 1ns. Since settle time only comes to play
@@ -150,6 +161,38 @@ func TestWatchSetInQueries(t *testing.T) {
 
 	ws2.Clear()
 	require.False(t, ws2.Has(closed[0]))
+}
+
+func TestWatchSetCancellationDuringSettle(t *testing.T) {
+	ws := NewWatchSet()
+
+	// Add a closed watch channel
+	ch1 := make(chan struct{})
+	close(ch1)
+	ws.Add(ch1)
+
+	// Use a context that times out in less time than settle time.
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	// Wait should now go into settle time wait. The context would cancel
+	// before the settle time expires.
+	closed, err := ws.Wait(ctx, time.Second)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.ElementsMatch(t, []<-chan struct{}{ch1}, closed)
+	require.False(t, ws.Has(ch1), "closed channel should be removed")
+
+	// Test again with more than one channel
+	ch2 := make(chan struct{})
+	ws.Add(ch1, ch2)
+	ctx, cancel = context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	closed, err = ws.Wait(ctx, time.Second)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.ElementsMatch(t, []<-chan struct{}{ch1}, closed)
+	require.False(t, ws.Has(ch1), "closed channel should be removed")
+	require.True(t, ws.Has(ch2), "open channel should not be removed")
 }
 
 func benchmarkWatchSet(b *testing.B, numChans int) {


### PR DESCRIPTION
The original semantics of returning immediately when the channel in a single channel set closes is at odds with how this is being used.

We want the settle time to be a form of rate-limiting to avoid computing too often and this should also apply to the single channel case.

Change the WatchSet.Wait to also wait with a single channel set.

Reported-by: Marco Iorio <marco.iorio@isovalent.com>