### PR TITLE
fix: remove obsolete empty secondary index keys

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -1386,6 +1386,25 @@ func TestDB_EmptyKeys(t *testing.T) {
 
 }
 
+func TestDB_DeleteEmptySecondaryKey(t *testing.T) {
+	t.Parallel()
+
+	db, table, _ := newTestDB(t, tagsIndex)
+
+	wtxn := db.WriteTxn(table)
+	obj := &testObject{ID: 1, Tags: part.NewSet("")}
+	_, _, err := table.Insert(wtxn, obj)
+	require.NoError(t, err)
+	wtxn.Commit()
+
+	wtxn = db.WriteTxn(table)
+	_, _, err = table.Delete(wtxn, obj)
+	require.NoError(t, err)
+	wtxn.Commit()
+
+	require.Empty(t, Collect(table.List(db.ReadTxn(), tagsIndex.Query(""))))
+}
+
 func TestWriteJSON(t *testing.T) {
 	t.Parallel()
 

--- a/index/keyset.go
+++ b/index/keyset.go
@@ -34,6 +34,9 @@ func (ks KeySet) Foreach(fn func(Key)) {
 }
 
 func (ks KeySet) Exists(k Key) bool {
+	if ks.head == nil {
+		return false
+	}
 	if ks.head.Equal(k) {
 		return true
 	}

--- a/index/keyset_test.go
+++ b/index/keyset_test.go
@@ -48,3 +48,8 @@ func TestKeySet_DuplicateKeys(t *testing.T) {
 	})
 	require.ElementsMatch(t, vs, [][]byte{[]byte("baz"), []byte("quux"), []byte("baz")})
 }
+
+func TestKeySet_Empty(t *testing.T) {
+	ks := index.NewKeySet()
+	require.False(t, ks.Exists(index.Key{}))
+}


### PR DESCRIPTION
Deleting an object with an empty secondary key leaves it queryable through that index

`KeySet.Exists` now treats a zero `KeySet` as empty, consistent with `Foreach`

Repro:
1. Apply the regression test only
2. Run `go test ./ -run TestDB_DeleteEmptySecondaryKey -count=1`
3. On main the deleted object still comes back

Tests: `make`