### PR TITLE
fix: stop Set.All iteration when requested

### DIFF
--- a/part/set.go
+++ b/part/set.go
@@ -96,7 +96,9 @@ func (s Set[T]) All() iter.Seq[T] {
 
 func (s Set[T]) yieldAll(yield func(v T) bool) {
 	for _, v := range s.tree.Iterator().All {
-		yield(v)
+		if !yield(v) {
+			return
+		}
 	}
 }
 

--- a/part/set_test.go
+++ b/part/set_test.go
@@ -60,6 +60,17 @@ func TestStringSet(t *testing.T) {
 	assert.Equal(t, 1, s5.Len())
 }
 
+func TestSetAllStopsEarly(t *testing.T) {
+	t.Parallel()
+
+	count := 0
+	for range part.NewSet("first", "second").All() {
+		count++
+		break
+	}
+	require.Equal(t, 1, count)
+}
+
 func TestSetJSON(t *testing.T) {
 	t.Parallel()
 	s := part.NewSet("foo", "bar", "baz")


### PR DESCRIPTION
`Set.All()` keeps yielding after a caller stops early. 
With 2 values, a normal `break` panics with `range function continued iteration after function for loop body returned false`

Repro:

```go
for range part.NewSet("first", "second").All() {
	break
}
```

Before this panics. 
After this fix exits cleanly

The iterator now returns when `yield` is false, with a regression test

Tested with `make test`, `make test-race`, `make build` and `make bench`
