### PR TITLE
fix: handle HTTP table dump write errors

### DIFF
--- a/http.go
+++ b/http.go
@@ -41,12 +41,12 @@ func (h dbHandler) dumpTable(w http.ResponseWriter, r *http.Request) {
 
 	var err error
 	if table := r.PathValue("table"); table != "" {
-		err = h.db.ReadTxn().WriteJSON(w, r.PathValue("table"))
+		err = h.db.ReadTxn().WriteJSON(w, table)
 	} else {
 		err = h.db.ReadTxn().WriteJSON(w)
 	}
 	if err != nil {
-		panic(err)
+		return
 	}
 }
 

--- a/http_test.go
+++ b/http_test.go
@@ -160,6 +160,17 @@ func Test_http_changes_write_error_does_not_panic(t *testing.T) {
 	})
 }
 
+func Test_http_dumpTable_write_error_does_not_panic(t *testing.T) {
+	db, table, _ := httpFixture(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/dump/"+table.Name(), nil)
+	req.SetPathValue("table", table.Name())
+	w := failingResponseWriter{header: make(http.Header), err: errors.New("client disconnected")}
+	require.NotPanics(t, func() {
+		dbHandler{db}.dumpTable(&w, req)
+	})
+}
+
 type failingResponseWriter struct {
 	header http.Header
 	err    error


### PR DESCRIPTION
`/dump/{table}` panics when the client disconnects mid response. 
`WriteJSON` returns the write error and the handler just does `panic(err)`

Same thing as #192 and #195 so the fix is the same: return on the write error instead of blowing up. 
Client is already gone, theres nothing left to write

`/dump` (dumpAll) already ignores the write error, so no change needed there

Repro:
1. apply only the regression test from this PR
2. `go test ./ -run Test_http_dumpTable_write_error_does_not_panic -count=1`
3. main panics with `client disconnected`, this branch passes

Related: #192, #195
Tests: `make all`
