### PR TITLE
Minor WriteTxn optimizations

### DIFF
--- a/db.go
+++ b/db.go
@@ -188,25 +188,12 @@ func (db *DB) ReadTxn() ReadTxn {
 // The modifications performed in the write transaction are not visible outside
 // it until Commit() is called. To discard the changes call Abort().
 //
+// Panics if called with duplicate tables.
+//
 // The returned WriteTxn is not thread-safe.
 func (db *DB) WriteTxn(tables ...TableMeta) WriteTxn {
 	txn := db.writeTxnPool.Get().(*writeTxnState)
 	txn.db = db
-
-	// Deduplicate the set of tables to avoid acquiring the same table lock
-	// more than once, which would deadlock down the line.
-	seen := make(map[int]struct{}, len(tables))
-	tables = slices.DeleteFunc(slices.Clone(tables), func(table TableMeta) bool {
-		pos := table.tablePos()
-		if pos < 0 {
-			panic(tableError(table.Name(), ErrTableNotRegistered))
-		}
-		if _, exists := seen[pos]; exists {
-			return true
-		}
-		seen[pos] = struct{}{}
-		return false
-	})
 
 	txn.smus = reuseSlice(txn.smus, len(tables))
 	for i, table := range tables {

--- a/db.go
+++ b/db.go
@@ -216,10 +216,9 @@ func (db *DB) WriteTxn(tables ...TableMeta) WriteTxn {
 	txn.tableNames = reuseSlice(txn.tableNames, len(tables))
 	for i, table := range tables {
 		pos := table.tablePos()
-		tableEntryCopy := *txn.tableEntries[pos]
-		tableEntryCopy.indexes = slices.Clone(tableEntryCopy.indexes)
+		tableEntryCopy := cloneTableEntry(txn.tableEntries[pos])
 		tableEntryCopy.locked = true
-		txn.tableEntries[pos] = &tableEntryCopy
+		txn.tableEntries[pos] = tableEntryCopy
 		name := table.Name()
 		txn.tableNames[i] = name
 

--- a/db_test.go
+++ b/db_test.go
@@ -1426,7 +1426,7 @@ func TestDB_PrimaryKeyCanSkipObject(t *testing.T) {
 		Name: "optional-key",
 		FromObject: func(obj *testObject) index.KeySet {
 			if obj.Key == "skip" {
-				return index.NewKeySet()
+				return index.EmptyKeySet
 			}
 			return index.NewKeySet(index.String(obj.Key))
 		},

--- a/db_test.go
+++ b/db_test.go
@@ -179,13 +179,9 @@ func TestDB_WriteTxn_DuplicateTables(t *testing.T) {
 	t.Parallel()
 
 	db, table := newTestDBWithMetrics(t, &NopMetrics{})
-
-	txn := db.WriteTxn(table, table)
-	_, _, err := table.Insert(txn, &testObject{ID: 1})
-	require.NoError(t, err, "Insert")
-	txn.Commit()
-
-	require.Equal(t, 1, table.NumObjects(db.ReadTxn()))
+	require.PanicsWithValue(t, `SortableMutexes: duplicate mutex`, func() {
+		db.WriteTxn(table, table)
+	})
 }
 
 func TestDB_Insert_SamePointer(t *testing.T) {

--- a/index/keyset.go
+++ b/index/keyset.go
@@ -61,11 +61,18 @@ func (ks KeySet) Exists(k Key) bool {
 	return false
 }
 
-// NewKeySet constructs a set from keys. Every argument is a key, including a
-// nil or zero-length key. Pass no arguments to construct an empty set.
-func NewKeySet(keys ...Key) KeySet {
+// EmptyKeySet is a KeySet containing no keys.
+var EmptyKeySet KeySet
+
+// NewKeySet constructs a non-empty set from keys. Every argument is a key,
+// including a nil or zero-length key.
+func NewKeySet(key Key, keys ...Key) KeySet {
+	return KeySet{head: key, tail: keys, hasHead: true}
+}
+
+func keySet(keys []Key) KeySet {
 	if len(keys) == 0 {
-		return KeySet{}
+		return EmptyKeySet
 	}
-	return KeySet{head: keys[0], tail: keys[1:], hasHead: true}
+	return NewKeySet(keys[0], keys[1:]...)
 }

--- a/index/keyset_test.go
+++ b/index/keyset_test.go
@@ -63,7 +63,7 @@ func TestKeySet_DuplicateKeys(t *testing.T) {
 }
 
 func TestKeySet_Empty(t *testing.T) {
-	ks := index.NewKeySet()
+	ks := index.EmptyKeySet
 	require.Zero(t, ks.Len())
 	_, ok := ks.First()
 	require.False(t, ok)

--- a/index/map.go
+++ b/index/map.go
@@ -8,5 +8,5 @@ func StringMap[V any](m map[string]V) KeySet {
 	for k := range m {
 		keys = append(keys, String(k))
 	}
-	return NewKeySet(keys...)
+	return keySet(keys)
 }

--- a/index/seq.go
+++ b/index/seq.go
@@ -18,7 +18,7 @@ func Seq[T any](
 	for v := range seq {
 		keys = append(keys, toKey(v))
 	}
-	return NewKeySet(keys...)
+	return keySet(keys)
 }
 
 // Seq2 creates a KeySet from an iter.Seq2[A,B] with the given indexing function.
@@ -34,5 +34,5 @@ func Seq2[A, B any](
 	for a := range seq {
 		keys = append(keys, toKey(a))
 	}
-	return NewKeySet(keys...)
+	return keySet(keys)
 }

--- a/index/set.go
+++ b/index/set.go
@@ -10,7 +10,7 @@ func Set[T any](s part.Set[T]) KeySet {
 	toBytes := s.ToBytesFunc()
 	switch s.Len() {
 	case 0:
-		return KeySet{}
+		return EmptyKeySet
 	case 1:
 		if v, ok := s.First(); ok {
 			return NewKeySet(toBytes(v))
@@ -21,6 +21,6 @@ func Set[T any](s part.Set[T]) KeySet {
 		for v := range s.All() {
 			keys = append(keys, toBytes(v))
 		}
-		return NewKeySet(keys...)
+		return keySet(keys)
 	}
 }

--- a/index/string.go
+++ b/index/string.go
@@ -27,7 +27,7 @@ func StringSlice(ss []string) KeySet {
 	for _, s := range ss {
 		keys = append(keys, String(s))
 	}
-	return NewKeySet(keys...)
+	return keySet(keys)
 }
 
 func StringerSlice[T fmt.Stringer](ss []T) KeySet {
@@ -35,7 +35,7 @@ func StringerSlice[T fmt.Stringer](ss []T) KeySet {
 	for _, s := range ss {
 		keys = append(keys, Stringer(s))
 	}
-	return NewKeySet(keys...)
+	return keySet(keys)
 }
 
 func StringerSeq[T fmt.Stringer](seq iter.Seq[T]) KeySet {

--- a/internal/sortable_mutex.go
+++ b/internal/sortable_mutex.go
@@ -48,8 +48,15 @@ type SortableMutexes []SortableMutex
 
 // Lock sorts the mutexes, and then locks them in order. If any lock cannot be acquired,
 // this will block while holding the locks with a lower sequence number.
+// Panics if the same mutex is included more than once.
 func (s SortableMutexes) Lock() {
-	slices.SortFunc(s, func(a, b SortableMutex) int { return cmp.Compare(a.Seq(), b.Seq()) })
+	slices.SortFunc(s, func(a, b SortableMutex) int {
+		aSeq, bSeq := a.Seq(), b.Seq()
+		if aSeq == bSeq {
+			panic("SortableMutexes: duplicate mutex")
+		}
+		return cmp.Compare(a.Seq(), b.Seq())
+	})
 	for _, mu := range s {
 		mu.Lock()
 	}

--- a/internal/sortable_mutex.go
+++ b/internal/sortable_mutex.go
@@ -15,42 +15,33 @@ import (
 // SortableMutex's with unique sequence numbers.
 var sortableMutexSeq atomic.Uint64
 
-// sortableMutex implements SortableMutex. Not exported as the only way to
-// initialize it is via NewSortableMutex().
-type sortableMutex struct {
+// SortableMutex is a mutex with a globally unique sequence number. The sequence
+// number allows SortableMutexes to lock a set of mutexes in a consistent order.
+type SortableMutex struct {
 	sync.Mutex
 	seq             uint64
 	acquireDuration time.Duration
 }
 
-func (s *sortableMutex) Lock() {
+func (s *SortableMutex) Lock() {
 	start := time.Now()
 	s.Mutex.Lock()
 	s.acquireDuration = time.Since(start)
 }
 
-func (s *sortableMutex) Seq() uint64 { return s.seq }
+func (s *SortableMutex) Seq() uint64 { return s.seq }
 
-func (s *sortableMutex) AcquireDuration() time.Duration { return s.acquireDuration }
-
-// SortableMutex provides a Mutex that can be globally sorted with other
-// sortable mutexes. This allows deadlock-safe locking of a set of mutexes
-// as it guarantees consistent lock ordering.
-type SortableMutex interface {
-	sync.Locker
-	Seq() uint64
-	AcquireDuration() time.Duration // The amount of time it took to acquire the lock
-}
+func (s *SortableMutex) AcquireDuration() time.Duration { return s.acquireDuration }
 
 // SortableMutexes is a set of mutexes that can be locked in a safe order.
 // Once Lock() is called it must not be mutated!
-type SortableMutexes []SortableMutex
+type SortableMutexes []*SortableMutex
 
 // Lock sorts the mutexes, and then locks them in order. If any lock cannot be acquired,
 // this will block while holding the locks with a lower sequence number.
 // Panics if the same mutex is included more than once.
 func (s SortableMutexes) Lock() {
-	slices.SortFunc(s, func(a, b SortableMutex) int {
+	slices.SortFunc(s, func(a, b *SortableMutex) int {
 		aSeq, bSeq := a.Seq(), b.Seq()
 		if aSeq == bSeq {
 			panic("SortableMutexes: duplicate mutex")
@@ -69,9 +60,9 @@ func (s SortableMutexes) Unlock() {
 	}
 }
 
-func NewSortableMutex() SortableMutex {
+func NewSortableMutex() *SortableMutex {
 	seq := sortableMutexSeq.Add(1)
-	return &sortableMutex{
+	return &SortableMutex{
 		seq: seq,
 	}
 }

--- a/lpm_index.go
+++ b/lpm_index.go
@@ -100,7 +100,10 @@ func (a NetIPPrefixIndex[Obj]) newTableIndex() tableIndex {
 			for prefix := range a.FromObject(obj.data.(Obj)) {
 				keys = append(keys, lpm.NetIPPrefixToIndexKey(prefix))
 			}
-			return index.NewKeySet(keys...)
+			if len(keys) == 0 {
+				return index.EmptyKeySet
+			}
+			return index.NewKeySet(keys[0], keys[1:]...)
 		},
 		watch: make(chan struct{}),
 	}
@@ -185,7 +188,10 @@ func (l LPMIndex[Obj]) newTableIndex() tableIndex {
 			for data, prefixLen := range l.FromObject(obj.data.(Obj)) {
 				keys = append(keys, mustEncodeLPMKey(data, prefixLen))
 			}
-			return index.NewKeySet(keys...)
+			if len(keys) == 0 {
+				return index.EmptyKeySet
+			}
+			return index.NewKeySet(keys[0], keys[1:]...)
 		},
 		watch: make(chan struct{}),
 	}

--- a/table.go
+++ b/table.go
@@ -181,7 +181,7 @@ func validateTableName(name string) error {
 type genTable[Obj any] struct {
 	pos                  int
 	table                TableName
-	smu                  internal.SortableMutex
+	smu                  *internal.SortableMutex
 	primaryIndexer       Indexer[Obj]
 	primaryAnyIndexer    anyIndexer
 	secondaryAnyIndexers []anyIndexer
@@ -619,7 +619,7 @@ func (t *genTable[Obj]) anyChanges(txn WriteTxn) (anyChangeIterator, error) {
 	return iter.(*changeIterator[Obj]), err
 }
 
-func (t *genTable[Obj]) sortableMutex() internal.SortableMutex {
+func (t *genTable[Obj]) sortableMutex() *internal.SortableMutex {
 	return t.smu
 }
 

--- a/types.go
+++ b/types.go
@@ -394,8 +394,8 @@ type tableInternal interface {
 	setTablePos(int)
 	indexPos(string) int
 	getIndexer(name string) *anyIndexer
-	secondary() []anyIndexer               // Secondary indexers (if any)
-	sortableMutex() internal.SortableMutex // The sortable mutex for locking the table for writing
+	secondary() []anyIndexer                // Secondary indexers (if any)
+	sortableMutex() *internal.SortableMutex // The sortable mutex for locking the table for writing
 	anyChanges(txn WriteTxn) (anyChangeIterator, error)
 	typeName() string                       // Returns the 'Obj' type as string
 	unmarshalYAML(data []byte) (any, error) // Unmarshal the data into 'Obj'

--- a/types.go
+++ b/types.go
@@ -6,6 +6,7 @@ package statedb
 import (
 	"io"
 	"iter"
+	"slices"
 
 	"github.com/cilium/statedb/index"
 	"github.com/cilium/statedb/internal"
@@ -486,6 +487,54 @@ type tableEntry struct {
 
 	// locked marks the table locked for writes.
 	locked bool
+}
+
+type tableEntryWithIndexes0 struct {
+	tableEntry
+	indexes [SecondaryIndexStartPos]tableIndex
+}
+
+type tableEntryWithIndexes1 struct {
+	tableEntry
+	indexes [SecondaryIndexStartPos + 1]tableIndex
+}
+
+type tableEntryWithIndexes2 struct {
+	tableEntry
+	indexes [SecondaryIndexStartPos + 2]tableIndex
+}
+
+type tableEntryWithIndexes3 struct {
+	tableEntry
+	indexes [SecondaryIndexStartPos + 3]tableIndex
+}
+
+func cloneTableEntry(entry *tableEntry) *tableEntry {
+	var clone *tableEntry
+	var indexes []tableIndex
+
+	switch len(entry.indexes) {
+	case SecondaryIndexStartPos:
+		withIndexes := &tableEntryWithIndexes0{}
+		clone, indexes = &withIndexes.tableEntry, withIndexes.indexes[:]
+	case SecondaryIndexStartPos + 1:
+		withIndexes := &tableEntryWithIndexes1{}
+		clone, indexes = &withIndexes.tableEntry, withIndexes.indexes[:]
+	case SecondaryIndexStartPos + 2:
+		withIndexes := &tableEntryWithIndexes2{}
+		clone, indexes = &withIndexes.tableEntry, withIndexes.indexes[:]
+	case SecondaryIndexStartPos + 3:
+		withIndexes := &tableEntryWithIndexes3{}
+		clone, indexes = &withIndexes.tableEntry, withIndexes.indexes[:]
+	default:
+		clone = &tableEntry{}
+		indexes = slices.Clone(entry.indexes)
+	}
+
+	*clone = *entry
+	copy(indexes, entry.indexes)
+	clone.indexes = indexes
+	return clone
 }
 
 func (t *tableEntry) numObjects() int {

--- a/write_txn.go
+++ b/write_txn.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"reflect"
 	"runtime"
-	"sync/atomic"
 	"time"
 
 	"github.com/cilium/statedb/index"
@@ -29,8 +28,7 @@ type writeTxnState struct {
 	db *DB
 
 	handle     string
-	acquiredAt time.Time     // the time at which the transaction acquired the locks
-	duration   atomic.Uint64 // the transaction duration after it finished
+	acquiredAt time.Time // the time at which the transaction acquired the locks
 
 	oldRoot      *dbRoot                  // snapshot of the root at the time WriteTxn was called
 	tableEntries []*tableEntry            // table entries being modified
@@ -344,8 +342,6 @@ func (handle *writeTxnHandle) Abort() {
 		}
 	}
 
-	txn.duration.Store(uint64(time.Since(txn.acquiredAt)))
-
 	txn.smus.Unlock()
 	txn.db.metrics.WriteTxnDuration(
 		txn.handle,
@@ -379,8 +375,6 @@ func (handle *writeTxnHandle) Commit() ReadTxn {
 		return nil
 	}
 	txn := handle.writeTxnState
-
-	txn.duration.Store(uint64(time.Since(txn.acquiredAt)))
 
 	db := txn.db
 


### PR DESCRIPTION
- Instead of deduplicating just detect duplicates and panic in WriteTxn(). This would be a very rare bug on caller side and it doesn't make sense to pay extra (allocation, memory copying) to handle it gracefully. This increases the one-insert-per-WriteTxn throughput ~6% (see commit message).
- Drop the unused `writeTxnState.duration` field
- Drop the `internal.SortableMutex` interface and just use the concrete type. This was leftover from when StateDB and the `SortableMutex` was in cilium/cilium.
- Change `index.NewKeySet` to take one argument and then vararg to remove an allocation. Add `index.EmptyKeySet` for the empty case.
- Co-locate `tableIndex` array with the `tableEntry` for the common number of indexes to save allocating the `[]tableIndex` slice


Before:
```
BenchmarkDB_WriteTxn_1-6                         1000000              1211 ns/op            825674 objects/sec       704 B/op         17 allocs/op
BenchmarkDB_WriteTxn_10-6                        2840197               420.9 ns/op         2376025 objects/sec       386 B/op          8 allocs/op
BenchmarkDB_WriteTxn_100-6                       3218432               385.1 ns/op         2596802 objects/sec       349 B/op          7 allocs/op
BenchmarkDB_WriteTxn_1000-6                      3152139               385.6 ns/op         2593571 objects/sec       350 B/op          7 allocs/op
BenchmarkDB_WriteTxn_100_SecondaryIndex-6        1698141               595.8 ns/op         1678371 objects/sec       507 B/op         12 allocs/op
BenchmarkDB_WriteTxn_CommitOnly_100Tables-6      1231267               983.5 ns/op          1128 B/op          6 allocs/op
BenchmarkDB_WriteTxn_CommitOnly_1Table-6         2035423               575.1 ns/op           240 B/op          6 allocs/op
BenchmarkDB_NewWriteTxn-6                        2327306               545.5 ns/op           216 B/op          5 allocs/op
BenchmarkDB_WriteTxnCommit100-6                  1220266               976.9 ns/op          1112 B/op          6 allocs/op

1000000 objects reconciled in 1.38 seconds (batch size 1000)
Throughput 722359.06 objects per second
568MB total allocated, 6015215 in-use objects, 239MB bytes in use
```

After:
```
BenchmarkDB_WriteTxn_1-6                         1352152               878.4 ns/op         1138474 objects/sec       664 B/op         14 allocs/op
BenchmarkDB_WriteTxn_10-6                        3196346               398.1 ns/op         2511816 objects/sec       361 B/op          7 allocs/op
BenchmarkDB_WriteTxn_100-6                       3865876               319.0 ns/op         3135261 objects/sec       325 B/op          6 allocs/op
BenchmarkDB_WriteTxn_1000-6                      2920508               357.4 ns/op         2797619 objects/sec       326 B/op          6 allocs/op
BenchmarkDB_WriteTxn_100_SecondaryIndex-6        2353370               529.3 ns/op         1889448 objects/sec       435 B/op          9 allocs/op
BenchmarkDB_WriteTxn_CommitOnly_100Tables-6      1396680               864.0 ns/op          1112 B/op          4 allocs/op
BenchmarkDB_WriteTxn_CommitOnly_1Table-6         2435631               499.4 ns/op           224 B/op          4 allocs/op
BenchmarkDB_NewWriteTxn-6                        2788807               424.8 ns/op           200 B/op          3 allocs/op
BenchmarkDB_WriteTxnCommit100-6          1417305               857.5 ns/op          1096 B/op          4 allocs/op

1000000 objects reconciled in 1.34 seconds (batch size 1000)
Throughput 747666.87 objects per second
522MB total allocated, 6015195 in-use objects, 239MB bytes in use
```

AIL:3