### PR TITLE
Small performance improvements

### DIFF
--- a/index/set.go
+++ b/index/set.go
@@ -10,12 +10,12 @@ func Set[T any](s part.Set[T]) KeySet {
 	toBytes := s.ToBytesFunc()
 	switch s.Len() {
 	case 0:
-		return NewKeySet()
+		return KeySet{}
 	case 1:
-		for v := range s.All() {
-			return NewKeySet(toBytes(v))
+		if v, ok := s.First(); ok {
+			return KeySet{head: toBytes(v)}
 		}
-		panic("BUG: Set.Len() == 1, but ranging returned nothing")
+		panic("BUG: Set.Len() == 1, but First returned nothing")
 	default:
 		keys := make([]Key, 0, s.Len())
 		for v := range s.All() {

--- a/part/map_set_bench_test.go
+++ b/part/map_set_bench_test.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package part
+
+import (
+	"strconv"
+	"testing"
+)
+
+var (
+	setBenchmarkSink  Set[[]byte]
+	mapBenchmarkSink  Map[string, int]
+	boolBenchmarkSink bool
+)
+
+func Benchmark_Set_Singleton_Create(b *testing.B) {
+	key := []byte("value")
+	for b.Loop() {
+		setBenchmarkSink = NewSet(key)
+	}
+}
+
+func Benchmark_Set_Singleton_Has(b *testing.B) {
+	key := []byte("value")
+	set := NewSet(key)
+	for b.Loop() {
+		boolBenchmarkSink = set.Has(key)
+	}
+}
+
+func Benchmark_StringMap_Txn_Insert(b *testing.B) {
+	const count = 1000
+	keys := make([]string, count)
+	for i := range keys {
+		keys[i] = "key-" + strconv.Itoa(i)
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		var m Map[string, int]
+		txn := m.Txn()
+		for i, key := range keys {
+			txn.Set(key, i)
+		}
+		mapBenchmarkSink = txn.Commit()
+	}
+	b.ReportMetric(float64(count*b.N)/b.Elapsed().Seconds(), "items/sec")
+}

--- a/part/registry.go
+++ b/part/registry.go
@@ -10,12 +10,15 @@ import (
 	"reflect"
 	"sync"
 	"unicode/utf8"
+	"unsafe"
 )
 
 // keyTypeRegistry is a registry of functions to convert to/from keys (of type K).
 // This mechanism enables use of zero value and JSON marshalling and unmarshalling
 // with Map and Set.
 var keyTypeRegistry sync.Map // map[reflect.Type]func(K) []byte
+
+var emptyStringKey = []byte{}
 
 // RegisterKeyType registers a new key type to be used with the Map and Set types.
 // Intended to be called from init() functions.
@@ -39,7 +42,13 @@ func lookupKeyType[K any]() func(K) []byte {
 
 func init() {
 	// Register common key types.
-	RegisterKeyType[string](func(s string) []byte { return []byte(s) })
+	RegisterKeyType[string](func(s string) []byte {
+		// Keys are immutable, so it is safe to avoid copying the string.
+		if len(s) == 0 {
+			return emptyStringKey
+		}
+		return unsafe.Slice(unsafe.StringData(s), len(s))
+	})
 	RegisterKeyType[[]byte](func(b []byte) []byte { return b })
 	RegisterKeyType[byte](func(b byte) []byte { return []byte{b} })
 	RegisterKeyType[rune](func(r rune) []byte { return utf8.AppendRune(nil, r) })

--- a/part/set.go
+++ b/part/set.go
@@ -20,9 +20,10 @@ import (
 // function for T have been registered with RegisterKeyType.
 // For Set-only use only [bytesFromKey] needs to be defined.
 type Set[T any] struct {
-	toBytes func(T) []byte
-	tree    Tree[T]
-	hasTree bool
+	toBytes   func(T) []byte
+	singleton *T
+	tree      Tree[T]
+	hasTree   bool
 }
 
 // NewSet creates a new set of T.
@@ -31,7 +32,12 @@ func NewSet[T any](values ...T) Set[T] {
 	if len(values) == 0 {
 		return Set[T]{}
 	}
-	s := Set[T]{}
+	s := Set[T]{toBytes: lookupKeyType[T]()}
+	if len(values) == 1 {
+		value := values[0]
+		s.singleton = &value
+		return s
+	}
 	s.ensureTree()
 	txn := s.tree.Txn()
 	for _, v := range values {
@@ -46,14 +52,34 @@ func (s *Set[T]) ensureTree() {
 		s.tree = New[T](RootOnlyWatch)
 		s.hasTree = true
 	}
-	s.toBytes = lookupKeyType[T]()
+	if s.toBytes == nil {
+		s.toBytes = lookupKeyType[T]()
+	}
+}
+
+func (s *Set[T]) keyToBytes(v T) []byte {
+	if s.toBytes == nil {
+		s.toBytes = lookupKeyType[T]()
+	}
+	return s.toBytes(v)
 }
 
 // Set a value. Returns a new set. Original is unchanged.
 func (s Set[T]) Set(v T) Set[T] {
+	key := s.keyToBytes(v)
+	if (!s.hasTree && s.singleton == nil) ||
+		(s.singleton != nil && bytes.Equal(key, s.keyToBytes(*s.singleton))) {
+		s.singleton = &v
+		return s
+	}
+
 	s.ensureTree()
 	txn := s.tree.Txn()
-	txn.Insert(s.toBytes(v), v)
+	txn.Insert(key, v)
+	if s.singleton != nil {
+		txn.Insert(s.keyToBytes(*s.singleton), *s.singleton)
+		s.singleton = nil
+	}
 	s.tree = txn.Commit() // As Set is passed by value we can just modify it.
 	return s
 }
@@ -61,26 +87,56 @@ func (s Set[T]) Set(v T) Set[T] {
 // Delete returns a new set without the value. The original
 // set is unchanged.
 func (s Set[T]) Delete(v T) Set[T] {
+	if s.singleton != nil {
+		if bytes.Equal(s.keyToBytes(*s.singleton), s.keyToBytes(v)) {
+			s.singleton = nil
+		}
+		return s
+	}
 	if !s.hasTree {
 		return s
 	}
 	txn := s.tree.Txn()
-	txn.Delete(s.toBytes(v))
-	s.tree = txn.Commit()
-	if s.tree.Len() == 0 {
+	txn.Delete(s.keyToBytes(v))
+	switch txn.Len() {
+	case 0:
 		s.tree = Tree[T]{}
 		s.hasTree = false
+	case 1:
+		iter := txn.Iterator()
+		_, value, _ := iter.Next()
+		s.singleton = &value
+		s.tree = Tree[T]{}
+		s.hasTree = false
+	default:
+		s.tree = txn.Commit()
 	}
 	return s
 }
 
 // Has returns true if the set has the value.
 func (s Set[T]) Has(v T) bool {
+	if s.singleton != nil {
+		return bytes.Equal(s.keyToBytes(*s.singleton), s.keyToBytes(v))
+	}
 	if !s.hasTree {
 		return false
 	}
-	_, found := s.tree.Get(s.toBytes(v))
+	_, found := s.tree.Get(s.keyToBytes(v))
 	return found
+}
+
+// First returns the first value in key order, or false if the set is empty.
+func (s Set[T]) First() (value T, ok bool) {
+	if s.singleton != nil {
+		return *s.singleton, true
+	}
+	if !s.hasTree {
+		return value, false
+	}
+	iter := s.tree.Iterator()
+	_, value, ok = iter.Next()
+	return value, ok
 }
 
 func emptySeq[T any](yield func(T) bool) {
@@ -88,13 +144,17 @@ func emptySeq[T any](yield func(T) bool) {
 
 // All returns an iterator for all values.
 func (s Set[T]) All() iter.Seq[T] {
-	if !s.hasTree {
+	if !s.hasTree && s.singleton == nil {
 		return emptySeq[T]
 	}
 	return s.yieldAll
 }
 
 func (s Set[T]) yieldAll(yield func(v T) bool) {
+	if s.singleton != nil {
+		yield(*s.singleton)
+		return
+	}
 	for _, v := range s.tree.Iterator().All {
 		if !yield(v) {
 			return
@@ -105,16 +165,26 @@ func (s Set[T]) yieldAll(yield func(v T) bool) {
 // Union returns a set that is the union of the values
 // in the input sets.
 func (s Set[T]) Union(s2 Set[T]) Set[T] {
-	if !s2.hasTree {
+	if s2.Len() == 0 {
 		return s
 	}
-	if !s.hasTree {
+	if s.Len() == 0 {
 		return s2
 	}
+
+	s.ensureTree()
 	txn := s.tree.Txn()
-	iter := s2.tree.Iterator()
-	for k, v, ok := iter.Next(); ok; k, v, ok = iter.Next() {
-		txn.Insert(k, v)
+	if s.singleton != nil {
+		txn.Insert(s.keyToBytes(*s.singleton), *s.singleton)
+		s.singleton = nil
+	}
+	if s2.singleton != nil {
+		txn.Insert(s2.keyToBytes(*s2.singleton), *s2.singleton)
+	} else {
+		iter := s2.tree.Iterator()
+		for k, v, ok := iter.Next(); ok; k, v, ok = iter.Next() {
+			txn.Insert(k, v)
+		}
 	}
 	s.tree = txn.Commit()
 	return s
@@ -123,21 +193,46 @@ func (s Set[T]) Union(s2 Set[T]) Set[T] {
 // Difference returns a set with values that only
 // appear in the first set.
 func (s Set[T]) Difference(s2 Set[T]) Set[T] {
-	if !s.hasTree || !s2.hasTree {
+	if s.Len() == 0 || s2.Len() == 0 {
+		return s
+	}
+	if s.singleton != nil {
+		if s2.Has(*s.singleton) {
+			s.singleton = nil
+		}
 		return s
 	}
 
 	txn := s.tree.Txn()
-	iter := s2.tree.Iterator()
-	for k, _, ok := iter.Next(); ok; k, _, ok = iter.Next() {
-		txn.Delete(k)
+	if s2.singleton != nil {
+		txn.Delete(s2.keyToBytes(*s2.singleton))
+	} else {
+		iter := s2.tree.Iterator()
+		for k, _, ok := iter.Next(); ok; k, _, ok = iter.Next() {
+			txn.Delete(k)
+		}
 	}
-	s.tree = txn.Commit()
+	switch txn.Len() {
+	case 0:
+		s.tree = Tree[T]{}
+		s.hasTree = false
+	case 1:
+		iter := txn.Iterator()
+		_, value, _ := iter.Next()
+		s.singleton = &value
+		s.tree = Tree[T]{}
+		s.hasTree = false
+	default:
+		s.tree = txn.Commit()
+	}
 	return s
 }
 
 // Len returns the number of values in the set.
 func (s Set[T]) Len() int {
+	if s.singleton != nil {
+		return 1
+	}
 	if !s.hasTree {
 		return 0
 	}
@@ -147,10 +242,14 @@ func (s Set[T]) Len() int {
 // Equal returns true if the two sets contain the equal keys.
 func (s Set[T]) Equal(other Set[T]) bool {
 	switch {
-	case !s.hasTree && !other.hasTree:
-		return true
 	case s.Len() != other.Len():
 		return false
+	case s.Len() == 0:
+		return true
+	case s.Len() == 1:
+		v1, _ := s.First()
+		v2, _ := other.First()
+		return bytes.Equal(s.keyToBytes(v1), other.keyToBytes(v2))
 	default:
 		iter1 := s.tree.Iterator()
 		iter2 := other.tree.Iterator()
@@ -177,11 +276,21 @@ func (s Set[T]) ToBytesFunc() func(T) []byte {
 }
 
 func (s Set[T]) MarshalJSON() ([]byte, error) {
-	if !s.hasTree {
+	if !s.hasTree && s.singleton == nil {
 		return []byte("[]"), nil
 	}
 	var b bytes.Buffer
 	b.WriteRune('[')
+	if s.singleton != nil {
+		bs, err := json.Marshal(*s.singleton)
+		if err != nil {
+			return nil, err
+		}
+		b.Write(bs)
+		b.WriteRune(']')
+		return b.Bytes(), nil
+	}
+
 	iter := s.tree.Iterator()
 	_, v, ok := iter.Next()
 	for ok {
@@ -200,6 +309,8 @@ func (s Set[T]) MarshalJSON() ([]byte, error) {
 }
 
 func (s *Set[T]) UnmarshalJSON(data []byte) error {
+	*s = Set[T]{}
+
 	dec := json.NewDecoder(bytes.NewReader(data))
 	t, err := dec.Token()
 	if err != nil {
@@ -209,22 +320,30 @@ func (s *Set[T]) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("%T.UnmarshalJSON: expected '[' got %v", s, t)
 	}
 
-	*s = Set[T]{}
-	s.ensureTree()
-	txn := s.tree.Txn()
-
-	for dec.More() {
-		var x T
-		err := dec.Decode(&x)
-		if err != nil {
-			return err
-		}
-		txn.Insert(s.toBytes(x), x)
+	if !dec.More() {
+		_, err = dec.Token()
+		return err
 	}
-	s.tree = txn.Commit()
-	if s.tree.Len() == 0 {
-		s.tree = Tree[T]{}
-		s.hasTree = false
+
+	var first T
+	if err := dec.Decode(&first); err != nil {
+		return err
+	}
+	if !dec.More() {
+		s.toBytes = lookupKeyType[T]()
+		s.singleton = &first
+	} else {
+		s.ensureTree()
+		txn := s.tree.Txn()
+		txn.Insert(s.keyToBytes(first), first)
+		for dec.More() {
+			var x T
+			if err := dec.Decode(&x); err != nil {
+				return err
+			}
+			txn.Insert(s.keyToBytes(x), x)
+		}
+		s.tree = txn.Commit()
 	}
 
 	t, err = dec.Token()
@@ -248,6 +367,19 @@ func (s *Set[T]) UnmarshalYAML(value *yaml.Node) error {
 	}
 
 	*s = Set[T]{}
+	switch len(value.Content) {
+	case 0:
+		return nil
+	case 1:
+		var v T
+		if err := value.Content[0].Decode(&v); err != nil {
+			return err
+		}
+		s.toBytes = lookupKeyType[T]()
+		s.singleton = &v
+		return nil
+	}
+
 	s.ensureTree()
 	txn := s.tree.Txn()
 

--- a/part/set_test.go
+++ b/part/set_test.go
@@ -20,9 +20,14 @@ func TestStringSet(t *testing.T) {
 	var s part.Set[string]
 
 	assert.False(t, s.Has("nothing"), "Has nothing")
+	_, ok := s.First()
+	assert.False(t, ok, "empty set has no first value")
 
 	s = s.Set("foo")
 	assert.True(t, s.Has("foo"), "Has foo")
+	first, ok := s.First()
+	assert.True(t, ok, "non-empty set has a first value")
+	assert.Equal(t, "foo", first)
 
 	count := 0
 	for v := range s.All() {
@@ -41,6 +46,15 @@ func TestStringSet(t *testing.T) {
 
 	values := slices.Collect(s3.All())
 	assert.ElementsMatch(t, []string{"foo", "bar"}, values)
+	count = 0
+	for range s3.All() {
+		count++
+		break
+	}
+	assert.Equal(t, 1, count, "iteration stops when the caller breaks")
+	first, ok = s3.First()
+	assert.True(t, ok)
+	assert.Equal(t, "bar", first)
 
 	s4 := s3.Difference(s2)
 	assert.False(t, s4.Has("bar"), "s4 has no bar")
@@ -71,17 +85,31 @@ func TestSetAllStopsEarly(t *testing.T) {
 	require.Equal(t, 1, count)
 }
 
+func TestNewSetCopiesSingleton(t *testing.T) {
+	values := []string{"original"}
+	s := part.NewSet(values...)
+	values[0] = "changed"
+
+	value, ok := s.First()
+	require.True(t, ok)
+	require.Equal(t, "original", value)
+}
+
 func TestSetJSON(t *testing.T) {
 	t.Parallel()
-	s := part.NewSet("foo", "bar", "baz")
+	for _, s := range []part.Set[string]{
+		{},
+		part.NewSet("foo"),
+		part.NewSet("foo", "bar", "baz"),
+	} {
+		bs, err := json.Marshal(s)
+		require.NoError(t, err, "Marshal")
 
-	bs, err := json.Marshal(s)
-	require.NoError(t, err, "Marshal")
-
-	var s2 part.Set[string]
-	err = json.Unmarshal(bs, &s2)
-	require.NoError(t, err, "Unmarshal")
-	require.True(t, s.Equal(s2), "Equal")
+		var s2 part.Set[string]
+		err = json.Unmarshal(bs, &s2)
+		require.NoError(t, err, "Unmarshal")
+		require.True(t, s.Equal(s2), "Equal")
+	}
 }
 
 func TestSetYAML(t *testing.T) {

--- a/reconciler/retries.go
+++ b/reconciler/retries.go
@@ -183,6 +183,10 @@ func (rq *retries) Add(obj any, rev statedb.Revision, origRev statedb.Revision, 
 }
 
 func (rq *retries) Clear(obj any) {
+	if len(rq.items) == 0 {
+		return
+	}
+
 	key := rq.objectToKey(obj)
 	if item, ok := rq.items[string(key)]; ok {
 		// Remove the object from the queue if it is still there.

--- a/reconciler/retries_test.go
+++ b/reconciler/retries_test.go
@@ -124,6 +124,18 @@ func TestRetries(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestRetriesClearEmptyDoesNotExtractKey(t *testing.T) {
+	keyCalls := 0
+	rq := newRetries(time.Millisecond, 100*time.Millisecond, func(any) index.Key {
+		keyCalls++
+		return index.Uint64(1)
+	})
+
+	rq.Clear(uint64(1))
+
+	assert.Zero(t, keyCalls)
+}
+
 func TestExponentialBackoff(t *testing.T) {
 	backoff := exponentialBackoff{
 		min: time.Millisecond,


### PR DESCRIPTION
- Skip unnecessary work in `retries.Clear` when queue is empty
- Avoid constructing iterator when dealing with singleton `part.Set`s
- Speed up `part.Set[string]` key construction with unsafe (same trick as `index.String`)

See commits for more details. 
AIL:3.