### PR TITLE
ci: run on release branches, ignore comment failure on forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - main
+    - 'v0.*'
 
 env:
   GO_VERSION: 1.25.6

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,8 +35,8 @@ jobs:
 
       - name: results
         if: success() || failure()
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
         uses: thollander/actions-comment-pull-request@v3
         with:
           comment-tag: results
           file-path: results.comment
-

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
     - main
+    - 'v0.*'
 
 env:
   GO_VERSION: 1.25.6


### PR DESCRIPTION
- Run the main and PR workflows in the release branches
- Skip the failure to post a comment to the PR