### PR TITLE
LPM fixes

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -20,6 +20,9 @@ var (
 	// ErrPrimaryIndexNotUnique indicates that the primary index for the table is not marked unique.
 	ErrPrimaryIndexNotUnique = errors.New("primary index not unique")
 
+	// ErrPrimaryIndexNotSupported indicates that the index type cannot be used as a primary index.
+	ErrPrimaryIndexNotSupported = errors.New("index type cannot be used as primary index")
+
 	// ErrEmptyIndexName indicates that a table index has an empty name.
 	ErrEmptyIndexName = errors.New("index name is empty")
 

--- a/lpm/key.go
+++ b/lpm/key.go
@@ -48,9 +48,13 @@ func NetIPPrefix4ToIndexKey(prefix netip.Prefix) index.Key {
 	)
 }
 
+func lpmDataLen(prefixLen PrefixLen) int {
+	return (int(prefixLen) + 7) / 8
+}
+
 func EncodeLPMKey(data []byte, prefixLen PrefixLen) index.Key {
-	dataLen := (prefixLen + 7) / 8
-	if int(dataLen) > len(data) {
+	dataLen := lpmDataLen(prefixLen)
+	if dataLen > len(data) {
 		panic(fmt.Sprintf("invalid LPM key, data too short (%d) for prefix length (%d)", len(data), prefixLen))
 	}
 	key := make(index.Key, dataLen, dataLen+2)
@@ -69,7 +73,7 @@ func DecodeLPMKey(key index.Key) (data []byte, prefixLen PrefixLen) {
 	}
 	data = key[:len(key)-2]
 	prefixLen = binary.BigEndian.Uint16(key[len(key)-2:])
-	if int((prefixLen+7)/8) > len(data) {
+	if lpmDataLen(prefixLen) > len(data) {
 		panic("prefix length too long in LPM key")
 	}
 	return

--- a/lpm/key.go
+++ b/lpm/key.go
@@ -30,32 +30,42 @@ func NetIPPrefixToIndexKey(prefix netip.Prefix) index.Key {
 		data[0] = 4
 		addr4 := addr.As4()
 		copy(data[1:], addr4[:])
-		return EncodeLPMKey(data[:1+len(addr4)], PrefixLen(familyBits+prefix.Bits()))
+		return mustEncodeLPMKey(data[:1+len(addr4)], PrefixLen(familyBits+prefix.Bits()))
 	}
 
 	data[0] = 6
 	addr16 := addr.As16()
 	copy(data[1:], addr16[:])
-	return EncodeLPMKey(data[:1+len(addr16)], PrefixLen(familyBits+prefix.Bits()))
+	return mustEncodeLPMKey(data[:1+len(addr16)], PrefixLen(familyBits+prefix.Bits()))
 }
 
 func NetIPPrefix4ToIndexKey(prefix netip.Prefix) index.Key {
 	addr := prefix.Addr().As4()
 	bits := prefix.Bits()
-	return EncodeLPMKey(
+	return mustEncodeLPMKey(
 		addr[:],
 		PrefixLen(bits),
 	)
+}
+
+func mustEncodeLPMKey(data []byte, prefixLen PrefixLen) index.Key {
+	key, err := EncodeLPMKey(data, prefixLen)
+	if err != nil {
+		panic(err)
+	}
+	return key
 }
 
 func lpmDataLen(prefixLen PrefixLen) int {
 	return (int(prefixLen) + 7) / 8
 }
 
-func EncodeLPMKey(data []byte, prefixLen PrefixLen) index.Key {
+// EncodeLPMKey encodes data and its prefix length as an LPM index key. It
+// returns an error if data does not contain enough bits for prefixLen.
+func EncodeLPMKey(data []byte, prefixLen PrefixLen) (index.Key, error) {
 	dataLen := lpmDataLen(prefixLen)
 	if dataLen > len(data) {
-		panic(fmt.Sprintf("invalid LPM key, data too short (%d) for prefix length (%d)", len(data), prefixLen))
+		return nil, fmt.Errorf("invalid LPM key, data too short (%d) for prefix length (%d)", len(data), prefixLen)
 	}
 	key := make(index.Key, dataLen, dataLen+2)
 	copy(key, data[:dataLen])
@@ -64,7 +74,7 @@ func EncodeLPMKey(data []byte, prefixLen PrefixLen) index.Key {
 			key[dataLen-1] &= 0xff << (8 - rem)
 		}
 	}
-	return binary.BigEndian.AppendUint16(key, prefixLen)
+	return binary.BigEndian.AppendUint16(key, prefixLen), nil
 }
 
 func DecodeLPMKey(key index.Key) (data []byte, prefixLen PrefixLen) {

--- a/lpm/key.go
+++ b/lpm/key.go
@@ -11,18 +11,32 @@ import (
 	"github.com/cilium/statedb/index"
 )
 
+// NetIPPrefixToIndexKey encodes prefix as an LPM index key. IPv4-mapped IPv6
+// prefixes contained in ::ffff:0:0/96 are canonicalized to IPv4.
 func NetIPPrefixToIndexKey(prefix netip.Prefix) index.Key {
-	addr := prefix.Addr().As16()
-	bits := prefix.Bits()
-	if prefix.Addr().Is4() {
-		// As we're working with the 16-byte format we'll need to add
-		// the 12 bytes of the IPv4-mapped IPv6 address prefix (::FFFF:).
-		bits += 12 * 8
-	}
-	return EncodeLPMKey(
-		addr[:],
-		PrefixLen(bits),
+	const (
+		familyBits           = 8
+		mappedIPv4PrefixBits = 96
 	)
+
+	prefix = prefix.Masked()
+	if prefix.Bits() >= mappedIPv4PrefixBits && prefix.Addr().Is4In6() {
+		prefix = netip.PrefixFrom(prefix.Addr().Unmap(), prefix.Bits()-mappedIPv4PrefixBits)
+	}
+
+	addr := prefix.Addr()
+	var data [1 + 16]byte
+	if addr.Is4() {
+		data[0] = 4
+		addr4 := addr.As4()
+		copy(data[1:], addr4[:])
+		return EncodeLPMKey(data[:1+len(addr4)], PrefixLen(familyBits+prefix.Bits()))
+	}
+
+	data[0] = 6
+	addr16 := addr.As16()
+	copy(data[1:], addr16[:])
+	return EncodeLPMKey(data[:1+len(addr16)], PrefixLen(familyBits+prefix.Bits()))
 }
 
 func NetIPPrefix4ToIndexKey(prefix netip.Prefix) index.Key {

--- a/lpm/trie.go
+++ b/lpm/trie.go
@@ -477,7 +477,10 @@ func lpmLookup[T any](root *lpmNode[T], key index.Key) (value T, ok bool) {
 		nodePrefixLen := node.prefixLen()
 		matchLen := longestMatch(currentLen, node, keyData, keyPrefixLen)
 		if matchLen == keyPrefixLen {
-			return node.value, !node.imaginary
+			if matchLen == nodePrefixLen && !node.imaginary {
+				return node.value, true
+			}
+			break
 		}
 		if matchLen < nodePrefixLen {
 			break

--- a/lpm/trie.go
+++ b/lpm/trie.go
@@ -232,9 +232,13 @@ func (txn *Txn[T]) Insert(key index.Key, value T) error {
 	// We found a [node] with which we matched fewer bits than are in the [key].
 	// As they can't exist in the same location we'll need to fork the tree
 	// with an imaginary node at the point where their prefixes diverge.
+	imaginaryKey, err := EncodeLPMKey(node.key, matchLen)
+	if err != nil {
+		return err
+	}
 	txn.size++
 	imaginary := &lpmNode[T]{
-		key:       EncodeLPMKey(node.key, matchLen),
+		key:       imaginaryKey,
 		imaginary: true,
 		txnID:     txn.txnID,
 	}

--- a/lpm/trie_test.go
+++ b/lpm/trie_test.go
@@ -178,6 +178,25 @@ func TestEncodeDecodeLPMKey(t *testing.T) {
 	roundtrip([]byte{0xa, 0xb}, 16)
 }
 
+func TestEncodeDecodeLPMKeyMaxPrefixLen(t *testing.T) {
+	maxPrefixLen := PrefixLen(^uint16(0))
+	dataLen := (int(maxPrefixLen) + 7) / 8
+	data := make([]byte, dataLen)
+	data[len(data)-1] = 0xff
+
+	key := EncodeLPMKey(data, maxPrefixLen)
+	require.Len(t, key, dataLen+2)
+
+	decoded, prefixLen := DecodeLPMKey(key)
+	require.Equal(t, maxPrefixLen, prefixLen)
+	require.Len(t, decoded, dataLen)
+	require.Equal(t, byte(0xfe), decoded[len(decoded)-1])
+
+	require.Panics(t, func() {
+		DecodeLPMKey(index.Key{0xff, 0xff})
+	})
+}
+
 func TestDeleteCompressionInvariants(t *testing.T) {
 	prefix := func(p string) index.Key {
 		key := netip.MustParsePrefix(p)

--- a/lpm/trie_test.go
+++ b/lpm/trie_test.go
@@ -43,7 +43,7 @@ func TestTrie(t *testing.T) {
 
 	prefix := func(p string) index.Key {
 		key := netip.MustParsePrefix(p)
-		return EncodeLPMKey(key.Addr().AsSlice(), uint16(key.Bits()))
+		return mustEncodeLPMKey(key.Addr().AsSlice(), uint16(key.Bits()))
 	}
 
 	txn := lpm.Txn()
@@ -59,7 +59,7 @@ func TestTrie(t *testing.T) {
 
 	lookupAddr := func(addrS string) (int, bool) {
 		addr := netip.MustParseAddr(addrS)
-		return lpm.Lookup(EncodeLPMKey(addr.AsSlice(), 32))
+		return lpm.Lookup(mustEncodeLPMKey(addr.AsSlice(), 32))
 	}
 
 	for i, c := range cases {
@@ -119,7 +119,7 @@ func TestTrie(t *testing.T) {
 	require.Empty(t, values)
 
 	txn = lpm.Txn()
-	v, found = txn.Delete(EncodeLPMKey(netip.MustParseAddr("10.1.1.1").AsSlice(), 32))
+	v, found = txn.Delete(mustEncodeLPMKey(netip.MustParseAddr("10.1.1.1").AsSlice(), 32))
 	lpm = txn.Commit()
 	require.True(t, found)
 	require.Equal(t, 999, v)
@@ -129,10 +129,10 @@ func TestTrieLookupQueryEndsAtCompressedNode(t *testing.T) {
 	t.Run("more specific node", func(t *testing.T) {
 		trie := New[string]()
 		txn := trie.Txn()
-		require.NoError(t, txn.Insert(EncodeLPMKey([]byte{0}, 2), "00/2"))
+		require.NoError(t, txn.Insert(mustEncodeLPMKey([]byte{0}, 2), "00/2"))
 		trie = txn.Commit()
 
-		value, found := trie.Lookup(EncodeLPMKey([]byte{0}, 1))
+		value, found := trie.Lookup(mustEncodeLPMKey([]byte{0}, 1))
 		require.False(t, found)
 		require.Empty(t, value)
 	})
@@ -140,12 +140,12 @@ func TestTrieLookupQueryEndsAtCompressedNode(t *testing.T) {
 	t.Run("imaginary node", func(t *testing.T) {
 		trie := New[string]()
 		txn := trie.Txn()
-		require.NoError(t, txn.Insert(EncodeLPMKey(nil, 0), "default"))
-		require.NoError(t, txn.Insert(EncodeLPMKey([]byte{0}, 2), "00/2"))
-		require.NoError(t, txn.Insert(EncodeLPMKey([]byte{64}, 2), "01/2"))
+		require.NoError(t, txn.Insert(mustEncodeLPMKey(nil, 0), "default"))
+		require.NoError(t, txn.Insert(mustEncodeLPMKey([]byte{0}, 2), "00/2"))
+		require.NoError(t, txn.Insert(mustEncodeLPMKey([]byte{64}, 2), "01/2"))
 		trie = txn.Commit()
 
-		value, found := trie.Lookup(EncodeLPMKey([]byte{0}, 1))
+		value, found := trie.Lookup(mustEncodeLPMKey([]byte{0}, 1))
 		require.True(t, found)
 		require.Equal(t, "default", value)
 	})
@@ -165,7 +165,7 @@ func TestEncodeDecodeLPMKey(t *testing.T) {
 		return masked
 	}
 	roundtrip := func(data []byte, prefixLen PrefixLen) {
-		key := EncodeLPMKey(data, prefixLen)
+		key := mustEncodeLPMKey(data, prefixLen)
 		assert.Len(t, key, 2+((int(prefixLen)+7)/8))
 		data2, prefixLen2 := DecodeLPMKey(key)
 		assert.Equal(t, prefixLen, prefixLen2)
@@ -184,7 +184,7 @@ func TestEncodeDecodeLPMKeyMaxPrefixLen(t *testing.T) {
 	data := make([]byte, dataLen)
 	data[len(data)-1] = 0xff
 
-	key := EncodeLPMKey(data, maxPrefixLen)
+	key := mustEncodeLPMKey(data, maxPrefixLen)
 	require.Len(t, key, dataLen+2)
 
 	decoded, prefixLen := DecodeLPMKey(key)
@@ -200,7 +200,7 @@ func TestEncodeDecodeLPMKeyMaxPrefixLen(t *testing.T) {
 func TestDeleteCompressionInvariants(t *testing.T) {
 	prefix := func(p string) index.Key {
 		key := netip.MustParsePrefix(p)
-		return EncodeLPMKey(key.Addr().AsSlice(), uint16(key.Bits()))
+		return mustEncodeLPMKey(key.Addr().AsSlice(), uint16(key.Bits()))
 	}
 
 	var assertNoImaginarySingleChild func(*lpmNode[int])
@@ -253,7 +253,7 @@ func TestQuickRoundTripEncodeDecodeLPMKey(t *testing.T) {
 	check := func(data []byte, prefixLen uint8) bool {
 		prefixLen = prefixLen % 128
 		prefixLen = min(prefixLen, uint8(len(data)*8))
-		key := EncodeLPMKey(data, PrefixLen(prefixLen))
+		key := mustEncodeLPMKey(data, PrefixLen(prefixLen))
 		assert.Len(t, key, 2+((int(prefixLen)+7)/8))
 		data2, prefixLen2 := DecodeLPMKey(key)
 		assert.Equal(t, PrefixLen(prefixLen), prefixLen2)
@@ -387,7 +387,7 @@ func FuzzLPMTrie(f *testing.F) {
 			}
 
 			txn := tree.Txn()
-			txn.Insert(EncodeLPMKey([]byte{k}, PrefixLen(prefixLen)), seen[seenk])
+			txn.Insert(mustEncodeLPMKey([]byte{k}, PrefixLen(prefixLen)), seen[seenk])
 			tree = txn.Commit()
 			if tree.size != len(seen) {
 				t.Errorf("unexpected length after insert of %s: %d (expected %d), root %+v", seenk, tree.size, len(seen), tree.root)
@@ -396,7 +396,7 @@ func FuzzLPMTrie(f *testing.F) {
 
 		// Now, validate
 		for seenK, seenV := range seen {
-			val, found := tree.Lookup(EncodeLPMKey([]byte{seenV.k}, PrefixLen(seenV.plen)))
+			val, found := tree.Lookup(mustEncodeLPMKey([]byte{seenV.k}, PrefixLen(seenV.plen)))
 			if !found {
 				t.Errorf("value %s not found", seenK)
 			}
@@ -411,7 +411,7 @@ func FuzzLPMTrie(f *testing.F) {
 			oldTree := tree
 
 			// Check that the value is still in the tree
-			val, found := tree.Lookup(EncodeLPMKey([]byte{seenV.k}, PrefixLen(seenV.plen)))
+			val, found := tree.Lookup(mustEncodeLPMKey([]byte{seenV.k}, PrefixLen(seenV.plen)))
 			if !found {
 				t.Errorf("value %s not found", seenK)
 			} else if val.val != seenV.val {
@@ -419,7 +419,7 @@ func FuzzLPMTrie(f *testing.F) {
 			}
 
 			txn := tree.Txn()
-			v, found := txn.Delete(EncodeLPMKey([]byte{seenV.k}, PrefixLen(seenV.plen)))
+			v, found := txn.Delete(mustEncodeLPMKey([]byte{seenV.k}, PrefixLen(seenV.plen)))
 			tree = txn.Commit()
 			if !found {
 				t.Errorf("value %s to be deleted not found, root %+v, size %d", seenK, oldTree.root, oldTree.size)

--- a/lpm/trie_test.go
+++ b/lpm/trie_test.go
@@ -125,6 +125,32 @@ func TestTrie(t *testing.T) {
 	require.Equal(t, 999, v)
 }
 
+func TestTrieLookupQueryEndsAtCompressedNode(t *testing.T) {
+	t.Run("more specific node", func(t *testing.T) {
+		trie := New[string]()
+		txn := trie.Txn()
+		require.NoError(t, txn.Insert(EncodeLPMKey([]byte{0}, 2), "00/2"))
+		trie = txn.Commit()
+
+		value, found := trie.Lookup(EncodeLPMKey([]byte{0}, 1))
+		require.False(t, found)
+		require.Empty(t, value)
+	})
+
+	t.Run("imaginary node", func(t *testing.T) {
+		trie := New[string]()
+		txn := trie.Txn()
+		require.NoError(t, txn.Insert(EncodeLPMKey(nil, 0), "default"))
+		require.NoError(t, txn.Insert(EncodeLPMKey([]byte{0}, 2), "00/2"))
+		require.NoError(t, txn.Insert(EncodeLPMKey([]byte{64}, 2), "01/2"))
+		trie = txn.Commit()
+
+		value, found := trie.Lookup(EncodeLPMKey([]byte{0}, 1))
+		require.True(t, found)
+		require.Equal(t, "default", value)
+	})
+}
+
 func TestEncodeDecodeLPMKey(t *testing.T) {
 	maskData := func(data []byte, prefixLen PrefixLen) []byte {
 		dataLen := (prefixLen + 7) / 8

--- a/lpm/validate.go
+++ b/lpm/validate.go
@@ -43,7 +43,7 @@ func validateTrie[T any](node *lpmNode[T], parents []*lpmNode[T], maxTxnID uint6
 	}
 
 	data, prefixLen := DecodeLPMKey(node.key)
-	dataLen := int((prefixLen + 7) / 8)
+	dataLen := lpmDataLen(prefixLen)
 	assert(len(node.key) == dataLen+2, "key length mismatch for %s", showKey(node.key))
 	assert(len(data) == dataLen, "key data length mismatch for %s", showKey(node.key))
 

--- a/lpm_index.go
+++ b/lpm_index.go
@@ -570,12 +570,14 @@ func (e *lpmEntry) upsert(primaryKey index.Key, obj object) bool {
 	case -1:
 		oldHead := e.head
 		e.head = lpmEntryObject{primary: primaryKey, obj: obj}
+		e.tail = slices.Clone(e.tail)
 		e.tail = append(e.tail, lpmEntryObject{})
 		copy(e.tail[1:], e.tail[:len(e.tail)-1])
 		e.tail[0] = oldHead
 		return true
 	}
 	idx, found := e.searchTail(primaryKey)
+	e.tail = slices.Clone(e.tail)
 	if found {
 		e.tail[idx].obj = obj
 		return false

--- a/lpm_index.go
+++ b/lpm_index.go
@@ -84,6 +84,8 @@ func (a NetIPPrefixIndex[Obj]) isIndexerOf(Obj) {
 	panic("isIndexerOf")
 }
 
+func (a NetIPPrefixIndex[Obj]) secondaryOnly() {}
+
 func (i NetIPPrefixIndex[Obj]) isUnique() bool {
 	return i.Unique
 }
@@ -126,6 +128,8 @@ type LPMIndex[Obj any] struct {
 func (l LPMIndex[Obj]) isIndexerOf(Obj) {
 	panic("isIndexerOf")
 }
+
+func (l LPMIndex[Obj]) secondaryOnly() {}
 
 // fromString implements Indexer.
 func (l LPMIndex[Obj]) fromString(s string) (index.Key, error) {

--- a/lpm_index.go
+++ b/lpm_index.go
@@ -137,7 +137,7 @@ func (l LPMIndex[Obj]) fromString(s string) (index.Key, error) {
 	if err != nil {
 		return index.Key{}, err
 	}
-	return lpm.EncodeLPMKey(data, plen), nil
+	return lpm.EncodeLPMKey(data, plen)
 }
 
 // indexName implements Indexer.
@@ -152,19 +152,24 @@ func (l LPMIndex[Obj]) ObjectToKey(obj Obj) index.Key {
 	return nil
 }
 
-// Query constructs a query against the index with the given prefix.
-func (l LPMIndex[Obj]) Query(data []byte, prefixLen lpm.PrefixLen) Query[Obj] {
+// Query constructs a query against the index with the given prefix. It returns
+// an error if data does not contain enough bits for prefixLen.
+func (l LPMIndex[Obj]) Query(data []byte, prefixLen lpm.PrefixLen) (Query[Obj], error) {
+	key, err := lpm.EncodeLPMKey(data, prefixLen)
+	if err != nil {
+		return Query[Obj]{}, err
+	}
 	return Query[Obj]{
 		index: l.Name,
-		key:   lpm.EncodeLPMKey(data, prefixLen),
-	}
+		key:   key,
+	}, nil
 }
 
 func (l LPMIndex[Obj]) QueryFromObject(obj Obj) Query[Obj] {
 	for key, length := range l.FromObject(obj) {
 		return Query[Obj]{
 			index: l.Name,
-			key:   lpm.EncodeLPMKey(key, length),
+			key:   mustEncodeLPMKey(key, length),
 		}
 	}
 	return Query[Obj]{}
@@ -178,7 +183,7 @@ func (l LPMIndex[Obj]) newTableIndex() tableIndex {
 		objectToKeys: func(obj object) index.KeySet {
 			keys := make([]index.Key, 0, 2)
 			for data, prefixLen := range l.FromObject(obj.data.(Obj)) {
-				keys = append(keys, lpm.EncodeLPMKey(data, prefixLen))
+				keys = append(keys, mustEncodeLPMKey(data, prefixLen))
 			}
 			return index.NewKeySet(keys...)
 		},
@@ -188,6 +193,14 @@ func (l LPMIndex[Obj]) newTableIndex() tableIndex {
 
 func (l LPMIndex[Obj]) isUnique() bool {
 	return l.Unique
+}
+
+func mustEncodeLPMKey(data []byte, prefixLen lpm.PrefixLen) index.Key {
+	key, err := lpm.EncodeLPMKey(data, prefixLen)
+	if err != nil {
+		panic(err)
+	}
+	return key
 }
 
 var _ Indexer[struct{}] = LPMIndex[struct{}]{}

--- a/lpm_index.go
+++ b/lpm_index.go
@@ -200,11 +200,11 @@ type lpmIndex struct {
 
 // all implements tableIndex.
 func (l lpmIndex) all() (tableIndexIterator, <-chan struct{}) {
-	return newLPMIterator(l.lpm.All()), l.watch
+	return newLPMIterator(l.lpm.All(), !l.unique), l.watch
 }
 
 func (l lpmIndex) allNoWatch() tableIndexIterator {
-	return newLPMIterator(l.lpm.All())
+	return newLPMIterator(l.lpm.All(), !l.unique)
 }
 
 // get implements tableIndex.
@@ -251,11 +251,11 @@ func (l lpmIndex) listNoWatch(key index.Key) tableIndexIterator {
 
 // lowerBound implements tableIndex.
 func (l lpmIndex) lowerBound(key index.Key) (tableIndexIterator, <-chan struct{}) {
-	return newLPMIterator(l.lpm.LowerBound(key)), l.watch
+	return newLPMIterator(l.lpm.LowerBound(key), !l.unique), l.watch
 }
 
 func (l lpmIndex) lowerBoundNoWatch(key index.Key) tableIndexIterator {
-	return newLPMIterator(l.lpm.LowerBound(key))
+	return newLPMIterator(l.lpm.LowerBound(key), !l.unique)
 }
 
 // lowerBoundNext implements tableIndexTxn.
@@ -274,11 +274,11 @@ func (l lpmIndex) objectToKey(obj object) index.Key {
 
 // prefix implements tableIndex.
 func (l lpmIndex) prefix(key index.Key) (tableIndexIterator, <-chan struct{}) {
-	return newLPMIterator(l.lpm.Prefix(key)), l.watch
+	return newLPMIterator(l.lpm.Prefix(key), !l.unique), l.watch
 }
 
 func (l lpmIndex) prefixNoWatch(key index.Key) tableIndexIterator {
-	return newLPMIterator(l.lpm.Prefix(key))
+	return newLPMIterator(l.lpm.Prefix(key), !l.unique)
 }
 
 // rootWatch implements tableIndex.
@@ -316,11 +316,11 @@ type lpmIndexTxn struct {
 
 // all implements tableIndexTxn.
 func (l *lpmIndexTxn) all() (tableIndexIterator, <-chan struct{}) {
-	return newLPMIterator(l.tx.All()), l.index.watch
+	return newLPMIterator(l.tx.All(), !l.index.unique), l.index.watch
 }
 
 func (l *lpmIndexTxn) allNoWatch() tableIndexIterator {
-	return newLPMIterator(l.tx.All())
+	return newLPMIterator(l.tx.All(), !l.index.unique)
 }
 
 // commit implements tableIndexTxn.
@@ -404,11 +404,11 @@ func (l *lpmIndexTxn) listNoWatch(key index.Key) tableIndexIterator {
 
 // lowerBound implements tableIndexTxn.
 func (l *lpmIndexTxn) lowerBound(key index.Key) (tableIndexIterator, <-chan struct{}) {
-	return newLPMIterator(l.tx.LowerBound(key)), l.index.watch
+	return newLPMIterator(l.tx.LowerBound(key), !l.index.unique), l.index.watch
 }
 
 func (l *lpmIndexTxn) lowerBoundNoWatch(key index.Key) tableIndexIterator {
-	return newLPMIterator(l.tx.LowerBound(key))
+	return newLPMIterator(l.tx.LowerBound(key), !l.index.unique)
 }
 
 // lowerBoundNext implements tableIndexTxn.
@@ -435,11 +435,11 @@ func (l *lpmIndexTxn) objectToKey(obj object) index.Key {
 
 // prefix implements tableIndexTxn.
 func (l *lpmIndexTxn) prefix(key index.Key) (tableIndexIterator, <-chan struct{}) {
-	return newLPMIterator(l.tx.Prefix(key)), l.index.watch
+	return newLPMIterator(l.tx.Prefix(key), !l.index.unique), l.index.watch
 }
 
 func (l *lpmIndexTxn) prefixNoWatch(key index.Key) tableIndexIterator {
-	return newLPMIterator(l.tx.Prefix(key))
+	return newLPMIterator(l.tx.Prefix(key), !l.index.unique)
 }
 
 // reindex implements tableIndexTxn.
@@ -657,17 +657,38 @@ func (e *lpmEntry) appendObjects(dst []object) []object {
 }
 
 type lpmIteratorAdapter struct {
-	iter *lpm.Iterator[lpmEntry]
+	iter        *lpm.Iterator[lpmEntry]
+	deduplicate bool
 }
 
-func newLPMIterator(iter *lpm.Iterator[lpmEntry]) tableIndexIterator {
-	return &lpmIteratorAdapter{iter: iter}
+func newLPMIterator(iter *lpm.Iterator[lpmEntry], deduplicate bool) tableIndexIterator {
+	return &lpmIteratorAdapter{iter: iter, deduplicate: deduplicate}
 }
 
 func (l *lpmIteratorAdapter) All(yield func([]byte, object) bool) {
+	var visited map[string]struct{}
+	if l.deduplicate {
+		visited = map[string]struct{}{}
+	}
+	emit := func(key []byte, entry lpmEntryObject) bool {
+		if visited != nil {
+			primary := string(entry.primary)
+			if _, found := visited[primary]; found {
+				return true
+			}
+			visited[primary] = struct{}{}
+		}
+		return yield(key, entry.obj)
+	}
 	l.iter.All(func(key []byte, entry lpmEntry) bool {
-		for _, obj := range entry.All {
-			if !yield(key, obj) {
+		if !entry.used {
+			return true
+		}
+		if !emit(key, entry.head) {
+			return false
+		}
+		for _, obj := range entry.tail {
+			if !emit(key, obj) {
 				return false
 			}
 		}

--- a/lpm_index.go
+++ b/lpm_index.go
@@ -13,8 +13,8 @@ import (
 	"github.com/cilium/statedb/lpm"
 )
 
-// NetIPPrefixIndex indexes objects with a [netip.Prefix] in a LPM
-// index.
+// NetIPPrefixIndex indexes objects with a [netip.Prefix] in a LPM index.
+// IPv4-mapped IPv6 addresses and prefixes are canonicalized to IPv4.
 type NetIPPrefixIndex[Obj any] struct {
 	// Name of the index
 	Name string
@@ -29,10 +29,9 @@ type NetIPPrefixIndex[Obj any] struct {
 }
 
 func (a NetIPPrefixIndex[Obj]) Query(addr netip.Addr) Query[Obj] {
-	addr16 := addr.As16()
 	return Query[Obj]{
 		index: a.Name,
-		key:   lpm.EncodeLPMKey(addr16[:], 128),
+		key:   lpm.NetIPPrefixToIndexKey(netip.PrefixFrom(addr, addr.BitLen())),
 	}
 }
 

--- a/lpm_index_test.go
+++ b/lpm_index_test.go
@@ -288,6 +288,45 @@ func TestLPMIndexNonUniqueSnapshotIsolation(t *testing.T) {
 	require.Equal(t, prefix2, objs[1].Prefix, "uncommitted update leaked into old snapshot")
 }
 
+func TestLPMIndexIterationDeduplicatesObjects(t *testing.T) {
+	db := New()
+	multiPortIndex := LPMIndex[lpmTestObject]{
+		Name:   "multi-port",
+		Unique: false,
+		FromObject: func(obj lpmTestObject) iter.Seq2[[]byte, lpm.PrefixLen] {
+			return func(yield func([]byte, lpm.PrefixLen) bool) {
+				key := binary.BigEndian.AppendUint16(nil, obj.Port)
+				if !yield(key, 8) {
+					return
+				}
+				yield(key, 16)
+			}
+		},
+	}
+	tbl, err := NewTable(db, "lpm-deduplicate", lpmIDIndex, multiPortIndex)
+	require.NoError(t, err)
+
+	wtxn := db.WriteTxn(tbl)
+	_, _, err = tbl.Insert(wtxn, lpmTestObject{ID: 1, Port: 0x1234})
+	require.NoError(t, err)
+	rtxn := wtxn.Commit()
+
+	key := binary.BigEndian.AppendUint16(nil, 0x1200)
+	objs := Collect(tbl.Prefix(rtxn, multiPortIndex.Query(key, 8)))
+	require.Equal(t, []uint16{1}, toLPMTestObjectIDs(objs))
+
+	objs = Collect(tbl.LowerBound(rtxn, multiPortIndex.Query(nil, 0)))
+	require.Equal(t, []uint16{1}, toLPMTestObjectIDs(objs))
+}
+
+func toLPMTestObjectIDs(objs []lpmTestObject) []uint16 {
+	ids := make([]uint16, len(objs))
+	for i, obj := range objs {
+		ids[i] = obj.ID
+	}
+	return ids
+}
+
 func TestLPMIndexIteratorNonUnique(t *testing.T) {
 	idx := lpmIndex{
 		lpm:          lpm.New[lpmEntry](),

--- a/lpm_index_test.go
+++ b/lpm_index_test.go
@@ -201,6 +201,39 @@ func TestLPMIndex(t *testing.T) {
 	require.Empty(t, objs)
 }
 
+func TestNetIPPrefixIndexCanonicalizesMappedIPv4(t *testing.T) {
+	db := New()
+	tbl := newLPMTestTable(db)
+
+	wtxn := db.WriteTxn(tbl)
+	_, _, err := tbl.Insert(wtxn, lpmTestObject{
+		ID:     1,
+		Prefix: netip.MustParsePrefix("::ffff:10.0.0.0/104"),
+	})
+	require.NoError(t, err)
+	_, _, err = tbl.Insert(wtxn, lpmTestObject{
+		ID:     2,
+		Prefix: netip.MustParsePrefix("::/0"),
+	})
+	require.NoError(t, err)
+	rtxn := wtxn.Commit()
+
+	obj, _, found := tbl.Get(rtxn, lpmPrefixIndex.Query(netip.MustParseAddr("10.1.2.3")))
+	require.True(t, found)
+	require.EqualValues(t, 1, obj.ID)
+
+	obj, _, found = tbl.Get(rtxn, lpmPrefixIndex.Query(netip.MustParseAddr("::ffff:10.1.2.3")))
+	require.True(t, found)
+	require.EqualValues(t, 1, obj.ID)
+
+	_, _, found = tbl.Get(rtxn, lpmPrefixIndex.Query(netip.MustParseAddr("192.0.2.1")))
+	require.False(t, found, "IPv6 default route must not match an IPv4 address")
+
+	obj, _, found = tbl.Get(rtxn, lpmPrefixIndex.Query(netip.MustParseAddr("2001:db8::1")))
+	require.True(t, found)
+	require.EqualValues(t, 2, obj.ID)
+}
+
 func TestLPMIndexNonUnique(t *testing.T) {
 	db := New()
 	tbl := newLPMNonUniqueTestTable(db)

--- a/lpm_index_test.go
+++ b/lpm_index_test.go
@@ -113,6 +113,20 @@ func newLPMNonUniqueTestTable(db *DB) RWTable[lpmTestObject] {
 	return t
 }
 
+func mustLPMQuery[Obj any](idx LPMIndex[Obj], data []byte, prefixLen lpm.PrefixLen) Query[Obj] {
+	query, err := idx.Query(data, prefixLen)
+	if err != nil {
+		panic(err)
+	}
+	return query
+}
+
+func TestLPMIndexQueryRejectsShortData(t *testing.T) {
+	query, err := lpmPortIndex.Query([]byte{0xff}, 9)
+	require.Equal(t, Query[lpmTestObject]{}, query)
+	require.EqualError(t, err, "invalid LPM key, data too short (1) for prefix length (9)")
+}
+
 func TestNewTableRejectsLPMPrimaryIndex(t *testing.T) {
 	for _, test := range []struct {
 		name    string
@@ -161,7 +175,7 @@ func TestLPMIndex(t *testing.T) {
 	})
 	txn := wtxn.Commit()
 
-	obj, _, found := tbl.Get(txn, lpmPortIndex.Query([]byte{0xff, 0x11}, 16))
+	obj, _, found := tbl.Get(txn, mustLPMQuery(lpmPortIndex, []byte{0xff, 0x11}, 16))
 	require.True(t, found)
 	require.EqualValues(t, 1, obj.ID)
 
@@ -277,17 +291,17 @@ func TestLPMIndexNonUnique(t *testing.T) {
 	txn := wtxn.Commit()
 
 	// Get returns the first matching object.
-	obj, _, found := tbl.Get(txn, lpmPortNonUniqueIndex.Query(key, 16))
+	obj, _, found := tbl.Get(txn, mustLPMQuery(lpmPortNonUniqueIndex, key, 16))
 	require.True(t, found)
 	require.EqualValues(t, 10, obj.ID)
 
 	// List returns all matches for the key.
-	objs := Collect(tbl.List(txn, lpmPortNonUniqueIndex.Query(key, 16)))
+	objs := Collect(tbl.List(txn, mustLPMQuery(lpmPortNonUniqueIndex, key, 16)))
 	require.Len(t, objs, 2)
 	require.EqualValues(t, []uint16{10, 20}, []uint16{objs[0].ID, objs[1].ID})
 
 	// Prefix iteration returns all objects matching the broader prefix.
-	objs = Collect(tbl.Prefix(txn, lpmPortNonUniqueIndex.Query(key, 8)))
+	objs = Collect(tbl.Prefix(txn, mustLPMQuery(lpmPortNonUniqueIndex, key, 8)))
 	require.Len(t, objs, 3)
 	require.ElementsMatch(t, []uint16{10, 20, 30}, []uint16{objs[0].ID, objs[1].ID, objs[2].ID})
 
@@ -298,7 +312,7 @@ func TestLPMIndexNonUnique(t *testing.T) {
 	require.EqualValues(t, 10, old.ID)
 	txn = wtxn.Commit()
 
-	objs = Collect(tbl.List(txn, lpmPortNonUniqueIndex.Query(key, 16)))
+	objs = Collect(tbl.List(txn, mustLPMQuery(lpmPortNonUniqueIndex, key, 16)))
 	require.Len(t, objs, 1)
 	require.EqualValues(t, 20, objs[0].ID)
 }
@@ -331,7 +345,7 @@ func TestLPMIndexNonUniqueSnapshotIsolation(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	objs := Collect(tbl.List(oldSnapshot, lpmPortNonUniqueIndex.Query(key, 16)))
+	objs := Collect(tbl.List(oldSnapshot, mustLPMQuery(lpmPortNonUniqueIndex, key, 16)))
 	require.Len(t, objs, 2)
 	require.Equal(t, prefix2, objs[1].Prefix, "uncommitted update leaked into old snapshot")
 }
@@ -360,10 +374,10 @@ func TestLPMIndexIterationDeduplicatesObjects(t *testing.T) {
 	rtxn := wtxn.Commit()
 
 	key := binary.BigEndian.AppendUint16(nil, 0x1200)
-	objs := Collect(tbl.Prefix(rtxn, multiPortIndex.Query(key, 8)))
+	objs := Collect(tbl.Prefix(rtxn, mustLPMQuery(multiPortIndex, key, 8)))
 	require.Equal(t, []uint16{1}, toLPMTestObjectIDs(objs))
 
-	objs = Collect(tbl.LowerBound(rtxn, multiPortIndex.Query(nil, 0)))
+	objs = Collect(tbl.LowerBound(rtxn, mustLPMQuery(multiPortIndex, nil, 0)))
 	require.Equal(t, []uint16{1}, toLPMTestObjectIDs(objs))
 }
 
@@ -400,14 +414,14 @@ func TestLPMIndexIteratorNonUnique(t *testing.T) {
 		}
 	}
 
-	key16 := lpm.EncodeLPMKey(binary.BigEndian.AppendUint16(nil, 0x1234), 16)
-	key8 := lpm.EncodeLPMKey(binary.BigEndian.AppendUint16(nil, 0x1200), 8)
+	key16 := mustEncodeLPMKey(binary.BigEndian.AppendUint16(nil, 0x1234), 16)
+	key8 := mustEncodeLPMKey(binary.BigEndian.AppendUint16(nil, 0x1200), 8)
 
 	txn.insertKey(index.Uint16(10), key16, obj(10, 0x1234, 16, netip.MustParsePrefix("10.0.0.0/8")))
 	txn.insertKey(index.Uint16(20), key16, obj(20, 0x1234, 16, netip.MustParsePrefix("10.0.0.0/8")))
 	txn.insertKey(index.Uint16(30), key8, obj(30, 0x1200, 8, netip.MustParsePrefix("10.1.0.0/16")))
 
-	iter, _ := txn.prefix(lpm.EncodeLPMKey(binary.BigEndian.AppendUint16(nil, 0x1200), 8))
+	iter, _ := txn.prefix(mustEncodeLPMKey(binary.BigEndian.AppendUint16(nil, 0x1200), 8))
 	var ids []uint16
 	iter.All(func(_ []byte, obj object) bool {
 		ids = append(ids, obj.data.(lpmTestObject).ID)
@@ -577,7 +591,7 @@ func TestQuickLPMIndexNonUnique(t *testing.T) {
 		}
 
 		key := binary.BigEndian.AppendUint16(nil, port)
-		listObjs := Collect(tbl.List(rtxn, lpmPortNonUniqueIndex.Query(key, 16)))
+		listObjs := Collect(tbl.List(rtxn, mustLPMQuery(lpmPortNonUniqueIndex, key, 16)))
 		expectedIDs := longestMatch(port)
 		listIDs := toIDs(listObjs)
 		if !slices.Equal(expectedIDs, listIDs) {
@@ -585,7 +599,7 @@ func TestQuickLPMIndexNonUnique(t *testing.T) {
 			return false
 		}
 
-		obj, _, found := tbl.Get(rtxn, lpmPortNonUniqueIndex.Query(key, 16))
+		obj, _, found := tbl.Get(rtxn, mustLPMQuery(lpmPortNonUniqueIndex, key, 16))
 		if len(expectedIDs) > 0 && !found {
 			t.Logf("expected result but Get returned no object")
 			return false

--- a/lpm_index_test.go
+++ b/lpm_index_test.go
@@ -113,6 +113,21 @@ func newLPMNonUniqueTestTable(db *DB) RWTable[lpmTestObject] {
 	return t
 }
 
+func TestNewTableRejectsLPMPrimaryIndex(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		indexer Indexer[lpmTestObject]
+	}{
+		{"NetIPPrefixIndex", lpmPrefixIndex},
+		{"LPMIndex", lpmPortIndex},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := NewTable(New(), "lpm-primary", test.indexer)
+			require.Error(t, err)
+		})
+	}
+}
+
 func TestLPMIndex(t *testing.T) {
 	db := New()
 	tbl := newLPMTestTable(db)

--- a/lpm_index_test.go
+++ b/lpm_index_test.go
@@ -255,6 +255,39 @@ func TestLPMIndexNonUnique(t *testing.T) {
 	require.EqualValues(t, 20, objs[0].ID)
 }
 
+func TestLPMIndexNonUniqueSnapshotIsolation(t *testing.T) {
+	db := New()
+	tbl := newLPMNonUniqueTestTable(db)
+
+	key := binary.BigEndian.AppendUint16(nil, 0x1234)
+	prefix1 := netip.MustParsePrefix("10.0.0.0/8")
+	prefix2 := netip.MustParsePrefix("10.1.0.0/16")
+
+	wtxn := db.WriteTxn(tbl)
+	for _, obj := range []lpmTestObject{
+		{ID: 10, Prefix: prefix1, Port: 0x1234, PortPrefixLen: 16},
+		{ID: 20, Prefix: prefix2, Port: 0x1234, PortPrefixLen: 16},
+	} {
+		_, _, err := tbl.Insert(wtxn, obj)
+		require.NoError(t, err)
+	}
+	oldSnapshot := wtxn.Commit()
+
+	wtxn = db.WriteTxn(tbl)
+	defer wtxn.Abort()
+	_, _, err := tbl.Insert(wtxn, lpmTestObject{
+		ID:            20,
+		Prefix:        netip.MustParsePrefix("10.1.1.0/24"),
+		Port:          0x1234,
+		PortPrefixLen: 16,
+	})
+	require.NoError(t, err)
+
+	objs := Collect(tbl.List(oldSnapshot, lpmPortNonUniqueIndex.Query(key, 16)))
+	require.Len(t, objs, 2)
+	require.Equal(t, prefix2, objs[1].Prefix, "uncommitted update leaked into old snapshot")
+}
+
 func TestLPMIndexIteratorNonUnique(t *testing.T) {
 	idx := lpmIndex{
 		lpm:          lpm.New[lpmEntry](),

--- a/table.go
+++ b/table.go
@@ -85,6 +85,10 @@ func NewTableAny[Obj any](
 		return nil, tableError(tableName, ErrEmptyIndexName)
 	}
 
+	if _, secondaryOnly := primaryIndexer.(secondaryOnlyIndexer); secondaryOnly {
+		return nil, tableError(tableName, ErrPrimaryIndexNotSupported)
+	}
+
 	// Primary index must always be unique
 	if !primaryIndexer.isUnique() {
 		return nil, tableError(tableName, ErrPrimaryIndexNotUnique)

--- a/testdata/db.txtar
+++ b/testdata/db.txtar
@@ -84,8 +84,8 @@ cmp obj2.yaml obj2_get.yaml
 db/get -i prefix -f yaml -o obj1_get.yaml test1 10.0.0.0/8
 cmp obj1.yaml obj1_get.yaml
 
-db/get -i prefix -f yaml -o obj2_get.yaml test1 10.1.0.0/16
-cmp obj2.yaml obj2_get.yaml
+db/get -i prefix -f yaml -o obj1_get.yaml test1 10.1.0.0/16
+cmp obj1.yaml obj1_get.yaml
 
 # List
 db/list -o=list.table test1 1

--- a/types.go
+++ b/types.go
@@ -322,6 +322,12 @@ type Indexer[Obj any] interface {
 	newTableIndex() tableIndex
 }
 
+// secondaryOnlyIndexer marks index implementations that cannot be used as a
+// table's primary index.
+type secondaryOnlyIndexer interface {
+	secondaryOnly()
+}
+
 // TableWritable is a constraint for objects that implement tabular
 // pretty-printing. Used by the "db" script commands to render a table.
 type TableWritable interface {


### PR DESCRIPTION
- Preserve all objects sharing a key in non-unique LPM indexes instead of overwriting earlier entries.
- Correct lookups for keys terminating within compressed trie paths.
- Deduplicate objects indexed under multiple matching prefixes in non-unique LPM query results.
- Canonicalize IPv4-mapped IPv6 to IPv4 while keeping ordinary IPv6 lookups isolated.
- Reject LPM indexes as primary table indexes because the LPM indexer doesn't implement all required methods for primary index.
- Prevent prefix-length arithmetic from overflowing for maximum-length LPM keys.

See commits for detailed descriptions.