### PR TITLE
docs: align README id index key encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ func (o *MyObject) TableRow() []string {
 var IDIndex = statedb.Index[*MyObject, uint32]{
   Name: "id",
   FromObject: func(obj *MyObject) index.KeySet {
-    return index.NewKeySet(index.Uint64(obj.ID))
+    return index.NewKeySet(index.Uint32(obj.ID))
   },
   FromKey: func(id uint32) index.Key {
     return index.Uint32(id)


### PR DESCRIPTION
In the first README example `ID` is `uint32`, but `FromObject` encodes with `index.Uint64` while `FromKey` uses `index.Uint32`. 
Stored key is 8 bytes, query key 4 bytes, they never match, so `Get` always misses and the Modify/Delete steps below it become no-ops. 
`index.Uint64(obj.ID)` doesnt compile either

Fix: use `index.Uint32` in `FromObject` so it matches `FromKey` and the field type

Repro: 
insert `&MyObject{ID: 1}`, then `tbl.Get(txn, IDIndex.Query(1))` returns found=false with `index.Uint64`, found=true with `index.Uint32`:
```go
type MyObject struct {
	ID  uint32
	Foo string
}

var IDIndex = statedb.Index[*MyObject, uint32]{
	Name:       "id",
	FromObject: func(o *MyObject) index.KeySet { return index.NewKeySet(index.Uint64(uint64(o.ID))) },
	FromKey:    func(id uint32) index.Key { return index.Uint32(id) },
	Unique:     true,
}

// insert &MyObject{ID: 1}, commit, then:
_, _, found := tbl.Get(db.ReadTxn(), IDIndex.Query(1))
// found == false
// swap FromObject to index.Uint32(o.ID) and found == true
```
