### PR TITLE
lpm: reject disjoint prefix queries

### DIFF
--- a/lpm/trie.go
+++ b/lpm/trie.go
@@ -394,15 +394,15 @@ func (txn *Txn[T]) Prefix(key index.Key) *Iterator[T] {
 	var matchLen PrefixLen
 	for node != nil {
 		matchLen = longestMatch(matchLen, node, data, prefixLen)
-		if matchLen == prefixLen || matchLen < node.prefixLen() {
-			break
+		if matchLen == prefixLen {
+			return &Iterator[T]{start: node}
+		}
+		if matchLen < node.prefixLen() {
+			return nil
 		}
 		node = node.children[getBitAt(data, node.prefixLen())]
 	}
-	if node == nil {
-		return nil
-	}
-	return &Iterator[T]{start: node}
+	return nil
 }
 
 func (txn *Txn[T]) LowerBound(key index.Key) *Iterator[T] {

--- a/lpm/trie_test.go
+++ b/lpm/trie_test.go
@@ -100,6 +100,9 @@ func TestTrie(t *testing.T) {
 	values = slices.Collect(iteratorToValues(txn.Prefix(prefix("192.168.0.0/16"))))
 	require.Equal(t, []int{2, 3}, values)
 
+	values = slices.Collect(iteratorToValues(txn.Prefix(prefix("172.16.0.0/12"))))
+	require.Empty(t, values)
+
 	values = slices.Collect(iteratorToValues(txn.LowerBound(prefix("0.0.0.0/0"))))
 	require.Equal(t, []int{1, 999, 2, 3}, values)
 

--- a/lpm_index_test.go
+++ b/lpm_index_test.go
@@ -197,6 +197,8 @@ func TestLPMIndex(t *testing.T) {
 	})
 	txn = wtxn.Commit()
 
+	objs = Collect(tbl.Prefix(txn, lpmPrefixIndex.QueryPrefix(netip.MustParsePrefix("10.0.0.0/8"))))
+	require.Empty(t, objs)
 }
 
 func TestLPMIndexNonUnique(t *testing.T) {


### PR DESCRIPTION
A disjoint `Prefix` query could return an unrelated LPM subtree when traversal hit a compressed node

Repro:
1. Insert only `10.0.0.0/8`
2. Query `Prefix` with `192.168.0.0/16`
3. The `10/8` object comes back

The fix returns no iterator when matching diverges inside a node. 
Added trie and public `NetIPPrefixIndex` regression tests

Tests: `make`