### PR TITLE
fix: handle unsupported HTTP change stream flushing

### DIFF
--- a/http.go
+++ b/http.go
@@ -187,7 +187,9 @@ func (h dbHandler) changes(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
-		w.(http.Flusher).Flush()
+		if err := http.NewResponseController(w).Flush(); err != nil {
+			return
+		}
 		select {
 		case <-r.Context().Done():
 			return

--- a/http_test.go
+++ b/http_test.go
@@ -160,6 +160,17 @@ func Test_http_changes_write_error_does_not_panic(t *testing.T) {
 	})
 }
 
+func Test_http_changes_without_flusher_does_not_panic(t *testing.T) {
+	db, table, _ := httpFixture(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/changes/"+table.Name(), nil)
+	req.SetPathValue("table", table.Name())
+	w := httptest.NewRecorder()
+	require.NotPanics(t, func() {
+		dbHandler{db}.changes(struct{ http.ResponseWriter }{w}, req)
+	})
+}
+
 func Test_http_dumpTable_write_error_does_not_panic(t *testing.T) {
 	db, table, _ := httpFixture(t)
 


### PR DESCRIPTION
The `/changes` handler assumes every response writer implements `http.Flusher`. 
Middleware wrappers may not preserve this optional interface, so the stream can panic after writing its initial changes

Use `http.ResponseController.Flush` and return cleanly if flushing fails. 
The fix keeps wrapped handlers from taking a spill

Reproduce on `main`:
```
go test ./ -run Test_http_changes_without_flusher_does_not_panic -count=1
```

The test panics without the fix and passes with it