### PR TITLE
Fix indexing of nil keys

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -1386,6 +1386,121 @@ func TestDB_EmptyKeys(t *testing.T) {
 
 }
 
+func TestDB_EmptyPrimaryKey(t *testing.T) {
+	t.Parallel()
+
+	db := New()
+	table, err := NewTable(db, "test", keyIndex, tagsIndex)
+	require.NoError(t, err)
+
+	obj := &testObject{Key: "", Tags: part.NewSet("tag")}
+	wtxn := db.WriteTxn(table)
+	_, hadOld, err := table.Insert(wtxn, obj)
+	require.NoError(t, err)
+	require.False(t, hadOld)
+	wtxn.Commit()
+
+	stored, _, found := table.Get(db.ReadTxn(), keyIndex.Query(""))
+	require.True(t, found)
+	require.Equal(t, obj, stored)
+	require.Len(t, Collect(table.List(db.ReadTxn(), tagsIndex.Query("tag"))), 1)
+
+	updated := &testObject{Key: "", Tags: part.NewSet("updated")}
+	wtxn = db.WriteTxn(table)
+	_, hadOld, err = table.Insert(wtxn, updated)
+	require.NoError(t, err)
+	require.True(t, hadOld)
+	wtxn.Commit()
+	require.Empty(t, Collect(table.List(db.ReadTxn(), tagsIndex.Query("tag"))))
+	require.Len(t, Collect(table.List(db.ReadTxn(), tagsIndex.Query("updated"))), 1)
+
+	wtxn = db.WriteTxn(table)
+	_, hadOld, err = table.Delete(wtxn, &testObject{})
+	require.NoError(t, err)
+	require.True(t, hadOld)
+	wtxn.Commit()
+	_, _, found = table.Get(db.ReadTxn(), keyIndex.Query(""))
+	require.False(t, found)
+}
+
+func TestDB_PrimaryKeyCanSkipObject(t *testing.T) {
+	t.Parallel()
+
+	primaryIndex := Index[*testObject, string]{
+		Name: "optional-key",
+		FromObject: func(obj *testObject) index.KeySet {
+			if obj.Key == "skip" {
+				return index.NewKeySet()
+			}
+			return index.NewKeySet(index.String(obj.Key))
+		},
+		FromKey: index.String,
+		Unique:  true,
+	}
+	db := New()
+	table, err := NewTable(db, "test", primaryIndex)
+	require.NoError(t, err)
+
+	wtxn := db.WriteTxn(table)
+	_, hadOld, err := table.Insert(wtxn, &testObject{Key: "skip"})
+	require.NoError(t, err)
+	require.False(t, hadOld)
+	wtxn.Commit()
+	require.Zero(t, table.NumObjects(db.ReadTxn()))
+	require.Empty(t, Collect(table.All(db.ReadTxn())))
+
+	wtxn = db.WriteTxn(table)
+	_, hadOld, err = table.Insert(wtxn, &testObject{Key: ""})
+	require.NoError(t, err)
+	require.False(t, hadOld)
+	wtxn.Commit()
+	require.Equal(t, 1, table.NumObjects(db.ReadTxn()))
+	_, _, found := table.Get(db.ReadTxn(), primaryIndex.Query(""))
+	require.True(t, found)
+}
+
+func TestDB_EmptyFirstKeyReindex(t *testing.T) {
+	t.Parallel()
+
+	// The nil first key is intentional: it verifies that a valid empty key
+	// does not prevent Foreach from visiting the non-empty tail.
+	multiKeyIndex := Index[*testObject, string]{
+		Name: "multi-key",
+		FromObject: func(obj *testObject) index.KeySet {
+			if obj.Key == "" {
+				return index.NewKeySet(nil)
+			}
+			return index.NewKeySet(nil, index.String(obj.Key))
+		},
+		FromKey: index.String,
+		Unique:  false,
+	}
+	db, table, _ := newTestDB(t, multiKeyIndex)
+
+	obj := &testObject{ID: 1, Key: "foo"}
+	wtxn := db.WriteTxn(table)
+	_, _, err := table.Insert(wtxn, obj)
+	require.NoError(t, err)
+	wtxn.Commit()
+	require.Len(t, Collect(table.List(db.ReadTxn(), multiKeyIndex.Query(""))), 1)
+	require.Len(t, Collect(table.List(db.ReadTxn(), multiKeyIndex.Query("foo"))), 1)
+
+	updated := &testObject{ID: 1, Key: "bar"}
+	wtxn = db.WriteTxn(table)
+	_, _, err = table.Insert(wtxn, updated)
+	require.NoError(t, err)
+	wtxn.Commit()
+	require.Empty(t, Collect(table.List(db.ReadTxn(), multiKeyIndex.Query("foo"))))
+	require.Len(t, Collect(table.List(db.ReadTxn(), multiKeyIndex.Query("bar"))), 1)
+
+	wtxn = db.WriteTxn(table)
+	_, _, err = table.Delete(wtxn, &testObject{ID: 1})
+	require.NoError(t, err)
+	wtxn.Commit()
+	require.Empty(t, Collect(table.List(db.ReadTxn(), multiKeyIndex.Query(""))))
+	require.Empty(t, Collect(table.List(db.ReadTxn(), multiKeyIndex.Query("bar"))))
+}
+
 func TestDB_DeleteEmptySecondaryKey(t *testing.T) {
 	t.Parallel()
 

--- a/derive.go
+++ b/derive.go
@@ -90,7 +90,11 @@ func (d derive[In, Out]) loop(ctx context.Context, _ cell.Health) error {
 			case DeriveInsert:
 				_, _, err = out.Insert(wtxn, outObj)
 			case DeriveUpdate:
-				_, _, found := out.Get(wtxn, out.PrimaryIndexer().QueryFromObject(outObj))
+				query, hasKey := out.PrimaryIndexer().QueryFromObject(outObj)
+				if !hasKey {
+					continue
+				}
+				_, _, found := out.Get(wtxn, query)
 				if found {
 					_, _, err = out.Insert(wtxn, outObj)
 				}

--- a/graveyard.go
+++ b/graveyard.go
@@ -96,7 +96,9 @@ func graveyardWorker(db *DB, ctx context.Context, gcRateLimitInterval time.Durat
 					// The dead object still existed (and wasn't replaced by a create->delete),
 					// delete it from the primary index.
 					graveyard := txn.mustIndexWriteTxn(meta, GraveyardIndexPos)
-					graveyard.delete(graveyard.objectToKey(oldObj))
+					if key, ok := graveyard.objectToKey(oldObj); ok {
+						graveyard.delete(key)
+					}
 				}
 			}
 			cleaningTimes[tableName] = time.Since(start)

--- a/index/keyset.go
+++ b/index/keyset.go
@@ -14,17 +14,30 @@ func (k Key) Equal(k2 Key) bool {
 	return bytes.Equal(k, k2)
 }
 
+// KeySet is a collection of keys used to index an object. Its zero value is
+// an empty set; a nil key supplied to NewKeySet is a valid zero-length key.
 type KeySet struct {
-	head Key
-	tail []Key
+	head    Key
+	tail    []Key
+	hasHead bool
 }
 
-func (ks KeySet) First() Key {
-	return ks.head
+// Len returns the number of keys in the set.
+func (ks KeySet) Len() int {
+	if !ks.hasHead {
+		return 0
+	}
+	return 1 + len(ks.tail)
 }
 
+// First returns the first key in the set, or false if the set is empty.
+func (ks KeySet) First() (Key, bool) {
+	return ks.head, ks.hasHead
+}
+
+// Foreach calls fn for each key in the set.
 func (ks KeySet) Foreach(fn func(Key)) {
-	if ks.head == nil {
+	if !ks.hasHead {
 		return
 	}
 	fn(ks.head)
@@ -34,7 +47,7 @@ func (ks KeySet) Foreach(fn func(Key)) {
 }
 
 func (ks KeySet) Exists(k Key) bool {
-	if ks.head == nil {
+	if !ks.hasHead {
 		return false
 	}
 	if ks.head.Equal(k) {
@@ -48,9 +61,11 @@ func (ks KeySet) Exists(k Key) bool {
 	return false
 }
 
+// NewKeySet constructs a set from keys. Every argument is a key, including a
+// nil or zero-length key. Pass no arguments to construct an empty set.
 func NewKeySet(keys ...Key) KeySet {
 	if len(keys) == 0 {
 		return KeySet{}
 	}
-	return KeySet{keys[0], keys[1:]}
+	return KeySet{head: keys[0], tail: keys[1:], hasHead: true}
 }

--- a/index/keyset_test.go
+++ b/index/keyset_test.go
@@ -4,16 +4,25 @@
 package index_test
 
 import (
+	"runtime"
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/statedb/index"
+	"github.com/cilium/statedb/part"
 )
+
+type testStringer string
+
+func (s testStringer) String() string { return string(s) }
 
 func TestKeySet_Single(t *testing.T) {
 	ks := index.NewKeySet([]byte("baz"))
-	require.EqualValues(t, "baz", ks.First())
+	first, ok := ks.First()
+	require.True(t, ok)
+	require.EqualValues(t, "baz", first)
 	require.True(t, ks.Exists([]byte("baz")))
 	require.False(t, ks.Exists([]byte("foo")))
 	vs := []index.Key{}
@@ -25,7 +34,9 @@ func TestKeySet_Single(t *testing.T) {
 
 func TestKeySet_Multi(t *testing.T) {
 	ks := index.NewKeySet([]byte("baz"), []byte("quux"))
-	require.EqualValues(t, "baz", ks.First())
+	first, ok := ks.First()
+	require.True(t, ok)
+	require.EqualValues(t, "baz", first)
 	require.True(t, ks.Exists([]byte("baz")))
 	require.True(t, ks.Exists([]byte("quux")))
 	require.False(t, ks.Exists([]byte("foo")))
@@ -38,7 +49,9 @@ func TestKeySet_Multi(t *testing.T) {
 
 func TestKeySet_DuplicateKeys(t *testing.T) {
 	ks := index.NewKeySet([]byte("baz"), []byte("quux"), []byte("baz"))
-	require.EqualValues(t, "baz", ks.First())
+	first, ok := ks.First()
+	require.True(t, ok)
+	require.EqualValues(t, "baz", first)
 	require.True(t, ks.Exists([]byte("baz")))
 	require.True(t, ks.Exists([]byte("quux")))
 	require.False(t, ks.Exists([]byte("foo")))
@@ -51,5 +64,76 @@ func TestKeySet_DuplicateKeys(t *testing.T) {
 
 func TestKeySet_Empty(t *testing.T) {
 	ks := index.NewKeySet()
+	require.Zero(t, ks.Len())
+	_, ok := ks.First()
+	require.False(t, ok)
 	require.False(t, ks.Exists(index.Key{}))
+	count := 0
+	ks.Foreach(func(index.Key) { count++ })
+	require.Zero(t, count)
+}
+
+func TestKeySet_EmptyKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		key  index.Key
+	}{
+		{name: "nil", key: nil},
+		{name: "non-nil", key: make(index.Key, 0)},
+		{name: "String", key: index.String("")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ks := index.NewKeySet(tt.key)
+			require.Equal(t, 1, ks.Len())
+			require.True(t, ks.Exists(nil))
+			require.True(t, ks.Exists(make(index.Key, 0)))
+
+			var keys []index.Key
+			ks.Foreach(func(key index.Key) { keys = append(keys, key) })
+			require.Len(t, keys, 1)
+			require.Len(t, keys[0], 0)
+		})
+	}
+}
+
+func TestKeySet_EmptyKeyWithTail(t *testing.T) {
+	for _, emptyKey := range []index.Key{nil, make(index.Key, 0), index.String("")} {
+		ks := index.NewKeySet(emptyKey, index.String("foo"))
+		var keys []index.Key
+		ks.Foreach(func(key index.Key) { keys = append(keys, key) })
+		require.Len(t, keys, 2)
+		require.True(t, ks.Exists(emptyKey))
+		require.True(t, ks.Exists(index.String("foo")))
+	}
+}
+
+func TestString_EmptyRepresentations(t *testing.T) {
+	var backing byte
+	withBacking := unsafe.String(&backing, 0)
+
+	for _, s := range []string{"", string([]byte{}), withBacking} {
+		key := index.String(s)
+		require.Len(t, key, 0)
+		ks := index.NewKeySet(key)
+		require.True(t, ks.Exists(index.Key{}))
+		first, ok := ks.First()
+		require.True(t, ok)
+		require.True(t, first.Equal(key))
+	}
+	runtime.KeepAlive(&backing)
+}
+
+func TestKeySet_EmptyKeyConstructors(t *testing.T) {
+	for _, ks := range []index.KeySet{
+		index.StringSlice([]string{"", "foo"}),
+		index.StringerSlice([]testStringer{"", "foo"}),
+		index.Set(part.NewSet[[]byte](nil)),
+	} {
+		require.True(t, ks.Exists(nil))
+		var keys []index.Key
+		ks.Foreach(func(key index.Key) { keys = append(keys, key) })
+		require.NotEmpty(t, keys)
+	}
 }

--- a/index/set.go
+++ b/index/set.go
@@ -13,7 +13,7 @@ func Set[T any](s part.Set[T]) KeySet {
 		return KeySet{}
 	case 1:
 		if v, ok := s.First(); ok {
-			return KeySet{head: toBytes(v)}
+			return NewKeySet(toBytes(v))
 		}
 		panic("BUG: Set.Len() == 1, but First returned nothing")
 	default:

--- a/lpm_index.go
+++ b/lpm_index.go
@@ -284,7 +284,7 @@ func (l lpmIndex) lowerBoundNextNoWatch(key index.Key) func() ([]byte, object, b
 }
 
 // objectToKey implements tableIndex.
-func (l lpmIndex) objectToKey(obj object) index.Key {
+func (l lpmIndex) objectToKey(obj object) (index.Key, bool) {
 	return l.objectToKeys(obj).First()
 }
 
@@ -445,7 +445,7 @@ func (l *lpmIndexTxn) notify() {
 }
 
 // objectToKey implements tableIndexTxn.
-func (l *lpmIndexTxn) objectToKey(obj object) index.Key {
+func (l *lpmIndexTxn) objectToKey(obj object) (index.Key, bool) {
 	return l.index.objectToKey(obj)
 }
 

--- a/lpm_index.go
+++ b/lpm_index.go
@@ -43,22 +43,22 @@ func (a NetIPPrefixIndex[Obj]) QueryPrefix(prefix netip.Prefix) Query[Obj] {
 }
 
 // ObjectToKey implements Indexer.
-func (a NetIPPrefixIndex[Obj]) ObjectToKey(obj Obj) index.Key {
+func (a NetIPPrefixIndex[Obj]) ObjectToKey(obj Obj) (index.Key, bool) {
 	for prefix := range a.FromObject(obj) {
-		return lpm.NetIPPrefixToIndexKey(prefix)
+		return lpm.NetIPPrefixToIndexKey(prefix), true
 	}
-	return nil
+	return nil, false
 }
 
 // QueryFromObject implements Indexer.
-func (a NetIPPrefixIndex[Obj]) QueryFromObject(obj Obj) Query[Obj] {
+func (a NetIPPrefixIndex[Obj]) QueryFromObject(obj Obj) (Query[Obj], bool) {
 	for prefix := range a.FromObject(obj) {
 		return Query[Obj]{
 			index: a.Name,
 			key:   lpm.NetIPPrefixToIndexKey(prefix),
-		}
+		}, true
 	}
-	return Query[Obj]{}
+	return Query[Obj]{}, false
 }
 
 // fromString implements Indexer.
@@ -145,11 +145,11 @@ func (l LPMIndex[Obj]) indexName() string {
 	return l.Name
 }
 
-func (l LPMIndex[Obj]) ObjectToKey(obj Obj) index.Key {
+func (l LPMIndex[Obj]) ObjectToKey(obj Obj) (index.Key, bool) {
 	for key := range l.FromObject(obj) {
-		return key
+		return key, true
 	}
-	return nil
+	return nil, false
 }
 
 // Query constructs a query against the index with the given prefix. It returns
@@ -165,14 +165,14 @@ func (l LPMIndex[Obj]) Query(data []byte, prefixLen lpm.PrefixLen) (Query[Obj], 
 	}, nil
 }
 
-func (l LPMIndex[Obj]) QueryFromObject(obj Obj) Query[Obj] {
+func (l LPMIndex[Obj]) QueryFromObject(obj Obj) (Query[Obj], bool) {
 	for key, length := range l.FromObject(obj) {
 		return Query[Obj]{
 			index: l.Name,
 			key:   mustEncodeLPMKey(key, length),
-		}
+		}, true
 	}
-	return Query[Obj]{}
+	return Query[Obj]{}, false
 }
 
 func (l LPMIndex[Obj]) newTableIndex() tableIndex {

--- a/part_index.go
+++ b/part_index.go
@@ -20,8 +20,8 @@ type Index[Obj any, Key any] struct {
 	Name string
 
 	// FromObject extracts key(s) from the object. The key set
-	// can contain 0, 1 or more keys. Must contain exactly one
-	// key for primary indices.
+	// can contain 0, 1 or more keys. Primary indices may contain
+	// zero or one key; an object with zero keys is not indexed.
 	FromObject func(obj Obj) index.KeySet
 
 	// FromKey converts the index key into a raw key.
@@ -73,7 +73,7 @@ func (i Index[Obj, Key]) Query(key Key) Query[Obj] {
 func (i Index[Obj, Key]) QueryFromObject(obj Obj) Query[Obj] {
 	return Query[Obj]{
 		index: i.Name,
-		key:   i.FromObject(obj).First(),
+		key:   i.objectToKey(obj),
 	}
 }
 
@@ -88,7 +88,16 @@ func (i Index[Obj, Key]) QueryFromKey(key index.Key) Query[Obj] {
 }
 
 func (i Index[Obj, Key]) ObjectToKey(obj Obj) index.Key {
-	return i.FromObject(obj).First()
+	return i.objectToKey(obj)
+}
+
+func (i Index[Obj, Key]) objectToKey(obj Obj) index.Key {
+	keys := i.FromObject(obj)
+	if keys.Len() > 1 {
+		panic("primary index must return at most one key")
+	}
+	key, _ := keys.First()
+	return key
 }
 
 // newTableIndex constructs a new instance of this index type.
@@ -164,8 +173,12 @@ func (r *partIndex) rootWatch() <-chan struct{} {
 	return r.tree.RootWatch()
 }
 
-func (r *partIndex) objectToKey(obj object) index.Key {
-	return r.objectToKeys(obj).First()
+func (r *partIndex) objectToKey(obj object) (index.Key, bool) {
+	keys := r.objectToKeys(obj)
+	if keys.Len() > 1 {
+		panic("primary index must return at most one key")
+	}
+	return keys.First()
 }
 
 func (r *partIndex) commit() (tableIndex, tableIndexTxnNotify) {
@@ -456,8 +469,12 @@ func (r *partIndexTxn) prefixNoWatch(ikey index.Key) tableIndexIterator {
 	return partPrefixNoWatch(r.unique, &snapshot, ikey)
 }
 
-func (r *partIndexTxn) objectToKey(obj object) index.Key {
-	return r.objectToKeys(obj).First()
+func (r *partIndexTxn) objectToKey(obj object) (index.Key, bool) {
+	keys := r.objectToKeys(obj)
+	if keys.Len() > 1 {
+		panic("primary index must return at most one key")
+	}
+	return keys.First()
 }
 
 // reindex implements tableIndexTxn.

--- a/part_index.go
+++ b/part_index.go
@@ -70,11 +70,15 @@ func (i Index[Obj, Key]) Query(key Key) Query[Obj] {
 	}
 }
 
-func (i Index[Obj, Key]) QueryFromObject(obj Obj) Query[Obj] {
+func (i Index[Obj, Key]) QueryFromObject(obj Obj) (Query[Obj], bool) {
+	key, ok := i.objectToKey(obj)
+	if !ok {
+		return Query[Obj]{}, false
+	}
 	return Query[Obj]{
 		index: i.Name,
-		key:   i.objectToKey(obj),
-	}
+		key:   key,
+	}, true
 }
 
 // QueryFromKey constructs a query against the index using the given
@@ -87,17 +91,16 @@ func (i Index[Obj, Key]) QueryFromKey(key index.Key) Query[Obj] {
 	}
 }
 
-func (i Index[Obj, Key]) ObjectToKey(obj Obj) index.Key {
+func (i Index[Obj, Key]) ObjectToKey(obj Obj) (index.Key, bool) {
 	return i.objectToKey(obj)
 }
 
-func (i Index[Obj, Key]) objectToKey(obj Obj) index.Key {
+func (i Index[Obj, Key]) objectToKey(obj Obj) (index.Key, bool) {
 	keys := i.FromObject(obj)
 	if keys.Len() > 1 {
 		panic("primary index must return at most one key")
 	}
-	key, _ := keys.First()
-	return key
+	return keys.First()
 }
 
 // newTableIndex constructs a new instance of this index type.

--- a/reconciler/builder.go
+++ b/reconciler/builder.go
@@ -71,7 +71,8 @@ func Register[Obj comparable](
 
 	idx := cfg.Table.PrimaryIndexer()
 	objectToKey := func(o any) index.Key {
-		return idx.ObjectToKey(o.(Obj))
+		key, _ := idx.ObjectToKey(o.(Obj))
+		return key
 	}
 	r := &reconciler[Obj]{
 		Params:               params,

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -192,7 +192,11 @@ func (r *reconciler[Obj]) refreshLoop(ctx context.Context, health cell.Health) e
 				// Mark the object for refreshing. We make the assumption that refreshing is spread over
 				// time enough that batching of the writes is not useful here.
 				wtxn := r.DB.WriteTxn(r.config.Table)
-				obj, newRev, ok := r.config.Table.Get(wtxn, indexer.QueryFromObject(obj))
+				query, hasKey := indexer.QueryFromObject(obj)
+				if !hasKey {
+					continue
+				}
+				obj, newRev, ok := r.config.Table.Get(wtxn, query)
 				if ok && rev == newRev {
 					obj = r.config.SetObjectStatus(r.config.CloneObject(obj), StatusRefreshing())
 					r.config.Table.Insert(wtxn, obj)

--- a/table.go
+++ b/table.go
@@ -294,7 +294,11 @@ func newGraveyardIndex(primaryIndex tableIndex) tableIndex {
 		tree: part.New[object](part.RootOnlyWatch),
 		partIndexTxn: partIndexTxn{
 			objectToKeys: func(obj object) index.KeySet {
-				return index.NewKeySet(primaryIndex.objectToKey(obj))
+				key, ok := primaryIndex.objectToKey(obj)
+				if !ok {
+					return index.KeySet{}
+				}
+				return index.NewKeySet(key)
 			},
 			unique: true,
 		},

--- a/types.go
+++ b/types.go
@@ -306,11 +306,12 @@ type Query[Obj any] struct {
 
 type Indexer[Obj any] interface {
 	// QueryFromObject constructs a query from an object against the
-	// primary index.
-	QueryFromObject(Obj) Query[Obj]
+	// primary index. The boolean is false when the object has no key.
+	QueryFromObject(Obj) (Query[Obj], bool)
 
-	// ObjectToKey returns the primary key of the object.
-	ObjectToKey(Obj) index.Key
+	// ObjectToKey returns the primary key of the object. The boolean is false
+	// when the object has no key.
+	ObjectToKey(Obj) (index.Key, bool)
 
 	// isIndexerOf is a marker method to constrain the indexer to the 'Obj'
 	// type which enforces that indexer of a wrong type is not used.

--- a/types.go
+++ b/types.go
@@ -428,7 +428,7 @@ type tableIndexReader interface {
 	all() (tableIndexIterator, <-chan struct{})
 	allNoWatch() tableIndexIterator
 	rootWatch() <-chan struct{}
-	objectToKey(obj object) index.Key
+	objectToKey(obj object) (index.Key, bool)
 }
 
 type tableIndex interface {

--- a/write_txn.go
+++ b/write_txn.go
@@ -128,13 +128,16 @@ func (txn *writeTxnState) modify(meta TableMeta, guardRevision Revision, newData
 		return object{}, false, nil, tableError(tableName, ErrTableNotLockedForWriting)
 	}
 	oldRevision := table.revision
-	table.revision++
-	revision := table.revision
 
 	// Update the primary index first
-	obj := object{data: newData, revision: revision}
+	obj := object{data: newData}
 	idIndexTxn := txn.mustIndexWriteTxn(meta, PrimaryIndexPos)
-	idKey := idIndexTxn.objectToKey(obj)
+	idKey, indexed := idIndexTxn.objectToKey(obj)
+	if !indexed {
+		return object{}, false, nil, nil
+	}
+	table.revision++
+	obj.revision = table.revision
 
 	var (
 		oldObj    object
@@ -254,7 +257,10 @@ func (txn *writeTxnState) delete(meta TableMeta, guardRevision Revision, data an
 	// We assume that "data" has only enough defined fields to
 	// compute the primary key.
 	idIndex := txn.mustIndexWriteTxn(meta, PrimaryIndexPos)
-	idKey := idIndex.objectToKey(object{data: data})
+	idKey, indexed := idIndex.objectToKey(object{data: data})
+	if !indexed {
+		return object{}, false, nil
+	}
 	obj, existed := idIndex.delete(idKey)
 	if !existed {
 		return object{}, false, nil


### PR DESCRIPTION
index.KeySet was a struct{head: Key, tail []Key} and used head == nil as indication that the set was empty. This broke indexing of for example index.String("") as that returned nil as the key.

Fix this by adding a 'hasHead' to the KeySet struct. Add Len() to KeySet and change First() to return (Key, bool) so that caller can distinquish whether a nil key was present or not. The API change to index.First is minor and I found no use of it in cilium/cilium so going to include this in a patch release.

AIL:3