### PR TITLE
fix: close db watch change iterator on exit

### DIFF
--- a/script.go
+++ b/script.go
@@ -818,6 +818,7 @@ func WatchCmd(db *DB) script.Cmd {
 			if err != nil {
 				return nil, err
 			}
+			defer iter.Close()
 
 			header := tbl.TableHeader()
 			if header == nil {

--- a/script_test.go
+++ b/script_test.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cilium/hive"
 	"github.com/cilium/hive/cell"
@@ -46,6 +47,30 @@ func TestScript(t *testing.T) {
 		[]string{},
 		"testdata/*.txtar",
 	)
+}
+
+func TestWatchCmdClosesChangeIterator(t *testing.T) {
+	db, table, metrics := newTestDB(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	state, err := script.NewState(ctx, t.TempDir(), nil)
+	require.NoError(t, err)
+	engine := script.Engine{
+		Cmds: map[string]script.Cmd{"db/watch": WatchCmd(db)},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- engine.ExecuteLine(state, "db/watch test", &strings.Builder{})
+	}()
+
+	require.Eventually(t, func() bool {
+		return expvarInt(metrics.DeleteTrackerCountVar.Get(table.Name())) == 1
+	}, time.Second, time.Millisecond)
+
+	cancel()
+	require.NoError(t, <-done)
+	require.EqualValues(t, 0, expvarInt(metrics.DeleteTrackerCountVar.Get(table.Name())))
 }
 
 func TestHeaderLine(t *testing.T) {


### PR DESCRIPTION
A canceled `db/watch` leaves its deletion tracker registered. 
That can keep deleted objects in the graveyard until runtime cleanup kicks in

This closes the change iterator when the command exits.
The test runs the real script command and checks the tracker returns to zero

Repro:
1. Run the new test against `main`
2. It fails because the tracker stays at 1
3. Apply the fix, it returns to 0

Tested with `make`