### PR TITLE
part: add bitmap Node64 and Node128

### DIFF
--- a/part/node.go
+++ b/part/node.go
@@ -6,6 +6,7 @@ package part
 import (
 	"bytes"
 	"fmt"
+	"math/bits"
 	"strings"
 	"unsafe"
 )
@@ -17,7 +18,8 @@ const (
 	nodeKindLeaf
 	nodeKind4
 	nodeKind16
-	nodeKind48
+	nodeKind64
+	nodeKind128
 	nodeKind256
 )
 
@@ -70,8 +72,10 @@ func (n *header[T]) cap() int {
 		return 4
 	case nodeKind16:
 		return 16
-	case nodeKind48:
-		return 48
+	case nodeKind64:
+		return 64
+	case nodeKind128:
+		return 128
 	case nodeKind256:
 		return 256
 	default:
@@ -91,8 +95,10 @@ func (n *header[T]) getLeaf() *leaf[T] {
 		return n.node4().leaf
 	case nodeKind16:
 		return n.node16().leaf
-	case nodeKind48:
-		return n.node48().leaf
+	case nodeKind64:
+		return n.node64().leaf
+	case nodeKind128:
+		return n.node128().leaf
 	case nodeKind256:
 		return n.node256().leaf
 	default:
@@ -108,8 +114,10 @@ func (n *header[T]) setLeaf(l *leaf[T]) {
 		n.node4().leaf = l
 	case nodeKind16:
 		n.node16().leaf = l
-	case nodeKind48:
-		n.node48().leaf = l
+	case nodeKind64:
+		n.node64().leaf = l
+	case nodeKind128:
+		n.node128().leaf = l
 	case nodeKind256:
 		n.node256().leaf = l
 	default:
@@ -137,8 +145,12 @@ func (n *header[T]) node16() *node16[T] {
 	return (*node16[T])(unsafe.Pointer(n))
 }
 
-func (n *header[T]) node48() *node48[T] {
-	return (*node48[T])(unsafe.Pointer(n))
+func (n *header[T]) node64() *node64[T] {
+	return (*node64[T])(unsafe.Pointer(n))
+}
+
+func (n *header[T]) node128() *node128[T] {
+	return (*node128[T])(unsafe.Pointer(n))
 }
 
 func (n *header[T]) node256() *node256[T] {
@@ -153,8 +165,10 @@ func (n *header[T]) txnID() uint64 {
 		return n.node4().txnID
 	case nodeKind16:
 		return n.node16().txnID
-	case nodeKind48:
-		return n.node48().txnID
+	case nodeKind64:
+		return n.node64().txnID
+	case nodeKind128:
+		return n.node128().txnID
 	case nodeKind256:
 		return n.node256().txnID
 	default:
@@ -170,8 +184,10 @@ func (n *header[T]) setTxnID(txnID uint64) {
 		n.node4().txnID = txnID
 	case nodeKind16:
 		n.node16().txnID = txnID
-	case nodeKind48:
-		n.node48().txnID = txnID
+	case nodeKind64:
+		n.node64().txnID = txnID
+	case nodeKind128:
+		n.node128().txnID = txnID
 	case nodeKind256:
 		n.node256().txnID = txnID
 	default:
@@ -194,9 +210,12 @@ func (n *header[T]) clone(watch bool) *header[T] {
 	case nodeKind16:
 		n16 := *n.node16()
 		nCopy = (&n16).self()
-	case nodeKind48:
-		n48 := *n.node48()
-		nCopy = (&n48).self()
+	case nodeKind64:
+		n64 := *n.node64()
+		nCopy = (&n64).self()
+	case nodeKind128:
+		n128 := *n.node128()
+		nCopy = (&n128).self()
 	case nodeKind256:
 		nCopy256 := *n.node256()
 		nCopy = (&nCopy256).self()
@@ -239,20 +258,32 @@ func (n *header[T]) promote(txnID uint64) *header[T] {
 		return node16.self()
 	case nodeKind16:
 		node16 := n.node16()
-		node48 := &node48[T]{header: *n}
-		node48.txnID = txnID
-		node48.setKind(nodeKind48)
-		node48.leaf = n.getLeaf()
-		copy(node48.children[:], node16.children[:node16.size()])
-		for i, k := range node16.keys[:node16.size()] {
-			node48.index[k] = uint8(i + 1)
+		node64 := &node64[T]{header: *n}
+		node64.txnID = txnID
+		node64.setKind(nodeKind64)
+		node64.leaf = n.getLeaf()
+		copy(node64.children[:], node16.children[:node16.size()])
+		for _, k := range node16.keys[:node16.size()] {
+			node64.bitmap[k/64] |= uint64(1) << (k % 64)
 		}
 		if n.watch != nil {
-			node48.watch = newWatchState()
+			node64.watch = newWatchState()
 		}
-		return node48.self()
-	case nodeKind48:
-		node48 := n.node48()
+		return node64.self()
+	case nodeKind64:
+		node64 := n.node64()
+		node128 := &node128[T]{header: *n}
+		node128.txnID = txnID
+		node128.setKind(nodeKind128)
+		node128.leaf = n.getLeaf()
+		copy(node128.children[:], node64.children[:node64.size()])
+		node128.bitmap = node64.bitmap
+		if n.watch != nil {
+			node128.watch = newWatchState()
+		}
+		return node128.self()
+	case nodeKind128:
+		node128 := n.node128()
 		node256 := &node256[T]{header: *n}
 		node256.txnID = txnID
 		node256.setKind(nodeKind256)
@@ -260,7 +291,7 @@ func (n *header[T]) promote(txnID uint64) *header[T] {
 
 		// Since Node256 has children indexed directly, iterate over the children
 		// to assign them to the right index.
-		for _, child := range node48.children[:node48.size()] {
+		for _, child := range node128.children[:node128.size()] {
 			node256.children[child.prefix()[0]] = child
 		}
 		if n.watch != nil {
@@ -272,6 +303,26 @@ func (n *header[T]) promote(txnID uint64) *header[T] {
 	default:
 		panic(fmt.Sprintf("unknown node kind: %x", n.kind()))
 	}
+}
+
+// bitmapIndex returns the packed child index for key and whether key is present.
+func bitmapIndex(bitmap *[4]uint64, key byte) (idx int, found bool) {
+	word := key / 64
+	bit := uint(key % 64)
+	mask := uint64(1) << bit
+	found = bitmap[word]&mask != 0
+	idx = bits.OnesCount64(bitmap[word] & (mask - 1))
+	switch word {
+	case 3:
+		idx += bits.OnesCount64(bitmap[2])
+		fallthrough
+	case 2:
+		idx += bits.OnesCount64(bitmap[1])
+		fallthrough
+	case 1:
+		idx += bits.OnesCount64(bitmap[0])
+	}
+	return
 }
 
 func (n *header[T]) printTree(level int) {
@@ -290,9 +341,12 @@ func (n *header[T]) printTree(level int) {
 	case nodeKind16:
 		fmt.Printf("node16[%x]:", n.prefix())
 		children = n.node16().children[:n.size()]
-	case nodeKind48:
-		fmt.Printf("node48[%x]:", n.prefix())
-		children = n.node48().children[:n.size()]
+	case nodeKind64:
+		fmt.Printf("node64[%x]:", n.prefix())
+		children = n.node64().children[:n.size()]
+	case nodeKind128:
+		fmt.Printf("node128[%x]:", n.prefix())
+		children = n.node128().children[:n.size()]
 	case nodeKind256:
 		fmt.Printf("node256[%x]:", n.prefix())
 		children = n.node256().children[:]
@@ -319,8 +373,10 @@ func (n *header[T]) children() []*header[T] {
 		return n.node4().children[0:n.size():4]
 	case nodeKind16:
 		return n.node16().children[0:n.size():16]
-	case nodeKind48:
-		return n.node48().children[0:n.size():48]
+	case nodeKind64:
+		return n.node64().children[0:n.size():64]
+	case nodeKind128:
+		return n.node128().children[0:n.size():128]
 	case nodeKind256:
 		return n.node256().children[:]
 	default:
@@ -363,35 +419,20 @@ func (n *header[T]) findIndex(key byte) (*header[T], int) {
 			}
 		}
 		return nil, size
-	case nodeKind48:
-		n48 := n.node48()
-		// Check for exact match first
-		if idx := n48.index[key]; idx != 0 {
-			i := int(idx - 1)
-			return n48.children[i], i
+	case nodeKind64:
+		n64 := n.node64()
+		idx, found := bitmapIndex(&n64.bitmap, key)
+		if found {
+			return n64.children[idx], idx
 		}
-		// No exact match. Binary search to find insertion point.
-		size := n48.size()
-		children := n48.children[:size]
-		// Is the key between smallest and highest?
-		switch {
-		case key < children[0].key():
-			return nil, 0
-		case key > children[size-1].key():
-			return nil, size
+		return nil, idx
+	case nodeKind128:
+		n128 := n.node128()
+		idx, found := bitmapIndex(&n128.bitmap, key)
+		if found {
+			return n128.children[idx], idx
 		}
-		// No exact match, but key is in range. Binary search to find insertion point.
-		// We're not using sort.Search as that requires a function closure.
-		lo, hi := 0, size
-		for lo < hi {
-			mid := int(uint(lo+hi) / 2)
-			if children[mid].key() < key {
-				lo = mid + 1
-			} else {
-				hi = mid
-			}
-		}
-		return nil, lo
+		return nil, idx
 	case nodeKind256:
 		return n.node256().children[key], int(key)
 	default:
@@ -423,13 +464,20 @@ func (n *header[T]) find(key byte) *header[T] {
 			return n16.children[idx]
 		}
 		return nil
-	case nodeKind48:
-		n48 := n.node48()
-		idx := n48.index[key]
-		if idx == 0 {
+	case nodeKind64:
+		n64 := n.node64()
+		idx, found := bitmapIndex(&n64.bitmap, key)
+		if !found {
 			return nil
 		}
-		return n48.children[idx-1]
+		return n64.children[idx]
+	case nodeKind128:
+		n128 := n.node128()
+		idx, found := bitmapIndex(&n128.bitmap, key)
+		if !found {
+			return nil
+		}
+		return n128.children[idx]
 	case nodeKind256:
 		return n.node256().children[key]
 	default:
@@ -455,16 +503,20 @@ func (n *header[T]) insert(idx int, child *header[T]) {
 		copy(n16.keys[idx+1:newSize], n16.keys[idx:newSize])
 		n16.children[idx] = child
 		n16.keys[idx] = child.key()
-	case nodeKind48:
+	case nodeKind64:
 		// Shift to make room
-		n48 := n.node48()
-		for i := size - 1; i >= idx; i-- {
-			c := n48.children[i]
-			n48.index[c.key()] = uint8(i + 2)
-			n48.children[i+1] = c
-		}
-		n48.children[idx] = child
-		n48.index[child.key()] = uint8(idx + 1)
+		n64 := n.node64()
+		copy(n64.children[idx+1:newSize], n64.children[idx:size])
+		n64.children[idx] = child
+		key := child.key()
+		n64.bitmap[key/64] |= uint64(1) << (key % 64)
+	case nodeKind128:
+		// Shift to make room
+		n128 := n.node128()
+		copy(n128.children[idx+1:newSize], n128.children[idx:size])
+		n128.children[idx] = child
+		key := child.key()
+		n128.bitmap[key/64] |= uint64(1) << (key % 64)
 	case nodeKind256:
 		n.node256().children[child.key()] = child
 	default:
@@ -490,16 +542,19 @@ func (n *header[T]) remove(idx int) {
 		copy(n16.children[idx:size], n16.children[idx+1:size])
 		n16.children[newSize] = nil
 		n16.keys[newSize] = 255
-	case nodeKind48:
+	case nodeKind64:
 		children := n.children()
 		key := children[idx].key()
-		n48 := n.node48()
-		for i := idx; i < newSize; i++ {
-			child := children[i+1]
-			children[i] = child
-			n48.index[child.key()] = uint8(i + 1)
-		}
-		n48.index[key] = 0
+		n64 := n.node64()
+		copy(children[idx:newSize], children[idx+1:newSize+1])
+		n64.bitmap[key/64] &^= uint64(1) << (key % 64)
+		children[newSize] = nil
+	case nodeKind128:
+		children := n.children()
+		key := children[idx].key()
+		n128 := n.node128()
+		copy(children[idx:newSize], children[idx+1:newSize+1])
+		n128.bitmap[key/64] &^= uint64(1) << (key % 64)
 		children[newSize] = nil
 	case nodeKind256:
 		n.node256().children[idx] = nil
@@ -551,12 +606,20 @@ type node16[T any] struct {
 	keys     [16]byte
 }
 
-type node48[T any] struct {
+type node64[T any] struct {
 	header[T]
 	txnID    uint64 // transaction ID that last mutated this node
-	children [48]*header[T]
-	leaf     *leaf[T]   // non-nil if this node contains a value
-	index    [256]uint8 // 1-based index for key in [children] (0 is absent, 1 is children[0])
+	children [64]*header[T]
+	leaf     *leaf[T] // non-nil if this node contains a value
+	bitmap   [4]uint64
+}
+
+type node128[T any] struct {
+	header[T]
+	txnID    uint64 // transaction ID that last mutated this node
+	children [128]*header[T]
+	leaf     *leaf[T] // non-nil if this node contains a value
+	bitmap   [4]uint64
 }
 
 type node256[T any] struct {

--- a/part/node_bitmap_test.go
+++ b/part/node_bitmap_test.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package part
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBitmapNodeTransitions(t *testing.T) {
+	tree := New[int](RootOnlyWatch)
+	expectedPromotions := map[int]nodeKind{
+		2:   nodeKind4,
+		5:   nodeKind16,
+		17:  nodeKind64,
+		65:  nodeKind128,
+		129: nodeKind256,
+	}
+	for i := range 256 {
+		_, _, tree = tree.Insert([]byte{byte(i)}, i)
+		if want, ok := expectedPromotions[i+1]; ok {
+			require.Equal(t, want, tree.root.kind(), "after inserting %d keys", i+1)
+		}
+	}
+	for i := range 256 {
+		value, ok := tree.Get([]byte{byte(i)})
+		require.True(t, ok)
+		require.Equal(t, i, value)
+	}
+
+	expectedDemotions := map[int]nodeKind{
+		128: nodeKind128,
+		64:  nodeKind64,
+		16:  nodeKind16,
+		4:   nodeKind4,
+	}
+	for i := 255; i > 0; i-- {
+		_, _, tree = tree.Delete([]byte{byte(i)})
+		if want, ok := expectedDemotions[i]; ok {
+			require.Equal(t, want, tree.root.kind(), "after deleting down to %d keys", i)
+		}
+		for j := range i {
+			value, found := tree.Get([]byte{byte(j)})
+			require.True(t, found)
+			require.Equal(t, j, value)
+		}
+	}
+}
+
+func TestBitmapIndex(t *testing.T) {
+	var bitmap [4]uint64
+	keys := []byte{0, 2, 63, 64, 65, 127, 128, 190, 191, 192, 254, 255}
+	for _, key := range keys {
+		bitmap[key/64] |= uint64(1) << (key % 64)
+	}
+
+	for key := range 256 {
+		idx, found := bitmapIndex(&bitmap, byte(key))
+		wantIdx := 0
+		wantFound := false
+		for _, present := range keys {
+			if int(present) < key {
+				wantIdx++
+			} else if int(present) == key {
+				wantFound = true
+			}
+		}
+		require.Equal(t, wantIdx, idx, "key %d", key)
+		require.Equal(t, wantFound, found, "key %d", key)
+	}
+}
+
+func TestBitmapNodeSizes(t *testing.T) {
+	if unsafe.Sizeof(uintptr(0)) != 8 {
+		t.Skip("node size assertions are for 64-bit platforms")
+	}
+	require.Equal(t, uintptr(584), unsafe.Sizeof(node64[bool]{}))
+	require.Equal(t, uintptr(1096), unsafe.Sizeof(node128[bool]{}))
+	require.Equal(t, uintptr(2088), unsafe.Sizeof(node256[bool]{}))
+}

--- a/part/part_test.go
+++ b/part/part_test.go
@@ -1766,78 +1766,78 @@ func Benchmark_findIndex16(b *testing.B) {
 	}
 }
 
-func Benchmark_find48(b *testing.B) {
-	n := &node48[bool]{
+func Benchmark_find64(b *testing.B) {
+	n := &node64[bool]{
 		header:   header[bool]{},
-		children: [48]*header[bool]{},
+		children: [64]*header[bool]{},
 		leaf:     nil,
-		index:    [256]uint8{},
+		bitmap:   [4]uint64{},
 	}
-	keyBytes := [48]byte{}
-	leaves := [48]leaf[bool]{}
-	for i := range 48 {
+	keyBytes := [64]byte{}
+	leaves := [64]leaf[bool]{}
+	for i := range 64 {
 		keyBytes[i] = byte(i)
 		leaves[i].prefixP = &keyBytes[i]
 		leaves[i].prefixLen = 1
 		leaves[i].setKind(nodeKindLeaf)
 		n.children[i] = leaves[i].self()
-		n.index[byte(i)] = uint8(i + 1)
+		n.bitmap[byte(i)/64] |= uint64(1) << (byte(i) % 64)
 	}
-	n.setKind(nodeKind48)
-	n.setSize(48)
+	n.setKind(nodeKind64)
+	n.setSize(64)
 
 	for b.Loop() {
-		n.find(48)
+		n.find(64)
 	}
 }
 
-func Benchmark_findIndex48_hit(b *testing.B) {
-	n := &node48[bool]{
+func Benchmark_findIndex64_hit(b *testing.B) {
+	n := &node64[bool]{
 		header:   header[bool]{},
-		children: [48]*header[bool]{},
+		children: [64]*header[bool]{},
 		leaf:     nil,
-		index:    [256]uint8{},
+		bitmap:   [4]uint64{},
 	}
-	keyBytes := [48]byte{}
-	leaves := [48]leaf[bool]{}
-	for i := range 48 {
+	keyBytes := [64]byte{}
+	leaves := [64]leaf[bool]{}
+	for i := range 64 {
 		keyBytes[i] = byte(i)
 		leaves[i].prefixP = &keyBytes[i]
 		leaves[i].prefixLen = 1
 		leaves[i].setKind(nodeKindLeaf)
 		n.children[i] = leaves[i].self()
-		n.index[byte(i)] = uint8(i + 1)
+		n.bitmap[byte(i)/64] |= uint64(1) << (byte(i) % 64)
 	}
-	n.setKind(nodeKind48)
-	n.setSize(48)
+	n.setKind(nodeKind64)
+	n.setSize(64)
 
 	for b.Loop() {
-		n.findIndex(47)
+		n.findIndex(63)
 	}
 }
 
-func Benchmark_findIndex48_miss(b *testing.B) {
-	n := &node48[bool]{
+func Benchmark_findIndex64_miss(b *testing.B) {
+	n := &node64[bool]{
 		header:   header[bool]{},
-		children: [48]*header[bool]{},
+		children: [64]*header[bool]{},
 		leaf:     nil,
-		index:    [256]uint8{},
+		bitmap:   [4]uint64{},
 	}
-	keyBytes := [48]byte{}
-	leaves := [48]leaf[bool]{}
-	for i := range 48 {
+	keyBytes := [64]byte{}
+	leaves := [64]leaf[bool]{}
+	for i := range 64 {
 		keyBytes[i] = byte(i)
 		leaves[i].prefixP = &keyBytes[i]
 		leaves[i].prefixLen = 1
 		leaves[i].setKind(nodeKindLeaf)
 		n.children[i] = leaves[i].self()
-		n.index[byte(i)] = uint8(i + 1)
+		n.bitmap[byte(i)/64] |= uint64(1) << (byte(i) % 64)
 	}
-	n.setKind(nodeKind48)
-	n.setSize(48)
+	n.setKind(nodeKind64)
+	n.setSize(64)
 
 	for b.Loop() {
-		n.findIndex(48)
+		n.findIndex(64)
 	}
 }
 

--- a/part/small_txn_bench_test.go
+++ b/part/small_txn_bench_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package part
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+// BenchmarkSmallWriteTxn measures path-copying costs for small transactions
+// against a tree whose second-level nodes have a mean fanout of 96.
+func BenchmarkSmallWriteTxn(b *testing.B) {
+	const numKeys = 24 * 1024
+	rng := rand.New(rand.NewSource(1))
+	keys := make([][]byte, 0, numKeys)
+	seen := make(map[uint64]struct{}, numKeys)
+	for len(keys) < numKeys {
+		key := rng.Uint64()
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		keys = append(keys, uint64Key(key))
+	}
+
+	for _, batchSize := range []int{1, 2, 4, 8, 16} {
+		b.Run(fmt.Sprintf("updates_%d", batchSize), func(b *testing.B) {
+			tree := New[int](RootOnlyWatch)
+			txn := tree.Txn()
+			for i, key := range keys {
+				txn.Insert(key, i)
+			}
+			tree = txn.CommitAndNotify()
+
+			next := 0
+			b.ResetTimer()
+			for i := range b.N {
+				txn := tree.Txn()
+				for j := range batchSize {
+					idx := (next + j*7919) % len(keys)
+					txn.Insert(keys[idx], i)
+				}
+				tree = txn.CommitAndNotify()
+				next = (next + batchSize) % len(keys)
+			}
+		})
+	}
+}

--- a/part/txn.go
+++ b/part/txn.go
@@ -609,25 +609,45 @@ func (txn *Txn[T]) removeChild(parent *header[T], index int) (newParent *header[
 		childClone.setPrefix(slices.Concat(parent.prefix(), childClone.prefix()))
 		return childClone
 
-	case parent.kind() == nodeKind256 && size <= 49:
-		demoted := (&node48[T]{header: *parent}).self()
+	case parent.kind() == nodeKind256 && size <= 129:
+		demoted := (&node128[T]{header: *parent}).self()
 		if parent.watch != nil {
 			demoted.watch = newWatchState()
 		}
-		demoted.setKind(nodeKind48)
+		demoted.setKind(nodeKind128)
 		demoted.setSize(size - 1)
 		demoted.setTxnID(txn.txnID)
-		n48 := demoted.node48()
-		n48.leaf = parent.getLeaf()
-		children := n48.children[:0]
+		n128 := demoted.node128()
+		n128.leaf = parent.getLeaf()
+		children := n128.children[:0]
 		for k, n := range parent.node256().children[:] {
 			if k != index && n != nil {
-				n48.index[k] = uint8(len(children) + 1)
+				n128.bitmap[k/64] |= uint64(1) << (k % 64)
 				children = append(children, n)
 			}
 		}
 		newParent = demoted
-	case parent.kind() == nodeKind48 && size <= 17:
+	case parent.kind() == nodeKind128 && size <= 65:
+		demoted := (&node64[T]{header: *parent}).self()
+		if parent.watch != nil {
+			demoted.watch = newWatchState()
+		}
+		demoted.setKind(nodeKind64)
+		demoted.setSize(size - 1)
+		demoted.setTxnID(txn.txnID)
+		n64 := demoted.node64()
+		n64.leaf = parent.getLeaf()
+		idx := 0
+		for i, child := range parent.children() {
+			if i != index {
+				n64.children[idx] = child
+				key := child.key()
+				n64.bitmap[key/64] |= uint64(1) << (key % 64)
+				idx++
+			}
+		}
+		newParent = demoted
+	case parent.kind() == nodeKind64 && size <= 17:
 		demoted := (&node16[T]{header: *parent}).self()
 		if parent.watch != nil {
 			demoted.watch = newWatchState()
@@ -736,11 +756,14 @@ func validateTree[T any](node *header[T], parents []*header[T], watches []*watch
 	// Node16 must have occupancy higher than 4
 	assert(node.kind() != nodeKind16 || node.size() > 4, "node16 has fewer children than 5")
 
-	// Node48 must have occupancy higher than 16
-	assert(node.kind() != nodeKind48 || node.size() > 16, "node48 has fewer children than 17")
+	// Node64 must have occupancy higher than 16
+	assert(node.kind() != nodeKind64 || node.size() > 16, "node64 has fewer children than 17")
 
-	// Node256 must have occupancy higher than 48
-	assert(node.kind() != nodeKind256 || node.size() > 48, "node256 has fewer children than 49")
+	// Node128 must have occupancy higher than 64
+	assert(node.kind() != nodeKind128 || node.size() > 64, "node128 has fewer children than 65")
+
+	// Node256 must have occupancy higher than 128
+	assert(node.kind() != nodeKind256 || node.size() > 128, "node256 has fewer children than 129")
 
 	// Nodes that have a watch channel that is to be closed must
 	// also have all their parent's watch channels to be closed.


### PR DESCRIPTION
Replace Node48's 256-byte reverse index with packed, sorted child arrays indexed by a 256-bit bitmap and popcount. Add Node64 and Node128 stages between Node16 and Node256, including symmetric promotion and demotion paths. With these node sizes we'll have smaller allocations and cloning of the nodes is faster as there's less to copy. The Node64+Node128 is slightly less optimal for lookups than having just Node48 but it significantly reduces allocations.

## Allocator sizes

On 64-bit Go:

| Node | Raw size | Size class | Slack |
| --- | ---: | ---: | ---: |
| Node48 | 680 B | 704 B | 24 B |
| Node64 | 584 B | 640 B | 56 B |
| Node128 | 1096 B | 1152 B | 56 B |
| Node256 | 2088 B | 2304 B | 216 B |

Thus Node64 (with bitmaps) has 16 more child slots than Node48 while using a smaller allocator class. Node128 delays the much larger Node256 allocation until fanout exceeds 128.

## Benchmarks

### `part` benchmarks

10 runs, 300 ms benchtime:

```text
goos: linux
goarch: arm64
pkg: github.com/cilium/statedb/part
                                   │   before    │                after                 │
                                   │   sec/op    │   sec/op     vs base                │
_Uint64Map_Sequential_Insert-6        520.3µ ± 4%   446.2µ ± 3%  -14.24% (p=0.000 n=10)
_Uint64Map_Sequential_Txn_Insert-6    71.33µ ± 1%   75.09µ ± 1%   +5.27% (p=0.000 n=10)
_Uint64Map_Random_Insert-6            624.1µ ± 3%   413.7µ ± 1%  -33.72% (p=0.000 n=10)
_Uint64Map_Random_Txn_Insert-6        111.5µ ± 2%   117.3µ ± 2%   +5.16% (p=0.000 n=10)
_Insert_RootOnlyWatch-6               74.87µ ± 3%   75.92µ ± 3%        ~ (p=0.105 n=10)
_Get-6                                16.12µ ± 1%   16.22µ ± 1%   +0.60% (p=0.027 n=10)
SmallWriteTxn/updates_1-6             2.241µ ± 1%   1.961µ ± 1%  -12.47% (p=0.000 n=10)
SmallWriteTxn/updates_2-6             3.487µ ± 2%   2.760µ ± 1%  -20.85% (p=0.000 n=10)
SmallWriteTxn/updates_4-6             5.899µ ± 2%   4.495µ ± 4%  -23.80% (p=0.000 n=10)
SmallWriteTxn/updates_8-6            10.614µ ± 2%   7.796µ ± 6%  -26.55% (p=0.002 n=10)
SmallWriteTxn/updates_16-6            20.08µ ± 1%   14.23µ ± 3%  -29.12% (p=0.000 n=10)
geomean                               31.53µ        26.93µ       -14.59%
```

```text
                                   │   before    │                 after                  │
                                   │    B/op     │    B/op      vs base                  │
_Uint64Map_Sequential_Insert-6        2.106Mi ± 0%   1.716Mi ± 0%  -18.54% (p=0.000 n=10)
_Uint64Map_Sequential_Txn_Insert-6    84.33Ki ± 0%   88.58Ki ± 0%   +5.04% (p=0.000 n=10)
_Uint64Map_Random_Insert-6            2.402Mi ± 0%   1.352Mi ± 0%  -43.70% (p=0.000 n=10)
_Uint64Map_Random_Txn_Insert-6        116.2Ki ± 1%   114.6Ki ± 1%   -1.42% (p=0.000 n=10)
_Insert_RootOnlyWatch-6               69.83Ki ± 0%   74.02Ki ± 0%   +6.00% (p=0.000 n=10)
_Get-6                                  0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10)
SmallWriteTxn/updates_1-6             4.681Ki ± 0%   3.548Ki ± 0%  -24.20% (p=0.000 n=10)
SmallWriteTxn/updates_2-6             6.994Ki ± 0%   4.732Ki ± 0%  -32.34% (p=0.000 n=10)
SmallWriteTxn/updates_4-6            11.594Ki ± 0%   7.090Ki ± 0%  -38.85% (p=0.000 n=10)
SmallWriteTxn/updates_8-6             20.69Ki ± 0%   11.75Ki ± 0%  -43.21% (p=0.000 n=10)
SmallWriteTxn/updates_16-6            38.52Ki ± 0%   20.89Ki ± 0%  -45.76% (p=0.000 n=10)
```

The small write transaction allocation counts are unchanged.

### Reconciler benchmark

1,000,000 objects and incremental batch size 1000. Parent and changed binaries were alternated; results are the best throughput of three runs per batch size:

| Batch | Before obj/s | After obj/s | Change | Before allocated | After allocated | Change |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 160071.01 | 183551.30 | +14.67% | 9946 MB | 8237 MB | -17.18% |
| 10 | 620465.78 | 594884.80 | -4.12% | 1793 MB | 1649 MB | -8.03% |
| 100 | 445345.12 | 532524.79 | +19.57% | 970 MB | 969 MB | -0.10% |
| 1000 | 663607.42 | 697113.34 | +5.05% | 888 MB | 901 MB | +1.46% |

AIL:3
