### PR TITLE
fix: handle HTTP change stream write errors

### DIFF
--- a/http.go
+++ b/http.go
@@ -183,9 +183,8 @@ func (h dbHandler) changes(w http.ResponseWriter, r *http.Request) {
 	for {
 		changes, watch := changeIter.nextAny(h.db.ReadTxn())
 		for change := range changes {
-			err := enc.Encode(change)
-			if err != nil {
-				panic(err)
+			if err := enc.Encode(change); err != nil {
+				return
 			}
 		}
 		w.(http.Flusher).Flush()

--- a/http_test.go
+++ b/http_test.go
@@ -149,6 +149,17 @@ func Test_http_query_write_error_does_not_panic(t *testing.T) {
 	})
 }
 
+func Test_http_changes_write_error_does_not_panic(t *testing.T) {
+	db, table, _ := httpFixture(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/changes/"+table.Name(), nil)
+	req.SetPathValue("table", table.Name())
+	w := failingResponseWriter{header: make(http.Header), err: errors.New("client disconnected")}
+	require.NotPanics(t, func() {
+		dbHandler{db}.changes(&w, req)
+	})
+}
+
 type failingResponseWriter struct {
 	header http.Header
 	err    error


### PR DESCRIPTION
`/changes/{table}` panics when a client disconnects while a change is being written.

The handler now returns on the write error, so existing cleanup runs

Repro:
1. Apply only the regression test
2. Run `go test ./ -run Test_http_changes_write_error_does_not_panic -count=1`
3. `main` panics with `client disconnected`, this branch passes

Related: #175, #192

Tests: `make all`
